### PR TITLE
Force service delete

### DIFF
--- a/api/backend/ecs/environment_manager.go
+++ b/api/backend/ecs/environment_manager.go
@@ -323,7 +323,7 @@ func (this *ECSEnvironmentManager) waitForAutoScalingGroupInactive(ecsEnvironmen
 
 	waiter := waitutils.Waiter{
 		Name:    fmt.Sprintf("Stop Autoscaling %s", autoScalingGroupName),
-		Retries: 30,
+		Retries: 50,
 		Delay:   time.Second * 10,
 		Clock:   this.Clock,
 		Check:   check,
@@ -343,7 +343,7 @@ func (this *ECSEnvironmentManager) waitForSecurityGroupDeleted(securityGroup *ec
 
 	waiter := waitutils.Waiter{
 		Name:    fmt.Sprintf("SecurityGroup delete for '%v'", securityGroup),
-		Retries: 30,
+		Retries: 50,
 		Delay:   time.Second * 10,
 		Clock:   this.Clock,
 		Check:   check,

--- a/api/backend/ecs/load_balancer_manager.go
+++ b/api/backend/ecs/load_balancer_manager.go
@@ -128,7 +128,7 @@ func (this *ECSLoadBalancerManager) DeleteLoadBalancer(loadBalancerID string) er
 
 		waiter := waitutils.Waiter{
 			Name:    fmt.Sprintf("SecurityGroup delete for '%s'", securityGroup),
-			Retries: 30,
+			Retries: 50,
 			Delay:   time.Second * 10,
 			Clock:   this.Clock,
 			Check:   check,
@@ -451,8 +451,8 @@ func (this *ECSLoadBalancerManager) upsertSecurityGroup(ecsLoadBalancerID id.ECS
 
 		waiter := waitutils.Waiter{
 			Name:    fmt.Sprintf("SecurityGroup setup for '%s'", ecsLoadBalancerID),
-			Retries: 60,
-			Delay:   time.Second * 1,
+			Retries: 50,
+			Delay:   time.Second * 10,
 			Clock:   this.Clock,
 			Check:   check,
 		}

--- a/cli/printer/text.go
+++ b/cli/printer/text.go
@@ -139,7 +139,7 @@ func (t *TextPrinter) PrintLoadBalancers(loadBalancers ...*models.LoadBalancer) 
 	}
 
 	getPort := func(l *models.LoadBalancer, i int) string {
-		if len(l.Ports) < i-1 {
+		if i > len(l.Ports)-1 {
 			return ""
 		}
 
@@ -229,7 +229,7 @@ func (t *TextPrinter) PrintServices(services ...*models.Service) error {
 	}
 
 	getDeployment := func(s *models.Service, i int) string {
-		if len(s.Deployments) < i-1 {
+		if i > len(s.Deployments)-1 {
 			return ""
 		}
 

--- a/common/aws/ecs/ecs.go
+++ b/common/aws/ecs/ecs.go
@@ -429,7 +429,6 @@ func (this *ECS) StartTask(cluster, taskDefinition string, overrides *TaskOverri
 }
 
 func (this *ECS) StopTask(cluster, reason, task string) (err error) {
-
 	input := &ecs.StopTaskInput{
 		Cluster: aws.String(cluster),
 		Reason:  aws.String(reason),

--- a/common/waitutils/waiter.go
+++ b/common/waitutils/waiter.go
@@ -41,12 +41,12 @@ func (this Waiter) Wait() error {
 			return nil
 		}
 
-		retryStr := fmt.Sprintf("%s", this.Retries)
+		retryStr := fmt.Sprintf("%d", this.Retries)
 		if this.Retries < 0 {
-			retryStr = "∞"
+			retryStr = "<infinite>"
 		}
 
-		log.Debugf("Wait %s iteration %v of %v", this.Name, i+1, retryStr)
+		log.Debugf("Wait %s iteration %d of %s", this.Name, i+1, retryStr)
 		this.Clock.Sleep(this.Delay)
 	}
 

--- a/runner/Makefile
+++ b/runner/Makefile
@@ -2,7 +2,7 @@ L0_VERSION?=$(shell git describe --tags)
 RUNNER_DOCKER_IMAGE=quintilesims/l0-runner:$(L0_VERSION)
 
 build:
-	CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -a --ldflags "-X main.Version=$(L0_VERSION)" --tags scratch -o l0-runner .
+	CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -a --ldflags "-X main.Version=$(L0_VERSION)" -o l0-runner .
 	docker build -t $(RUNNER_DOCKER_IMAGE) .
 
 release: build

--- a/runner/job/environment.go
+++ b/runner/job/environment.go
@@ -8,12 +8,12 @@ import (
 var DeleteEnvironmentSteps = []Step{
 	Step{
 		Name:    "Delete Dependencies",
-		Timeout: time.Minute * 10,
+		Timeout: time.Minute * 15,
 		Action:  Fold(DeleteEnvironmentLoadBalancers, DeleteEnvironmentServices),
 	},
 	Step{
 		Name:    "Delete Environment",
-		Timeout: time.Minute * 5,
+		Timeout: time.Minute * 10,
 		Action:  DeleteEnvironment,
 	},
 }

--- a/runner/job/loadbalancer.go
+++ b/runner/job/loadbalancer.go
@@ -8,7 +8,7 @@ import (
 var DeleteLoadBalancerSteps = []Step{
 	Step{
 		Name:    "Delete Load Balancer",
-		Timeout: time.Minute * 5,
+		Timeout: time.Minute * 10,
 		Action:  DeleteLoadBalancer,
 	},
 }

--- a/runner/job/service.go
+++ b/runner/job/service.go
@@ -8,7 +8,7 @@ import (
 var DeleteServiceSteps = []Step{
 	Step{
 		Name:    "Delete Service",
-		Timeout: time.Minute * 5,
+		Timeout: time.Minute * 10,
 		Action:  DeleteService,
 	},
 }


### PR DESCRIPTION
This calls `ecs.StopTask` on each task a service is running before deleting the service. This also removes the `waitUntilServiceStopped` function, as it appears ecs no longer requires the number of running tasks to be 0 before being able to call `ecs.DeleteService`. I've also bumped up the wait times for jobs, as I noticed relatively small environments are bumping up to about 60% of max allowed time. 

Iv'e tested this against an environment with a large number of services running (10), but this still needs to be QA'd against a service that doesn't respond to kill commands before merging. 

This fixes https://github.com/quintilesims/layer0/issues/34 and https://github.com/quintilesims/layer0/issues/10