### PR TITLE
#11 l0-setup dockercfg flag update

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,5 @@ pass_file
 **pyc
 *.save
 coverage.*
+*.tags*
+

--- a/setup/context/commands_test.go
+++ b/setup/context/commands_test.go
@@ -30,27 +30,40 @@ func (mock MockFileIO) Stat(path string) (os.FileInfo, error) {
 }
 
 func TestValidateDockercfgWithValidData(t *testing.T) {
-	mockIO := MockFileIO{data: map[string][]byte{"foo": []byte(`
+	mockIO := MockFileIO{data: map[string][]byte{"path": []byte(`
         {
             "https://d.ims.io": {
                 "auth": "StopLookingAtMySecretsYouJerk=",
                 "email": ""
             }
         }`)}}
-	if err := validateDockercfg("foo", mockIO); err != nil {
+	if err := validateDockercfg("path", mockIO); err != nil {
 		t.Fatal(err)
 	}
 }
 
 func TestValidateDockercfgWithInvalidData(t *testing.T) {
-	mockIO := MockFileIO{data: map[string][]byte{"foo": []byte(`
+	mockIO := MockFileIO{data: map[string][]byte{"path": []byte(`
         {
             "https://d.ims.io": {
                 "auth": "StopLookingAtMySecretsYouJerk=",
                 "email": ""
             },
         }`)}}
-	if err := validateDockercfg("foo", mockIO); err == nil {
+	if err := validateDockercfg("path", mockIO); err == nil {
+		t.Fatal(err)
+	}
+}
+
+func TestValidateDockercfgWithInvalidPath(t *testing.T) {
+	mockIO := MockFileIO{data: map[string][]byte{"path": []byte(`
+        {
+            "https://d.ims.io": {
+                "auth": "StopLookingAtMySecretsYouJerk=",
+                "email": ""
+            }
+        }`)}}
+	if err := validateDockercfg("badpath", mockIO); err == nil {
 		t.Fatal(err)
 	}
 }

--- a/setup/context/commands_test.go
+++ b/setup/context/commands_test.go
@@ -1,48 +1,55 @@
 package context
 
 import (
+	"fmt"
 	"os"
 	"testing"
 )
 
 type MockFileIO struct {
-	data []byte
+	data map[string][]byte
 }
 
 func (mock MockFileIO) ReadFile(path string) ([]byte, error) {
-	return mock.data, nil
+	if contents, ok := mock.data[path]; ok {
+		return contents, nil
+	}
+	return nil, fmt.Errorf("Failed to read file at path: `%s`", path)
 }
 
 func (mock MockFileIO) WriteFile(path string, data []byte, perm os.FileMode) error {
-	mock.data = data
+	mock.data[path] = data
 	return nil
 }
 
 func (mock MockFileIO) Stat(path string) (os.FileInfo, error) {
-	return nil, nil
+	if _, ok := mock.data[path]; ok {
+		return nil, nil
+	}
+	return nil, fmt.Errorf("Failed to stat file at path: `%s`", path)
 }
 
 func TestValidateDockercfgWithValidData(t *testing.T) {
-	mockIO := MockFileIO{data: []byte(`
+	mockIO := MockFileIO{data: map[string][]byte{"foo": []byte(`
         {
             "https://d.ims.io": {
                 "auth": "StopLookingAtMySecretsYouJerk=",
                 "email": ""
             }
-        }`)}
+        }`)}}
 	if err := validateDockercfg("foo", mockIO); err != nil {
 		t.Fatal(err)
 	}
 }
 
 func TestValidateDockercfgWithInvalidData(t *testing.T) {
-	mockIO := MockFileIO{data: []byte(`
+	mockIO := MockFileIO{data: map[string][]byte{"foo": []byte(`
         {
             "https://d.ims.io": {
                 "auth": "StopLookingAtMySecretsYouJerk=",
                 "email": ""
             },
-        }`)}
+        }`)}}
 	if err := validateDockercfg("foo", mockIO); err == nil {
 		t.Fatal(err)
 	}

--- a/setup/context/commands_test.go
+++ b/setup/context/commands_test.go
@@ -1,0 +1,49 @@
+package context
+
+import (
+	"os"
+	"testing"
+)
+
+type MockFileIO struct {
+	data []byte
+}
+
+func (mock MockFileIO) ReadFile(path string) ([]byte, error) {
+	return mock.data, nil
+}
+
+func (mock MockFileIO) WriteFile(path string, data []byte, perm os.FileMode) error {
+	mock.data = data
+	return nil
+}
+
+func (mock MockFileIO) Stat(path string) (os.FileInfo, error) {
+	return nil, nil
+}
+
+func TestValidateDockercfgWithValidData(t *testing.T) {
+	mockIO := MockFileIO{data: []byte(`
+        {
+            "https://d.ims.io": {
+                "auth": "StopLookingAtMySecretsYouJerk=",
+                "email": ""
+            }
+        }`)}
+	if err := validateDockercfg("foo", mockIO); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestValidateDockercfgWithInvalidData(t *testing.T) {
+	mockIO := MockFileIO{data: []byte(`
+        {
+            "https://d.ims.io": {
+                "auth": "StopLookingAtMySecretsYouJerk=",
+                "email": ""
+            },
+        }`)}
+	if err := validateDockercfg("foo", mockIO); err == nil {
+		t.Fatal(err)
+	}
+}

--- a/setup/main.go
+++ b/setup/main.go
@@ -2,9 +2,10 @@ package main
 
 import (
 	"fmt"
+	"os"
+
 	"github.com/jawher/mow.cli"
 	"github.com/quintilesims/layer0/setup/context"
-	"os"
 )
 
 var Version string
@@ -74,6 +75,10 @@ func main() {
 
 	app.Command("apply", "Create/Update a Layer0", func(cmd *cli.Cmd) {
 		flags := loadFlags(cmd, []string{"access_key", "secret_key", "region"})
+
+		dockercfg := cmd.StringOpt("dockercfg", "", "Path to valid dockercfg file")
+		flags["dockercfg"] = dockercfg
+
 		force := cmd.BoolOpt("force", false, "Set this flag to skip prompting on a missing dockercfg file")
 
 		vpc := cmd.StringOpt("vpc", "", "VPC id to target.  Will create new VPC if blank.")


### PR DESCRIPTION
Addresses Issue #11.

Principal changes include:
- Add `--dockercfg` flag on `l0-setup apply` allowing passing a path to valid`dockercfg` file. This file will be copied to the instance directory.
- Reword user prompt displayed when no `dockercfg` file supplied by user.
- Create default `dockercfg` file before showing user prompt.
- Add simple JSON validation of `dockercfg` file.
- Begin refactoring for easier testability.
- Add simple unit test for `validateDockercfg`.

Further work would be needed to add more test coverage.