### PR TITLE
WIP: Load Balancer Healthchecks (L0)

### DIFF
--- a/api/backend/ecs/load_balancer_manager.go
+++ b/api/backend/ecs/load_balancer_manager.go
@@ -36,8 +36,8 @@ func NewECSLoadBalancerManager(ec2 ec2.Provider, elb elb.Provider, iam iam.Provi
 	}
 }
 
-func (this *ECSLoadBalancerManager) ListLoadBalancers() ([]*models.LoadBalancer, error) {
-	loadBalancerDescriptions, err := this.ELB.DescribeLoadBalancers()
+func (e *ECSLoadBalancerManager) ListLoadBalancers() ([]*models.LoadBalancer, error) {
+	loadBalancerDescriptions, err := e.ELB.DescribeLoadBalancers()
 	if err != nil {
 		return nil, err
 	}
@@ -57,10 +57,10 @@ func (this *ECSLoadBalancerManager) ListLoadBalancers() ([]*models.LoadBalancer,
 	return loadBalancers, nil
 }
 
-func (this *ECSLoadBalancerManager) GetLoadBalancer(loadBalancerID string) (*models.LoadBalancer, error) {
+func (e *ECSLoadBalancerManager) GetLoadBalancer(loadBalancerID string) (*models.LoadBalancer, error) {
 	ecsLoadBalancerID := id.L0LoadBalancerID(loadBalancerID).ECSLoadBalancerID()
 
-	loadBalancer, err := this.ELB.DescribeLoadBalancer(ecsLoadBalancerID.String())
+	loadBalancer, err := e.ELB.DescribeLoadBalancer(ecsLoadBalancerID.String())
 	if err != nil {
 		if ContainsErrCode(err, "LoadBalancerNotFound") {
 			err := fmt.Errorf("LoadBalancer with id '%s' does not exist", loadBalancerID)
@@ -70,47 +70,47 @@ func (this *ECSLoadBalancerManager) GetLoadBalancer(loadBalancerID string) (*mod
 		return nil, err
 	}
 
-	// todo: does describe laodbalancer return nil or erro?
-	return this.populateModel(loadBalancer), nil
+	// todo: does describe loadbalancer return nil or erro?
+	return e.populateModel(loadBalancer), nil
 }
 
-func (this *ECSLoadBalancerManager) DeleteLoadBalancer(loadBalancerID string) error {
+func (e *ECSLoadBalancerManager) DeleteLoadBalancer(loadBalancerID string) error {
 	ecsLoadBalancerID := id.L0LoadBalancerID(loadBalancerID).ECSLoadBalancerID()
 	roleName := ecsLoadBalancerID.RoleName()
 
-	policyList, err := this.IAM.ListRolePolicies(roleName)
+	policyList, err := e.IAM.ListRolePolicies(roleName)
 	if err != nil && !ContainsErrCode(err, "NoSuchEntity") {
 		return err
 	}
 
 	for _, name := range policyList {
 		policy := stringOrEmpty(name)
-		if err := this.IAM.DeleteRolePolicy(roleName, policy); err != nil {
+		if err := e.IAM.DeleteRolePolicy(roleName, policy); err != nil {
 			return err
 		}
 	}
 
-	if err := this.waitUntilRolePoliciesDeleted(roleName); err != nil {
+	if err := e.waitUntilRolePoliciesDeleted(roleName); err != nil {
 		return err
 	}
 
-	if err := this.IAM.DeleteRole(roleName); err != nil {
+	if err := e.IAM.DeleteRole(roleName); err != nil {
 		if !ContainsErrCode(err, "NoSuchEntity") {
 			return err
 		}
 	}
 
-	if err := this.waitUntilRoleDeleted(roleName); err != nil {
+	if err := e.waitUntilRoleDeleted(roleName); err != nil {
 		return err
 	}
 
-	if err := this.ELB.DeleteLoadBalancer(ecsLoadBalancerID.String()); err != nil {
+	if err := e.ELB.DeleteLoadBalancer(ecsLoadBalancerID.String()); err != nil {
 		if !ContainsErrCode(err, "NoSuchEntity") {
 			return err
 		}
 	}
 
-	securityGroup, err := this.EC2.DescribeSecurityGroup(ecsLoadBalancerID.SecurityGroupName())
+	securityGroup, err := e.EC2.DescribeSecurityGroup(ecsLoadBalancerID.SecurityGroupName())
 	if err != nil {
 		return err
 	}
@@ -119,7 +119,7 @@ func (this *ECSLoadBalancerManager) DeleteLoadBalancer(loadBalancerID string) er
 	// todo: using waiters seems pretty verbose - should find a way to clean this up
 	if securityGroup != nil {
 		check := func() (bool, error) {
-			if err := this.EC2.DeleteSecurityGroup(securityGroup); err == nil {
+			if err := e.EC2.DeleteSecurityGroup(securityGroup); err == nil {
 				return true, nil
 			}
 
@@ -130,7 +130,7 @@ func (this *ECSLoadBalancerManager) DeleteLoadBalancer(loadBalancerID string) er
 			Name:    fmt.Sprintf("SecurityGroup delete for '%s'", securityGroup),
 			Retries: 30,
 			Delay:   time.Second * 10,
-			Clock:   this.Clock,
+			Clock:   e.Clock,
 			Check:   check,
 		}
 
@@ -142,9 +142,9 @@ func (this *ECSLoadBalancerManager) DeleteLoadBalancer(loadBalancerID string) er
 	return nil
 }
 
-func (this *ECSLoadBalancerManager) waitUntilRolePoliciesDeleted(roleName string) error {
+func (e *ECSLoadBalancerManager) waitUntilRolePoliciesDeleted(roleName string) error {
 	check := func() (bool, error) {
-		policies, err := this.IAM.ListRolePolicies(roleName)
+		policies, err := e.IAM.ListRolePolicies(roleName)
 		if err != nil && !ContainsErrCode(err, "NoSuchEntity") {
 			return false, err
 		}
@@ -156,16 +156,16 @@ func (this *ECSLoadBalancerManager) waitUntilRolePoliciesDeleted(roleName string
 		Name:    fmt.Sprintf("Wait for deleted role policies %s", roleName),
 		Retries: 50,
 		Delay:   time.Second * 5,
-		Clock:   this.Clock,
+		Clock:   e.Clock,
 		Check:   check,
 	}
 
 	return waiter.Wait()
 }
 
-func (this *ECSLoadBalancerManager) waitUntilRoleDeleted(roleName string) error {
+func (e *ECSLoadBalancerManager) waitUntilRoleDeleted(roleName string) error {
 	check := func() (bool, error) {
-		policies, err := this.IAM.ListRolePolicies(roleName)
+		policies, err := e.IAM.ListRolePolicies(roleName)
 		if err != nil && !ContainsErrCode(err, "NoSuchEntity") {
 			return false, err
 		}
@@ -177,19 +177,27 @@ func (this *ECSLoadBalancerManager) waitUntilRoleDeleted(roleName string) error 
 		Name:    fmt.Sprintf("Wait for deleted role %s", roleName),
 		Retries: 50,
 		Delay:   time.Second * 5,
-		Clock:   this.Clock,
+		Clock:   e.Clock,
 		Check:   check,
 	}
 
 	return waiter.Wait()
 }
 
-func (this *ECSLoadBalancerManager) populateModel(description *elb.LoadBalancerDescription) *models.LoadBalancer {
+func (e *ECSLoadBalancerManager) populateModel(description *elb.LoadBalancerDescription) *models.LoadBalancer {
 	ecsLoadBalancerID := id.ECSLoadBalancerID(*description.LoadBalancerName)
 
 	ports := []models.Port{}
 	for _, listener := range description.ListenerDescriptions {
-		ports = append(ports, this.listenerToPort(listener.Listener))
+		ports = append(ports, e.listenerToPort(listener.Listener))
+	}
+
+	healthCheck := models.HealthCheck{
+		Target:             *description.HealthCheck.Target,
+		Interval:           int(*description.HealthCheck.Interval),
+		Timeout:            int(*description.HealthCheck.Timeout),
+		HealthyThreshold:   int(*description.HealthCheck.HealthyThreshold),
+		UnhealthyThreshold: int(*description.HealthCheck.UnhealthyThreshold),
 	}
 
 	model := &models.LoadBalancer{
@@ -197,12 +205,13 @@ func (this *ECSLoadBalancerManager) populateModel(description *elb.LoadBalancerD
 		Ports:          ports,
 		IsPublic:       stringOrEmpty(description.Scheme) == "internet-facing",
 		URL:            stringOrEmpty(description.DNSName),
+		HealthCheck:    healthCheck,
 	}
 
 	return model
 }
 
-func (this *ECSLoadBalancerManager) listenerToPort(listener *awselb.Listener) models.Port {
+func (e *ECSLoadBalancerManager) listenerToPort(listener *awselb.Listener) models.Port {
 	port := models.Port{
 		ContainerPort: *listener.InstancePort,
 		HostPort:      *listener.LoadBalancerPort,
@@ -217,8 +226,8 @@ func (this *ECSLoadBalancerManager) listenerToPort(listener *awselb.Listener) mo
 	return port
 }
 
-func (this *ECSLoadBalancerManager) getSecurityGroupIDByName(securityGroupName string) (string, error) {
-	securityGroup, err := this.EC2.DescribeSecurityGroup(securityGroupName)
+func (e *ECSLoadBalancerManager) getSecurityGroupIDByName(securityGroupName string) (string, error) {
+	securityGroup, err := e.EC2.DescribeSecurityGroup(securityGroupName)
 	if err != nil {
 		return "", err
 	}
@@ -230,18 +239,24 @@ func (this *ECSLoadBalancerManager) getSecurityGroupIDByName(securityGroupName s
 	return *securityGroup.GroupId, nil
 }
 
-func (this *ECSLoadBalancerManager) CreateLoadBalancer(
+func (e *ECSLoadBalancerManager) CreateLoadBalancer(
 	loadBalancerName,
 	environmentID string,
 	isPublic bool,
 	ports []models.Port,
+	healthCheck models.HealthCheck,
 ) (*models.LoadBalancer, error) {
 	// we generate a hashed id for load balancers since aws does not enforce unique load balancer names
 	loadBalancerID := id.GenerateHashedEntityID(loadBalancerName)
 	ecsLoadBalancerID := id.L0LoadBalancerID(loadBalancerID).ECSLoadBalancerID()
 	ecsEnvironmentID := id.L0EnvironmentID(environmentID).ECSEnvironmentID()
 
-	if err := this.createLoadBalancer(ecsLoadBalancerID, ecsEnvironmentID, isPublic, ports); err != nil {
+	if err := e.createLoadBalancer(ecsLoadBalancerID, ecsEnvironmentID, isPublic, ports); err != nil {
+		return nil, err
+	}
+
+	// Once the loadbalancer has been created, we can update its healthcheck
+	if err := e.updateHealthCheck(ecsLoadBalancerID, healthCheck); err != nil {
 		return nil, err
 	}
 
@@ -251,12 +266,13 @@ func (this *ECSLoadBalancerManager) CreateLoadBalancer(
 		EnvironmentID:    ecsEnvironmentID.L0EnvironmentID(),
 		IsPublic:         isPublic,
 		Ports:            ports,
+		HealthCheck:      healthCheck,
 	}
 
 	return model, nil
 }
 
-func (this *ECSLoadBalancerManager) createLoadBalancer(
+func (e *ECSLoadBalancerManager) createLoadBalancer(
 	ecsLoadBalancerID id.ECSLoadBalancerID,
 	ecsEnvironmentID id.ECSEnvironmentID,
 	isPublic bool,
@@ -264,7 +280,7 @@ func (this *ECSLoadBalancerManager) createLoadBalancer(
 ) error {
 	listeners := []*elb.Listener{}
 	for _, port := range ports {
-		listener, err := this.portToListener(port)
+		listener, err := e.portToListener(port)
 		if err != nil {
 			return err
 		}
@@ -273,27 +289,27 @@ func (this *ECSLoadBalancerManager) createLoadBalancer(
 	}
 
 	roleName := ecsLoadBalancerID.RoleName()
-	if _, err := this.IAM.CreateRole(roleName, "ecs.amazonaws.com"); err != nil {
+	if _, err := e.IAM.CreateRole(roleName, "ecs.amazonaws.com"); err != nil {
 		if !ContainsErrCode(err, "EntityAlreadyExists") {
 			return err
 		}
 	}
 
-	policy, err := this.generateRolePolicy(ecsLoadBalancerID)
+	policy, err := e.generateRolePolicy(ecsLoadBalancerID)
 	if err != nil {
 		return err
 	}
 
-	if err := this.IAM.PutRolePolicy(roleName, policy); err != nil {
+	if err := e.IAM.PutRolePolicy(roleName, policy); err != nil {
 		return err
 	}
 
-	securityGroup, err := this.upsertSecurityGroup(ecsLoadBalancerID, ports)
+	securityGroup, err := e.upsertSecurityGroup(ecsLoadBalancerID, ports)
 	if err != nil {
 		return err
 	}
 
-	environmentSecurityGroupID, err := this.getSecurityGroupIDByName(ecsEnvironmentID.SecurityGroupName())
+	environmentSecurityGroupID, err := e.getSecurityGroupIDByName(ecsEnvironmentID.SecurityGroupName())
 	if err != nil {
 		return fmt.Errorf("Failed to find environment Security Group: %v", err)
 	}
@@ -305,26 +321,47 @@ func (this *ECSLoadBalancerManager) createLoadBalancer(
 		scheme = "internet-facing"
 	}
 
-	subnets, _, err := this.getSubnetsAndAvailZones(isPublic)
+	subnets, _, err := e.getSubnetsAndAvailZones(isPublic)
 	if err != nil {
 		return err
 	}
 
-	if _, err := this.ELB.CreateLoadBalancer(ecsLoadBalancerID.String(), scheme, securityGroups, subnets, listeners); err != nil {
+	if _, err := e.ELB.CreateLoadBalancer(ecsLoadBalancerID.String(), scheme, securityGroups, subnets, listeners); err != nil {
 		return err
 	}
 
 	return nil
 }
 
-func (this *ECSLoadBalancerManager) UpdateLoadBalancer(loadBalancerID string, ports []models.Port) (*models.LoadBalancer, error) {
-	model, err := this.GetLoadBalancer(loadBalancerID)
+func (e *ECSLoadBalancerManager) UpdateLoadBalancerHealthCheck(loadBalancerID string, healthCheck models.HealthCheck) (*models.LoadBalancer, error) {
+	ecsLoadBalancerID := id.L0LoadBalancerID(loadBalancerID).ECSLoadBalancerID()
+	if err := e.updateHealthCheck(ecsLoadBalancerID, healthCheck); err != nil {
+		return nil, err
+	}
+
+	return e.GetLoadBalancer(loadBalancerID)
+}
+
+func (e *ECSLoadBalancerManager) updateHealthCheck(ecsLoadBalancerID id.ECSLoadBalancerID, healthCheck models.HealthCheck) error {
+	elbHealthCheck := elb.NewHealthCheck(
+		healthCheck.Target,
+		int64(healthCheck.Interval),
+		int64(healthCheck.Timeout),
+		int64(healthCheck.HealthyThreshold),
+		int64(healthCheck.UnhealthyThreshold),
+	)
+
+	return e.ELB.ConfigureHealthCheck(ecsLoadBalancerID.String(), elbHealthCheck)
+}
+
+func (e *ECSLoadBalancerManager) UpdateLoadBalancerPorts(loadBalancerID string, ports []models.Port) (*models.LoadBalancer, error) {
+	model, err := e.GetLoadBalancer(loadBalancerID)
 	if err != nil {
 		return nil, err
 	}
 
 	ecsLoadBalancerID := id.L0LoadBalancerID(loadBalancerID).ECSLoadBalancerID()
-	updatedPorts, err := this.updatePorts(ecsLoadBalancerID, model.Ports, ports)
+	updatedPorts, err := e.updatePorts(ecsLoadBalancerID, model.Ports, ports)
 	if err != nil {
 		return nil, err
 	}
@@ -333,15 +370,15 @@ func (this *ECSLoadBalancerManager) UpdateLoadBalancer(loadBalancerID string, po
 	return model, nil
 }
 
-func (this *ECSLoadBalancerManager) updatePorts(ecsLoadBalancerID id.ECSLoadBalancerID, currentPorts, requestedPorts []models.Port) ([]models.Port, error) {
+func (e *ECSLoadBalancerManager) updatePorts(ecsLoadBalancerID id.ECSLoadBalancerID, currentPorts, requestedPorts []models.Port) ([]models.Port, error) {
 	if reflect.DeepEqual(currentPorts, requestedPorts) {
 		return currentPorts, nil
 	}
 
-	// remove first to we don't duplicate host ports
+	// remove first so we don't duplicate host ports
 	listenersToRemove := []*elb.Listener{}
 	for _, port := range portDifference(currentPorts, requestedPorts) {
-		listener, err := this.portToListener(port)
+		listener, err := e.portToListener(port)
 		if err != nil {
 			return nil, err
 		}
@@ -350,14 +387,14 @@ func (this *ECSLoadBalancerManager) updatePorts(ecsLoadBalancerID id.ECSLoadBala
 	}
 
 	if len(listenersToRemove) > 0 {
-		if err := this.ELB.DeleteLoadBalancerListeners(ecsLoadBalancerID.String(), listenersToRemove); err != nil {
+		if err := e.ELB.DeleteLoadBalancerListeners(ecsLoadBalancerID.String(), listenersToRemove); err != nil {
 			return nil, err
 		}
 	}
 
 	listenersToAdd := []*elb.Listener{}
 	for _, port := range portDifference(requestedPorts, currentPorts) {
-		listener, err := this.portToListener(port)
+		listener, err := e.portToListener(port)
 		if err != nil {
 			return nil, err
 		}
@@ -366,19 +403,19 @@ func (this *ECSLoadBalancerManager) updatePorts(ecsLoadBalancerID id.ECSLoadBala
 	}
 
 	if len(listenersToAdd) > 0 {
-		if err := this.ELB.CreateLoadBalancerListeners(ecsLoadBalancerID.String(), listenersToAdd); err != nil {
+		if err := e.ELB.CreateLoadBalancerListeners(ecsLoadBalancerID.String(), listenersToAdd); err != nil {
 			return nil, err
 		}
 	}
 
-	if _, err := this.upsertSecurityGroup(ecsLoadBalancerID, requestedPorts); err != nil {
+	if _, err := e.upsertSecurityGroup(ecsLoadBalancerID, requestedPorts); err != nil {
 		return nil, err
 	}
 
 	return requestedPorts, nil
 }
 
-func (this *ECSLoadBalancerManager) portToListener(port models.Port) (*elb.Listener, error) {
+func (e *ECSLoadBalancerManager) portToListener(port models.Port) (*elb.Listener, error) {
 	hostProtocol := strings.ToUpper(port.Protocol)
 	if hostProtocol != "SSL" && hostProtocol != "TCP" && hostProtocol != "HTTP" && hostProtocol != "HTTPS" {
 		return nil, fmt.Errorf("Protocol '%s' is not valid", port.Protocol)
@@ -395,7 +432,7 @@ func (this *ECSLoadBalancerManager) portToListener(port models.Port) (*elb.Liste
 
 	var certificateARN string
 	if port.CertificateName != "" {
-		arn, err := this.getCertificateARN(port.CertificateName)
+		arn, err := e.getCertificateARN(port.CertificateName)
 		if err != nil {
 			return nil, err
 		}
@@ -407,8 +444,8 @@ func (this *ECSLoadBalancerManager) portToListener(port models.Port) (*elb.Liste
 	return listener, nil
 }
 
-func (this *ECSLoadBalancerManager) getCertificateARN(name string) (string, error) {
-	certificates, err := this.IAM.ListCertificates()
+func (e *ECSLoadBalancerManager) getCertificateARN(name string) (string, error) {
+	certificates, err := e.IAM.ListCertificates()
 	if err != nil {
 		return "", err
 	}
@@ -422,10 +459,10 @@ func (this *ECSLoadBalancerManager) getCertificateARN(name string) (string, erro
 	return "", fmt.Errorf("Certificate with name '%s' does not exist. ", name)
 }
 
-func (this *ECSLoadBalancerManager) upsertSecurityGroup(ecsLoadBalancerID id.ECSLoadBalancerID, ports []models.Port) (*ec2.SecurityGroup, error) {
+func (e *ECSLoadBalancerManager) upsertSecurityGroup(ecsLoadBalancerID id.ECSLoadBalancerID, ports []models.Port) (*ec2.SecurityGroup, error) {
 	securityGroupName := ecsLoadBalancerID.SecurityGroupName()
 
-	securityGroup, err := this.EC2.DescribeSecurityGroup(securityGroupName)
+	securityGroup, err := e.EC2.DescribeSecurityGroup(securityGroupName)
 	if err != nil {
 		return nil, err
 	}
@@ -434,12 +471,12 @@ func (this *ECSLoadBalancerManager) upsertSecurityGroup(ecsLoadBalancerID id.ECS
 		desc := "Auto-generated Layer0 Load Balancer Security Group"
 		vpcID := config.AWSVPCID()
 
-		if _, err = this.EC2.CreateSecurityGroup(securityGroupName, desc, vpcID); err != nil {
+		if _, err = e.EC2.CreateSecurityGroup(securityGroupName, desc, vpcID); err != nil {
 			return nil, err
 		}
 
 		check := func() (bool, error) {
-			securityGroup, err = this.EC2.DescribeSecurityGroup(securityGroupName)
+			securityGroup, err = e.EC2.DescribeSecurityGroup(securityGroupName)
 			if err != nil {
 				return false, err
 			}
@@ -453,7 +490,7 @@ func (this *ECSLoadBalancerManager) upsertSecurityGroup(ecsLoadBalancerID id.ECS
 			Name:    fmt.Sprintf("SecurityGroup setup for '%s'", ecsLoadBalancerID),
 			Retries: 60,
 			Delay:   time.Second * 1,
-			Clock:   this.Clock,
+			Clock:   e.Clock,
 			Check:   check,
 		}
 
@@ -481,7 +518,7 @@ func (this *ECSLoadBalancerManager) upsertSecurityGroup(ecsLoadBalancerID id.ECS
 
 	if len(ingressesToRemove) > 0 {
 		log.Debug("Removing Ports: ", *securityGroup.GroupId, ingressesToRemove)
-		if err := this.EC2.RevokeSecurityGroupIngress(ingressesToRemove); err != nil {
+		if err := e.EC2.RevokeSecurityGroupIngress(ingressesToRemove); err != nil {
 			return nil, err
 		}
 	}
@@ -494,7 +531,7 @@ func (this *ECSLoadBalancerManager) upsertSecurityGroup(ecsLoadBalancerID id.ECS
 
 	if len(ingressesToAdd) > 0 {
 		log.Debug("Adding ports: ", *securityGroup.GroupId, ingressesToAdd)
-		if err := this.EC2.AuthorizeSecurityGroupIngress(ingressesToAdd); err != nil {
+		if err := e.EC2.AuthorizeSecurityGroupIngress(ingressesToAdd); err != nil {
 			return nil, err
 		}
 	}
@@ -547,7 +584,7 @@ func ingressPortDifference(requested, current []int64) []int64 {
 // need to do something to calculate which subnets to use based on where the instance
 // got provisioned.
 
-func (this *ECSLoadBalancerManager) getSubnetsAndAvailZones(public bool) ([]*string, []*string, error) {
+func (e *ECSLoadBalancerManager) getSubnetsAndAvailZones(public bool) ([]*string, []*string, error) {
 
 	// todo: the majority of this function can be taken out, we essentially jsut need to split
 	// config.Subnets() and return []string. AWS Handles the overlap error check for us already
@@ -564,7 +601,7 @@ func (this *ECSLoadBalancerManager) getSubnetsAndAvailZones(public bool) ([]*str
 		subnet := strings.TrimSpace(subnetID)
 		subnetIDs = append(subnetIDs, &subnet)
 
-		description, err := this.EC2.DescribeSubnet(subnetID)
+		description, err := e.EC2.DescribeSubnet(subnetID)
 		if err != nil {
 			return nil, nil, err
 		}
@@ -587,7 +624,7 @@ func (this *ECSLoadBalancerManager) getSubnetsAndAvailZones(public bool) ([]*str
 	return subnetIDs, availZones, nil
 }
 
-func (this *ECSLoadBalancerManager) generateRolePolicy(ecsLoadBalancerID id.ECSLoadBalancerID) (string, error) {
+func (e *ECSLoadBalancerManager) generateRolePolicy(ecsLoadBalancerID id.ECSLoadBalancerID) (string, error) {
 	// the default policy includes "ec2:AuthorizeSecurityGroupIngress" which we exclude
 	// because we don't know why it's there
 	policy := `
@@ -617,7 +654,7 @@ func (this *ECSLoadBalancerManager) generateRolePolicy(ecsLoadBalancerID id.ECSL
 
     ]
 }`
-	awsAccountID, err := this.IAM.GetAccountId()
+	awsAccountID, err := e.IAM.GetAccountId()
 	if err != nil {
 		return "", err
 	}

--- a/api/backend/ecs/mock_ecsbackend/mock_cluster_scaler.go
+++ b/api/backend/ecs/mock_ecsbackend/mock_cluster_scaler.go
@@ -4,8 +4,8 @@
 package mock_ecsbackend
 
 import (
-	gomock "github.com/golang/mock/gomock"
 	id "github.com/quintilesims/layer0/api/backend/ecs/id"
+	gomock "github.com/golang/mock/gomock"
 )
 
 // Mock of ClusterScaler interface

--- a/api/backend/ecs/mock_ecsbackend/mock_task_scheduler.go
+++ b/api/backend/ecs/mock_ecsbackend/mock_task_scheduler.go
@@ -6,8 +6,8 @@ package mock_ecsbackend
 import (
 	gomock "github.com/golang/mock/gomock"
 	id "github.com/quintilesims/layer0/api/backend/ecs/id"
-	ecs "github.com/quintilesims/layer0/common/aws/ecs"
 	models "github.com/quintilesims/layer0/common/models"
+	ecs "github.com/quintilesims/layer0/common/aws/ecs"
 )
 
 // Mock of TaskScheduler interface

--- a/api/backend/interface.go
+++ b/api/backend/interface.go
@@ -33,8 +33,9 @@ type Backend interface {
 	ListLoadBalancers() ([]*models.LoadBalancer, error)
 	GetLoadBalancer(id string) (*models.LoadBalancer, error)
 	DeleteLoadBalancer(id string) error
-	CreateLoadBalancer(loadBalancerName, environmentID string, isPublic bool, ports []models.Port) (*models.LoadBalancer, error)
-	UpdateLoadBalancer(loadBalancerID string, ports []models.Port) (*models.LoadBalancer, error)
+	CreateLoadBalancer(loadBalancerName, environmentID string, isPublic bool, ports []models.Port, healthCheck models.HealthCheck) (*models.LoadBalancer, error)
+	UpdateLoadBalancerPorts(loadBalancerID string, ports []models.Port) (*models.LoadBalancer, error)
+	UpdateLoadBalancerHealthCheck(loadBalancerID string, healthCheck models.HealthCheck) (*models.LoadBalancer, error)
 
 	StartRightSizer()
 	GetRightSizerHealth() (string, error)

--- a/api/backend/mock_backend/mock_backend.go
+++ b/api/backend/mock_backend/mock_backend.go
@@ -4,8 +4,8 @@
 package mock_backend
 
 import (
-	gomock "github.com/golang/mock/gomock"
 	models "github.com/quintilesims/layer0/common/models"
+	gomock "github.com/golang/mock/gomock"
 )
 
 // Mock of Backend interface
@@ -51,15 +51,15 @@ func (_mr *_MockBackendRecorder) CreateEnvironment(arg0, arg1, arg2, arg3 interf
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "CreateEnvironment", arg0, arg1, arg2, arg3)
 }
 
-func (_m *MockBackend) CreateLoadBalancer(_param0 string, _param1 string, _param2 bool, _param3 []models.Port) (*models.LoadBalancer, error) {
-	ret := _m.ctrl.Call(_m, "CreateLoadBalancer", _param0, _param1, _param2, _param3)
+func (_m *MockBackend) CreateLoadBalancer(_param0 string, _param1 string, _param2 bool, _param3 []models.Port, _param4 models.HealthCheck) (*models.LoadBalancer, error) {
+	ret := _m.ctrl.Call(_m, "CreateLoadBalancer", _param0, _param1, _param2, _param3, _param4)
 	ret0, _ := ret[0].(*models.LoadBalancer)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockBackendRecorder) CreateLoadBalancer(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "CreateLoadBalancer", arg0, arg1, arg2, arg3)
+func (_mr *_MockBackendRecorder) CreateLoadBalancer(arg0, arg1, arg2, arg3, arg4 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "CreateLoadBalancer", arg0, arg1, arg2, arg3, arg4)
 }
 
 func (_m *MockBackend) CreateService(_param0 string, _param1 string, _param2 string, _param3 string) (*models.Service, error) {
@@ -307,15 +307,26 @@ func (_mr *_MockBackendRecorder) UpdateEnvironment(arg0, arg1 interface{}) *gomo
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "UpdateEnvironment", arg0, arg1)
 }
 
-func (_m *MockBackend) UpdateLoadBalancer(_param0 string, _param1 []models.Port) (*models.LoadBalancer, error) {
-	ret := _m.ctrl.Call(_m, "UpdateLoadBalancer", _param0, _param1)
+func (_m *MockBackend) UpdateLoadBalancerHealthCheck(_param0 string, _param1 models.HealthCheck) (*models.LoadBalancer, error) {
+	ret := _m.ctrl.Call(_m, "UpdateLoadBalancerHealthCheck", _param0, _param1)
 	ret0, _ := ret[0].(*models.LoadBalancer)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockBackendRecorder) UpdateLoadBalancer(arg0, arg1 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "UpdateLoadBalancer", arg0, arg1)
+func (_mr *_MockBackendRecorder) UpdateLoadBalancerHealthCheck(arg0, arg1 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "UpdateLoadBalancerHealthCheck", arg0, arg1)
+}
+
+func (_m *MockBackend) UpdateLoadBalancerPorts(_param0 string, _param1 []models.Port) (*models.LoadBalancer, error) {
+	ret := _m.ctrl.Call(_m, "UpdateLoadBalancerPorts", _param0, _param1)
+	ret0, _ := ret[0].(*models.LoadBalancer)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+func (_mr *_MockBackendRecorder) UpdateLoadBalancerPorts(arg0, arg1 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "UpdateLoadBalancerPorts", arg0, arg1)
 }
 
 func (_m *MockBackend) UpdateService(_param0 string, _param1 string, _param2 string) (*models.Service, error) {

--- a/api/handlers/load_balancer_handler_test.go
+++ b/api/handlers/load_balancer_handler_test.go
@@ -22,7 +22,7 @@ func TestListLoadBalancers(t *testing.T) {
 	}
 
 	testCases := []HandlerTestCase{
-		HandlerTestCase{
+		{
 			Name:    "Should return loadBalancers from logic layer",
 			Request: &TestRequest{},
 			Setup: func(ctrl *gomock.Controller) interface{} {
@@ -44,7 +44,7 @@ func TestListLoadBalancers(t *testing.T) {
 				reporter.AssertEqual(response, loadBalancers)
 			},
 		},
-		HandlerTestCase{
+		{
 			Name:    "Should propogate ListLoadBalancers error",
 			Request: &TestRequest{},
 			Setup: func(ctrl *gomock.Controller) interface{} {
@@ -77,7 +77,7 @@ func TestGetLoadBalancer(t *testing.T) {
 	}
 
 	testCases := []HandlerTestCase{
-		HandlerTestCase{
+		{
 			Name: "Should call GetLoadBalancer with proper params",
 			Request: &TestRequest{
 				Parameters: map[string]string{"id": "some_id"},
@@ -96,7 +96,7 @@ func TestGetLoadBalancer(t *testing.T) {
 				handler.GetLoadBalancer(req, resp)
 			},
 		},
-		HandlerTestCase{
+		{
 			Name: "Should return loadBalancer from logic layer",
 			Request: &TestRequest{
 				Parameters: map[string]string{"id": "some_id"},
@@ -120,7 +120,7 @@ func TestGetLoadBalancer(t *testing.T) {
 				reporter.AssertEqual(response, loadBalancer)
 			},
 		},
-		HandlerTestCase{
+		{
 			Name:    "Should return MissingParameter error with no id",
 			Request: &TestRequest{},
 			Setup: func(ctrl *gomock.Controller) interface{} {
@@ -138,7 +138,7 @@ func TestGetLoadBalancer(t *testing.T) {
 				reporter.AssertEqual(response.ErrorCode, int64(errors.MissingParameter))
 			},
 		},
-		HandlerTestCase{
+		{
 			Name: "Should propagate GetLoadBalancer error",
 			Request: &TestRequest{
 				Parameters: map[string]string{"id": "some_id"},
@@ -176,8 +176,8 @@ func TestCreateLoadBalancer(t *testing.T) {
 	}
 
 	testCases := []HandlerTestCase{
-		HandlerTestCase{
-			Name: "Should call CreateLoadBalancer with correct params",
+		{
+			Name: "Should call logic:CreateLoadBalancer with correct params",
 			Request: &TestRequest{
 				Body: request,
 			},
@@ -195,7 +195,7 @@ func TestCreateLoadBalancer(t *testing.T) {
 				handler.CreateLoadBalancer(req, resp)
 			},
 		},
-		HandlerTestCase{
+		{
 			Name: "Should propagate CreateLoadBalancer error",
 			Request: &TestRequest{
 				Body: request,
@@ -226,7 +226,7 @@ func TestCreateLoadBalancer(t *testing.T) {
 
 func TestDeleteLoadBalancer(t *testing.T) {
 	testCases := []HandlerTestCase{
-		HandlerTestCase{
+		{
 			Name: "Should call CreateJob with correct params",
 			Request: &TestRequest{
 				Parameters: map[string]string{"id": "some_id"},
@@ -246,7 +246,7 @@ func TestDeleteLoadBalancer(t *testing.T) {
 				handler.DeleteLoadBalancer(req, resp)
 			},
 		},
-		HandlerTestCase{
+		{
 			Name: "Should set Location and X-Jobid headers",
 			Request: &TestRequest{
 				Parameters: map[string]string{"id": "some_id"},
@@ -270,7 +270,7 @@ func TestDeleteLoadBalancer(t *testing.T) {
 				reporter.AssertInSlice("job_id", header["X-Jobid"])
 			},
 		},
-		HandlerTestCase{
+		{
 			Name: "Should propagate CreateJob error",
 			Request: &TestRequest{
 				Parameters: map[string]string{"id": "some_id"},
@@ -295,7 +295,7 @@ func TestDeleteLoadBalancer(t *testing.T) {
 				reporter.AssertEqual(int64(errors.UnexpectedError), response.ErrorCode)
 			},
 		},
-		HandlerTestCase{
+		{
 			Name:    "Should return MissingParameter error with no id",
 			Request: &TestRequest{},
 			Setup: func(ctrl *gomock.Controller) interface{} {
@@ -312,6 +312,43 @@ func TestDeleteLoadBalancer(t *testing.T) {
 				read(&response)
 
 				reporter.AssertEqual(int64(errors.MissingParameter), response.ErrorCode)
+			},
+		},
+	}
+
+	RunHandlerTestCases(t, testCases)
+}
+
+func TestUpdateLoadBalancerHealthCheck(t *testing.T) {
+	request := models.UpdateLoadBalancerHealthCheckRequest{
+		models.HealthCheck{
+			Target:             "TCP:80",
+			Interval:           30,
+			Timeout:            5,
+			HealthyThreshold:   2,
+			UnhealthyThreshold: 2,
+		},
+	}
+
+	testCases := []HandlerTestCase{
+		{
+			Name: "Should call UpdateLoadBalancerHealthCheck with correct params",
+			Request: &TestRequest{
+				Parameters: map[string]string{"id": "some_id"},
+				Body:       request,
+			},
+			Setup: func(ctrl *gomock.Controller) interface{} {
+				mockLogic := mock_logic.NewMockLoadBalancerLogic(ctrl)
+				mockJob := mock_logic.NewMockJobLogic(ctrl)
+
+				mockLogic.EXPECT().
+					UpdateLoadBalancerHealthCheck("some_id", request.HealthCheck)
+
+				return NewLoadBalancerHandler(mockLogic, mockJob)
+			},
+			Run: func(reporter *testutils.Reporter, target interface{}, req *restful.Request, resp *restful.Response, read Readf) {
+				handler := target.(*LoadBalancerHandler)
+				handler.UpdateLoadBalancerHealthCheck(req, resp)
 			},
 		},
 	}

--- a/api/logic/load_balancer_logic.go
+++ b/api/logic/load_balancer_logic.go
@@ -11,7 +11,8 @@ type LoadBalancerLogic interface {
 	GetLoadBalancer(loadBalancerID string) (*models.LoadBalancer, error)
 	DeleteLoadBalancer(loadBalancerID string) error
 	CreateLoadBalancer(req models.CreateLoadBalancerRequest) (*models.LoadBalancer, error)
-	UpdateLoadBalancer(loadBalancerID string, ports []models.Port) (*models.LoadBalancer, error)
+	UpdateLoadBalancerPorts(loadBalancerID string, ports []models.Port) (*models.LoadBalancer, error)
+	UpdateLoadBalancerHealthCheck(loadBalancerID string, healthCheck models.HealthCheck) (*models.LoadBalancer, error)
 }
 
 type L0LoadBalancerLogic struct {
@@ -24,15 +25,15 @@ func NewL0LoadBalancerLogic(logic Logic) *L0LoadBalancerLogic {
 	}
 }
 
-func (this *L0LoadBalancerLogic) ListLoadBalancers() ([]*models.LoadBalancerSummary, error) {
-	loadBalancers, err := this.Backend.ListLoadBalancers()
+func (l *L0LoadBalancerLogic) ListLoadBalancers() ([]*models.LoadBalancerSummary, error) {
+	loadBalancers, err := l.Backend.ListLoadBalancers()
 	if err != nil {
 		return nil, err
 	}
 
 	summaries := make([]*models.LoadBalancerSummary, len(loadBalancers))
 	for i, loadBalancer := range loadBalancers {
-		if err := this.populateModel(loadBalancer); err != nil {
+		if err := l.populateModel(loadBalancer); err != nil {
 			return nil, err
 		}
 
@@ -47,32 +48,32 @@ func (this *L0LoadBalancerLogic) ListLoadBalancers() ([]*models.LoadBalancerSumm
 	return summaries, nil
 }
 
-func (this *L0LoadBalancerLogic) GetLoadBalancer(loadBalancerID string) (*models.LoadBalancer, error) {
-	loadBalancer, err := this.Backend.GetLoadBalancer(loadBalancerID)
+func (l *L0LoadBalancerLogic) GetLoadBalancer(loadBalancerID string) (*models.LoadBalancer, error) {
+	loadBalancer, err := l.Backend.GetLoadBalancer(loadBalancerID)
 	if err != nil {
 		return nil, err
 	}
 
-	if err := this.populateModel(loadBalancer); err != nil {
+	if err := l.populateModel(loadBalancer); err != nil {
 		return nil, err
 	}
 
 	return loadBalancer, nil
 }
 
-func (this *L0LoadBalancerLogic) DeleteLoadBalancer(loadBalancerID string) error {
-	if err := this.Backend.DeleteLoadBalancer(loadBalancerID); err != nil {
+func (l *L0LoadBalancerLogic) DeleteLoadBalancer(loadBalancerID string) error {
+	if err := l.Backend.DeleteLoadBalancer(loadBalancerID); err != nil {
 		return err
 	}
 
-	if err := this.deleteEntityTags("load_balancer", loadBalancerID); err != nil {
+	if err := l.deleteEntityTags("load_balancer", loadBalancerID); err != nil {
 		return err
 	}
 
 	return nil
 }
 
-func (this *L0LoadBalancerLogic) CreateLoadBalancer(req models.CreateLoadBalancerRequest) (*models.LoadBalancer, error) {
+func (l *L0LoadBalancerLogic) CreateLoadBalancer(req models.CreateLoadBalancerRequest) (*models.LoadBalancer, error) {
 	if req.EnvironmentID == "" {
 		return nil, errors.Newf(errors.MissingParameter, "EnvironmentID not specified")
 	}
@@ -81,7 +82,7 @@ func (this *L0LoadBalancerLogic) CreateLoadBalancer(req models.CreateLoadBalance
 		return nil, errors.Newf(errors.MissingParameter, "LoadBalancerName not specified")
 	}
 
-	exists, err := this.doesLoadBalancerTagExist(req.EnvironmentID, req.LoadBalancerName)
+	exists, err := l.doesLoadBalancerTagExist(req.EnvironmentID, req.LoadBalancerName)
 	if err != nil {
 		return nil, err
 	}
@@ -91,47 +92,63 @@ func (this *L0LoadBalancerLogic) CreateLoadBalancer(req models.CreateLoadBalance
 		return nil, errors.New(errors.InvalidLoadBalancerName, err)
 	}
 
-	loadBalancer, err := this.Backend.CreateLoadBalancer(
+	loadBalancer, err := l.Backend.CreateLoadBalancer(
 		req.LoadBalancerName,
 		req.EnvironmentID,
 		req.IsPublic,
-		req.Ports)
+		req.Ports,
+		req.HealthCheck,
+	)
+
 	if err != nil {
 		return loadBalancer, err
 	}
 
 	loadBalancerID := loadBalancer.LoadBalancerID
-	if err := this.upsertTagf(loadBalancerID, "load_balancer", "name", req.LoadBalancerName); err != nil {
+	if err := l.upsertTagf(loadBalancerID, "load_balancer", "name", req.LoadBalancerName); err != nil {
 		return loadBalancer, err
 	}
 
 	environmentID := loadBalancer.EnvironmentID
-	if err := this.upsertTagf(loadBalancerID, "load_balancer", "environment_id", environmentID); err != nil {
+	if err := l.upsertTagf(loadBalancerID, "load_balancer", "environment_id", environmentID); err != nil {
 		return loadBalancer, err
 	}
 
-	if err := this.populateModel(loadBalancer); err != nil {
+	if err := l.populateModel(loadBalancer); err != nil {
 		return loadBalancer, err
 	}
 
 	return loadBalancer, nil
 }
 
-func (this *L0LoadBalancerLogic) UpdateLoadBalancer(loadBalancerID string, ports []models.Port) (*models.LoadBalancer, error) {
-	loadBalancer, err := this.Backend.UpdateLoadBalancer(loadBalancerID, ports)
+func (l *L0LoadBalancerLogic) UpdateLoadBalancerPorts(loadBalancerID string, ports []models.Port) (*models.LoadBalancer, error) {
+	loadBalancer, err := l.Backend.UpdateLoadBalancerPorts(loadBalancerID, ports)
 	if err != nil {
 		return nil, err
 	}
 
-	if err := this.populateModel(loadBalancer); err != nil {
+	if err := l.populateModel(loadBalancer); err != nil {
 		return nil, err
 	}
 
 	return loadBalancer, nil
 }
 
-func (this *L0LoadBalancerLogic) doesLoadBalancerTagExist(environmentID, name string) (bool, error) {
-	tags, err := this.TagStore.SelectByQuery("load_balancer", "")
+func (l *L0LoadBalancerLogic) UpdateLoadBalancerHealthCheck(loadBalancerID string, healthCheck models.HealthCheck) (*models.LoadBalancer, error) {
+	loadBalancer, err := l.Backend.UpdateLoadBalancerHealthCheck(loadBalancerID, healthCheck)
+	if err != nil {
+		return nil, err
+	}
+
+	if err := l.populateModel(loadBalancer); err != nil {
+		return nil, err
+	}
+
+	return loadBalancer, nil
+}
+
+func (l *L0LoadBalancerLogic) doesLoadBalancerTagExist(environmentID, name string) (bool, error) {
+	tags, err := l.TagStore.SelectByQuery("load_balancer", "")
 	if err != nil {
 		return false, err
 	}
@@ -145,8 +162,8 @@ func (this *L0LoadBalancerLogic) doesLoadBalancerTagExist(environmentID, name st
 	return len(ewts) > 0, nil
 }
 
-func (this *L0LoadBalancerLogic) populateModel(model *models.LoadBalancer) error {
-	tags, err := this.TagStore.SelectByQuery("load_balancer", model.LoadBalancerID)
+func (l *L0LoadBalancerLogic) populateModel(model *models.LoadBalancer) error {
+	tags, err := l.TagStore.SelectByQuery("load_balancer", model.LoadBalancerID)
 	if err != nil {
 		return err
 	}
@@ -160,7 +177,7 @@ func (this *L0LoadBalancerLogic) populateModel(model *models.LoadBalancer) error
 	}
 
 	if model.EnvironmentID != "" {
-		tags, err := this.TagStore.SelectByQuery("environment", model.EnvironmentID)
+		tags, err := l.TagStore.SelectByQuery("environment", model.EnvironmentID)
 		if err != nil {
 			return err
 		}
@@ -170,7 +187,7 @@ func (this *L0LoadBalancerLogic) populateModel(model *models.LoadBalancer) error
 		}
 	}
 
-	tags, err = this.TagStore.SelectByQuery("service", "")
+	tags, err = l.TagStore.SelectByQuery("service", "")
 	if err != nil {
 		return err
 	}
@@ -178,7 +195,7 @@ func (this *L0LoadBalancerLogic) populateModel(model *models.LoadBalancer) error
 	if tag := tags.WithKey("load_balancer_id").WithValue(model.LoadBalancerID).First(); tag != nil {
 		model.ServiceID = tag.EntityID
 
-		serviceTags, err := this.TagStore.SelectByQuery("service", model.ServiceID)
+		serviceTags, err := l.TagStore.SelectByQuery("service", model.ServiceID)
 		if err != nil {
 			return err
 		}

--- a/api/logic/load_balancer_logic_test.go
+++ b/api/logic/load_balancer_logic_test.go
@@ -112,15 +112,24 @@ func TestCreateLoadBalancer(t *testing.T) {
 	testLogic, ctrl := NewTestLogic(t)
 	defer ctrl.Finish()
 
+	healthCheck := models.HealthCheck{
+		Target:             "TCP:80:",
+		Interval:           30,
+		Timeout:            5,
+		HealthyThreshold:   2,
+		UnhealthyThreshold: 2,
+	}
+
 	retLoadBalancer := &models.LoadBalancer{
 		LoadBalancerID: "l1",
 		EnvironmentID:  "e1",
 		IsPublic:       true,
 		Ports:          []models.Port{},
+		HealthCheck:    healthCheck,
 	}
 
 	testLogic.Backend.EXPECT().
-		CreateLoadBalancer("name", "e1", true, []models.Port{}).
+		CreateLoadBalancer("name", "e1", true, []models.Port{}, healthCheck).
 		Return(retLoadBalancer, nil)
 
 	request := models.CreateLoadBalancerRequest{
@@ -128,6 +137,7 @@ func TestCreateLoadBalancer(t *testing.T) {
 		EnvironmentID:    "e1",
 		IsPublic:         true,
 		Ports:            []models.Port{},
+		HealthCheck:      healthCheck,
 	}
 
 	loadBalancerLogic := NewL0LoadBalancerLogic(testLogic.Logic())
@@ -142,6 +152,7 @@ func TestCreateLoadBalancer(t *testing.T) {
 		EnvironmentID:    "e1",
 		IsPublic:         true,
 		Ports:            []models.Port{},
+		HealthCheck:      healthCheck,
 	}
 
 	testutils.AssertEqual(t, received, expected)
@@ -156,10 +167,10 @@ func TestCreateLoadBalancerError_missingRequiredParams(t *testing.T) {
 	loadBalancerLogic := NewL0LoadBalancerLogic(testLogic.Logic())
 
 	cases := map[string]models.CreateLoadBalancerRequest{
-		"Missing EnvironmentID": models.CreateLoadBalancerRequest{
+		"Missing EnvironmentID": {
 			LoadBalancerName: "name",
 		},
-		"Missing LoadBalancerName": models.CreateLoadBalancerRequest{
+		"Missing LoadBalancerName": {
 			EnvironmentID: "e1",
 		},
 	}
@@ -191,7 +202,7 @@ func TestCreateLoadBalancerError_duplicateName(t *testing.T) {
 	}
 }
 
-func TestUpdateLoadBalancer(t *testing.T) {
+func TestUpdateLoadBalancerPorts(t *testing.T) {
 	testLogic, ctrl := NewTestLogic(t)
 	defer ctrl.Finish()
 
@@ -202,7 +213,7 @@ func TestUpdateLoadBalancer(t *testing.T) {
 	}
 
 	testLogic.Backend.EXPECT().
-		UpdateLoadBalancer("l1", []models.Port{}).
+		UpdateLoadBalancerPorts("l1", []models.Port{}).
 		Return(retLoadBalancer, nil)
 
 	testLogic.AddTags(t, []*models.Tag{
@@ -212,7 +223,7 @@ func TestUpdateLoadBalancer(t *testing.T) {
 	})
 
 	loadBalancerLogic := NewL0LoadBalancerLogic(testLogic.Logic())
-	received, err := loadBalancerLogic.UpdateLoadBalancer("l1", []models.Port{})
+	received, err := loadBalancerLogic.UpdateLoadBalancerPorts("l1", []models.Port{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -225,4 +236,29 @@ func TestUpdateLoadBalancer(t *testing.T) {
 	}
 
 	testutils.AssertEqual(t, received, expected)
+}
+
+func TestUpdateLoadBalancerHealthCheck(t *testing.T) {
+	testLogic, ctrl := NewTestLogic(t)
+	defer ctrl.Finish()
+
+	healthCheck := models.HealthCheck{
+		Target:             "TCP:80",
+		Interval:           30,
+		Timeout:            5,
+		HealthyThreshold:   2,
+		UnhealthyThreshold: 2,
+	}
+
+	testLogic.Backend.EXPECT().
+		UpdateLoadBalancerHealthCheck("lb_id", healthCheck).
+		Return(&models.LoadBalancer{HealthCheck: healthCheck}, nil)
+
+	loadBalancerLogic := NewL0LoadBalancerLogic(testLogic.Logic())
+	received, err := loadBalancerLogic.UpdateLoadBalancerHealthCheck("lb_id", healthCheck)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	testutils.AssertEqual(t, received.HealthCheck, healthCheck)
 }

--- a/api/logic/mock_logic/mock_deploy_logic.go
+++ b/api/logic/mock_logic/mock_deploy_logic.go
@@ -4,8 +4,8 @@
 package mock_logic
 
 import (
-	gomock "github.com/golang/mock/gomock"
 	models "github.com/quintilesims/layer0/common/models"
+	gomock "github.com/golang/mock/gomock"
 )
 
 // Mock of DeployLogic interface

--- a/api/logic/mock_logic/mock_environment_logic.go
+++ b/api/logic/mock_logic/mock_environment_logic.go
@@ -4,8 +4,8 @@
 package mock_logic
 
 import (
-	gomock "github.com/golang/mock/gomock"
 	models "github.com/quintilesims/layer0/common/models"
+	gomock "github.com/golang/mock/gomock"
 )
 
 // Mock of EnvironmentLogic interface

--- a/api/logic/mock_logic/mock_job_logic.go
+++ b/api/logic/mock_logic/mock_job_logic.go
@@ -4,8 +4,8 @@
 package mock_logic
 
 import (
-	gomock "github.com/golang/mock/gomock"
 	models "github.com/quintilesims/layer0/common/models"
+	gomock "github.com/golang/mock/gomock"
 	types "github.com/quintilesims/layer0/common/types"
 )
 

--- a/api/logic/mock_logic/mock_load_balancer_logic.go
+++ b/api/logic/mock_logic/mock_load_balancer_logic.go
@@ -4,8 +4,8 @@
 package mock_logic
 
 import (
-	gomock "github.com/golang/mock/gomock"
 	models "github.com/quintilesims/layer0/common/models"
+	gomock "github.com/golang/mock/gomock"
 )
 
 // Mock of LoadBalancerLogic interface
@@ -72,13 +72,24 @@ func (_mr *_MockLoadBalancerLogicRecorder) ListLoadBalancers() *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "ListLoadBalancers")
 }
 
-func (_m *MockLoadBalancerLogic) UpdateLoadBalancer(_param0 string, _param1 []models.Port) (*models.LoadBalancer, error) {
-	ret := _m.ctrl.Call(_m, "UpdateLoadBalancer", _param0, _param1)
+func (_m *MockLoadBalancerLogic) UpdateLoadBalancerHealthCheck(_param0 string, _param1 models.HealthCheck) (*models.LoadBalancer, error) {
+	ret := _m.ctrl.Call(_m, "UpdateLoadBalancerHealthCheck", _param0, _param1)
 	ret0, _ := ret[0].(*models.LoadBalancer)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockLoadBalancerLogicRecorder) UpdateLoadBalancer(arg0, arg1 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "UpdateLoadBalancer", arg0, arg1)
+func (_mr *_MockLoadBalancerLogicRecorder) UpdateLoadBalancerHealthCheck(arg0, arg1 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "UpdateLoadBalancerHealthCheck", arg0, arg1)
+}
+
+func (_m *MockLoadBalancerLogic) UpdateLoadBalancerPorts(_param0 string, _param1 []models.Port) (*models.LoadBalancer, error) {
+	ret := _m.ctrl.Call(_m, "UpdateLoadBalancerPorts", _param0, _param1)
+	ret0, _ := ret[0].(*models.LoadBalancer)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+func (_mr *_MockLoadBalancerLogicRecorder) UpdateLoadBalancerPorts(arg0, arg1 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "UpdateLoadBalancerPorts", arg0, arg1)
 }

--- a/api/logic/mock_logic/mock_service_logic.go
+++ b/api/logic/mock_logic/mock_service_logic.go
@@ -4,8 +4,8 @@
 package mock_logic
 
 import (
-	gomock "github.com/golang/mock/gomock"
 	models "github.com/quintilesims/layer0/common/models"
+	gomock "github.com/golang/mock/gomock"
 )
 
 // Mock of ServiceLogic interface

--- a/api/logic/mock_logic/mock_task_logic.go
+++ b/api/logic/mock_logic/mock_task_logic.go
@@ -4,8 +4,8 @@
 package mock_logic
 
 import (
-	gomock "github.com/golang/mock/gomock"
 	models "github.com/quintilesims/layer0/common/models"
+	gomock "github.com/golang/mock/gomock"
 )
 
 // Mock of TaskLogic interface

--- a/cli/client/interface.go
+++ b/cli/client/interface.go
@@ -22,11 +22,12 @@ type Client interface {
 	ListJobs() ([]*models.Job, error)
 	WaitForJob(jobID string, timeout time.Duration) error
 
-	CreateLoadBalancer(name, environmentID string, ports []models.Port, isPublic bool) (*models.LoadBalancer, error)
+	CreateLoadBalancer(name, environmentID string, healthCheck models.HealthCheck, ports []models.Port, isPublic bool) (*models.LoadBalancer, error)
 	DeleteLoadBalancer(id string) (string, error)
 	GetLoadBalancer(id string) (*models.LoadBalancer, error)
 	ListLoadBalancers() ([]*models.LoadBalancerSummary, error)
-	UpdateLoadBalancer(id string, ports []models.Port) (*models.LoadBalancer, error)
+	UpdateLoadBalancerHealthCheck(id string, healthCheck models.HealthCheck) (*models.LoadBalancer, error)
+	UpdateLoadBalancerPorts(id string, ports []models.Port) (*models.LoadBalancer, error)
 
 	CreateService(name, environmentID, deployID, loadBalancerID string) (*models.Service, error)
 	DeleteService(id string) (string, error)

--- a/cli/client/load_balancer.go
+++ b/cli/client/load_balancer.go
@@ -4,10 +4,11 @@ import (
 	"github.com/quintilesims/layer0/common/models"
 )
 
-func (c *APIClient) CreateLoadBalancer(name, environmentID string, ports []models.Port, isPublic bool) (*models.LoadBalancer, error) {
+func (c *APIClient) CreateLoadBalancer(name, environmentID string, healthCheck models.HealthCheck, ports []models.Port, isPublic bool) (*models.LoadBalancer, error) {
 	req := models.CreateLoadBalancerRequest{
 		LoadBalancerName: name,
 		EnvironmentID:    environmentID,
+		HealthCheck:      healthCheck,
 		Ports:            ports,
 		IsPublic:         isPublic,
 	}
@@ -47,8 +48,21 @@ func (c *APIClient) ListLoadBalancers() ([]*models.LoadBalancerSummary, error) {
 	return loadBalancers, nil
 }
 
-func (c *APIClient) UpdateLoadBalancer(id string, ports []models.Port) (*models.LoadBalancer, error) {
-	req := models.UpdateLoadBalancerRequest{
+func (c *APIClient) UpdateLoadBalancerHealthCheck(id string, healthCheck models.HealthCheck) (*models.LoadBalancer, error) {
+	req := models.UpdateLoadBalancerHealthCheckRequest{
+		HealthCheck: healthCheck,
+	}
+
+	var loadBalancer *models.LoadBalancer
+	if err := c.Execute(c.Sling("loadbalancer/").Put(id+"/healthcheck").BodyJSON(req), &loadBalancer); err != nil {
+		return nil, err
+	}
+
+	return loadBalancer, nil
+}
+
+func (c *APIClient) UpdateLoadBalancerPorts(id string, ports []models.Port) (*models.LoadBalancer, error) {
+	req := models.UpdateLoadBalancerPortsRequest{
 		Ports: ports,
 	}
 

--- a/cli/client/load_balancer_test.go
+++ b/cli/client/load_balancer_test.go
@@ -8,6 +8,14 @@ import (
 )
 
 func TestCreateLoadBalancer(t *testing.T) {
+	healthCheck := models.HealthCheck{
+		Target:             "TCP:80",
+		Interval:           30,
+		Timeout:            5,
+		HealthyThreshold:   10,
+		UnhealthyThreshold: 2,
+	}
+
 	ports := []models.Port{
 		{
 			HostPort:        443,
@@ -33,6 +41,7 @@ func TestCreateLoadBalancer(t *testing.T) {
 		testutils.AssertEqual(t, req.LoadBalancerName, "name")
 		testutils.AssertEqual(t, req.EnvironmentID, "environmentID")
 		testutils.AssertEqual(t, req.IsPublic, true)
+		testutils.AssertEqual(t, req.HealthCheck, healthCheck)
 		testutils.AssertEqual(t, req.Ports, ports)
 
 		MarshalAndWrite(t, w, models.LoadBalancer{LoadBalancerID: "id"}, 200)
@@ -41,7 +50,7 @@ func TestCreateLoadBalancer(t *testing.T) {
 	client, server := newClientAndServer(handler)
 	defer server.Close()
 
-	loadBalancer, err := client.CreateLoadBalancer("name", "environmentID", ports, true)
+	loadBalancer, err := client.CreateLoadBalancer("name", "environmentID", healthCheck, ports, true)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -118,7 +127,39 @@ func TestListLoadBalancers(t *testing.T) {
 	testutils.AssertEqual(t, loadBalancers[1].LoadBalancerID, "id2")
 }
 
-func TestUpdateLoadBalancer(t *testing.T) {
+func TestUpdateLoadBalancerHealthCheck(t *testing.T) {
+	healthCheck := models.HealthCheck{
+		Target:             "TCP:80",
+		Interval:           30,
+		Timeout:            5,
+		HealthyThreshold:   10,
+		UnhealthyThreshold: 2,
+	}
+
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		testutils.AssertEqual(t, r.Method, "PUT")
+		testutils.AssertEqual(t, r.URL.Path, "/loadbalancer/id/healthcheck")
+
+		var req models.UpdateLoadBalancerHealthCheckRequest
+		Unmarshal(t, r, &req)
+
+		testutils.AssertEqual(t, req.HealthCheck, healthCheck)
+
+		MarshalAndWrite(t, w, models.LoadBalancer{LoadBalancerID: "id"}, 200)
+	}
+
+	client, server := newClientAndServer(handler)
+	defer server.Close()
+
+	loadBalancer, err := client.UpdateLoadBalancerHealthCheck("id", healthCheck)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	testutils.AssertEqual(t, loadBalancer.LoadBalancerID, "id")
+}
+
+func TestUpdateLoadBalancerPorts(t *testing.T) {
 	ports := []models.Port{
 		{
 			HostPort:        443,
@@ -138,7 +179,7 @@ func TestUpdateLoadBalancer(t *testing.T) {
 		testutils.AssertEqual(t, r.Method, "PUT")
 		testutils.AssertEqual(t, r.URL.Path, "/loadbalancer/id/ports")
 
-		var req models.UpdateLoadBalancerRequest
+		var req models.UpdateLoadBalancerPortsRequest
 		Unmarshal(t, r, &req)
 
 		testutils.AssertEqual(t, req.Ports, ports)
@@ -149,7 +190,7 @@ func TestUpdateLoadBalancer(t *testing.T) {
 	client, server := newClientAndServer(handler)
 	defer server.Close()
 
-	loadBalancer, err := client.UpdateLoadBalancer("id", ports)
+	loadBalancer, err := client.UpdateLoadBalancerPorts("id", ports)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/cli/client/mock_client/mock_client.go
+++ b/cli/client/mock_client/mock_client.go
@@ -4,9 +4,9 @@
 package mock_client
 
 import (
-	gomock "github.com/golang/mock/gomock"
 	models "github.com/quintilesims/layer0/common/models"
 	time "time"
+	gomock "github.com/golang/mock/gomock"
 )
 
 // Mock of Client interface
@@ -52,15 +52,15 @@ func (_mr *_MockClientRecorder) CreateEnvironment(arg0, arg1, arg2, arg3 interfa
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "CreateEnvironment", arg0, arg1, arg2, arg3)
 }
 
-func (_m *MockClient) CreateLoadBalancer(_param0 string, _param1 string, _param2 []models.Port, _param3 bool) (*models.LoadBalancer, error) {
-	ret := _m.ctrl.Call(_m, "CreateLoadBalancer", _param0, _param1, _param2, _param3)
+func (_m *MockClient) CreateLoadBalancer(_param0 string, _param1 string, _param2 models.HealthCheck, _param3 []models.Port, _param4 bool) (*models.LoadBalancer, error) {
+	ret := _m.ctrl.Call(_m, "CreateLoadBalancer", _param0, _param1, _param2, _param3, _param4)
 	ret0, _ := ret[0].(*models.LoadBalancer)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockClientRecorder) CreateLoadBalancer(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "CreateLoadBalancer", arg0, arg1, arg2, arg3)
+func (_mr *_MockClientRecorder) CreateLoadBalancer(arg0, arg1, arg2, arg3, arg4 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "CreateLoadBalancer", arg0, arg1, arg2, arg3, arg4)
 }
 
 func (_m *MockClient) CreateService(_param0 string, _param1 string, _param2 string, _param3 string) (*models.Service, error) {
@@ -357,15 +357,26 @@ func (_mr *_MockClientRecorder) UpdateEnvironment(arg0, arg1 interface{}) *gomoc
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "UpdateEnvironment", arg0, arg1)
 }
 
-func (_m *MockClient) UpdateLoadBalancer(_param0 string, _param1 []models.Port) (*models.LoadBalancer, error) {
-	ret := _m.ctrl.Call(_m, "UpdateLoadBalancer", _param0, _param1)
+func (_m *MockClient) UpdateLoadBalancerHealthCheck(_param0 string, _param1 models.HealthCheck) (*models.LoadBalancer, error) {
+	ret := _m.ctrl.Call(_m, "UpdateLoadBalancerHealthCheck", _param0, _param1)
 	ret0, _ := ret[0].(*models.LoadBalancer)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockClientRecorder) UpdateLoadBalancer(arg0, arg1 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "UpdateLoadBalancer", arg0, arg1)
+func (_mr *_MockClientRecorder) UpdateLoadBalancerHealthCheck(arg0, arg1 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "UpdateLoadBalancerHealthCheck", arg0, arg1)
+}
+
+func (_m *MockClient) UpdateLoadBalancerPorts(_param0 string, _param1 []models.Port) (*models.LoadBalancer, error) {
+	ret := _m.ctrl.Call(_m, "UpdateLoadBalancerPorts", _param0, _param1)
+	ret0, _ := ret[0].(*models.LoadBalancer)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+func (_mr *_MockClientRecorder) UpdateLoadBalancerPorts(arg0, arg1 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "UpdateLoadBalancerPorts", arg0, arg1)
 }
 
 func (_m *MockClient) UpdateSQL() error {

--- a/cli/command/load_balancer_command.go
+++ b/cli/command/load_balancer_command.go
@@ -51,6 +51,31 @@ func (l *LoadBalancerCommand) GetCommand() cli.Command {
 						Name:  "private",
 						Usage: "if specified, creates a private load balancer (default is public)",
 					},
+					cli.StringFlag{
+						Name:  "healthcheck-target",
+						Value: "TCP:80",
+						Usage: "health check target in format 'PROTOCOL:PORT' or 'PROTOCOL:PORT/WITH/PATH'",
+					},
+					cli.IntFlag{
+						Name:  "healthcheck-interval",
+						Value: 30,
+						Usage: "health check interval in seconds",
+					},
+					cli.IntFlag{
+						Name:  "healthcheck-timeout",
+						Value: 5,
+						Usage: "health check timeout in seconds",
+					},
+					cli.IntFlag{
+						Name:  "healthcheck-healthy-threshold",
+						Value: 2,
+						Usage: "number of consecutive successes required to count as healthy",
+					},
+					cli.IntFlag{
+						Name:  "healthcheck-unhealthy-threshold",
+						Value: 2,
+						Usage: "number of consecutive failures required to count as unhealthy",
+					},
 				},
 			},
 			{
@@ -76,6 +101,34 @@ func (l *LoadBalancerCommand) GetCommand() cli.Command {
 				Usage:     "describe a load balancer",
 				Action:    wrapAction(l.Command, l.Get),
 				ArgsUsage: "NAME",
+			},
+			{
+				Name:      "healthcheck",
+				Usage:     "view or update the health check for a load balancer",
+				Action:    wrapAction(l.Command, l.HealthCheck),
+				ArgsUsage: "NAME",
+				Flags: []cli.Flag{
+					cli.StringFlag{
+						Name:  "set-target",
+						Usage: "health check target in format 'PROTOCOL:PORT' or 'PROTOCOL:PORT/WITH/PATH'",
+					},
+					cli.StringFlag{
+						Name:  "set-interval",
+						Usage: "health check interval in seconds",
+					},
+					cli.StringFlag{
+						Name:  "set-timeout",
+						Usage: "health check timeout in seconds",
+					},
+					cli.StringFlag{
+						Name:  "set-healthy-threshold",
+						Usage: "number of consecutive successes required to count as healthy",
+					},
+					cli.StringFlag{
+						Name:  "set-unhealthy-threshold",
+						Usage: "number of consecutive failures required to count as unhealthy",
+					},
+				},
 			},
 			{
 				Name:      "list",
@@ -109,7 +162,7 @@ func (l *LoadBalancerCommand) AddPort(c *cli.Context) error {
 	}
 
 	loadBalancer.Ports = append(loadBalancer.Ports, *port)
-	loadBalancer, err = l.Client.UpdateLoadBalancer(id, loadBalancer.Ports)
+	loadBalancer, err = l.Client.UpdateLoadBalancerPorts(id, loadBalancer.Ports)
 	if err != nil {
 		return err
 	}
@@ -143,12 +196,20 @@ func (l *LoadBalancerCommand) Create(c *cli.Context) error {
 		ports = append(ports, port)
 	}
 
+	healthCheck := models.HealthCheck{
+		Target:             c.String("healthcheck-target"),
+		Interval:           c.Int("healthcheck-interval"),
+		Timeout:            c.Int("healthcheck-timeout"),
+		HealthyThreshold:   c.Int("healthcheck-healthy-threshold"),
+		UnhealthyThreshold: c.Int("healthcheck-unhealthy-threshold"),
+	}
+
 	environmentID, err := l.resolveSingleID("environment", args["ENVIRONMENT"])
 	if err != nil {
 		return err
 	}
 
-	loadBalancer, err := l.Client.CreateLoadBalancer(args["NAME"], environmentID, ports, !c.Bool("private"))
+	loadBalancer, err := l.Client.CreateLoadBalancer(args["NAME"], environmentID, healthCheck, ports, !c.Bool("private"))
 	if err != nil {
 		return err
 	}
@@ -193,13 +254,12 @@ func (l *LoadBalancerCommand) DropPort(c *cli.Context) error {
 		return fmt.Errorf("Host port '%v' doesn't exist on this Load Balancer", port)
 	}
 
-	loadBalancer, err = l.Client.UpdateLoadBalancer(id, loadBalancer.Ports)
+	loadBalancer, err = l.Client.UpdateLoadBalancerPorts(id, loadBalancer.Ports)
 	if err != nil {
 		return err
 	}
 
 	return l.Printer.PrintLoadBalancers(loadBalancer)
-
 }
 
 func (l *LoadBalancerCommand) Get(c *cli.Context) error {
@@ -219,6 +279,100 @@ func (l *LoadBalancerCommand) Get(c *cli.Context) error {
 	}
 
 	return l.Printer.PrintLoadBalancers(loadBalancers...)
+}
+
+func (l *LoadBalancerCommand) HealthCheck(c *cli.Context) error {
+	args, err := extractArgs(c.Args(), "NAME")
+	if err != nil {
+		return err
+	}
+
+	updateIsRequired := false
+	healthCheck := models.HealthCheck{}
+
+	if target := c.String("set-target"); target != "" {
+		updateIsRequired = true
+		healthCheck.Target = target
+	}
+
+	if interval := c.String("set-interval"); interval != "" {
+		i, err := strconv.Atoi(interval)
+		if err != nil {
+			return err
+		}
+
+		updateIsRequired = true
+		healthCheck.Interval = i
+	}
+
+	if timeout := c.String("set-timeout"); timeout != "" {
+		t, err := strconv.Atoi(timeout)
+		if err != nil {
+			return err
+		}
+
+		updateIsRequired = true
+		healthCheck.Timeout = t
+	}
+
+	if healthyThreshold := c.String("set-healthy-threshold"); healthyThreshold != "" {
+		h, err := strconv.Atoi(healthyThreshold)
+		if err != nil {
+			return err
+		}
+
+		updateIsRequired = true
+		healthCheck.HealthyThreshold = h
+	}
+
+	if unhealthyThreshold := c.String("set-unhealthy-threshold"); unhealthyThreshold != "" {
+		u, err := strconv.Atoi(unhealthyThreshold)
+		if err != nil {
+			return err
+		}
+
+		updateIsRequired = true
+		healthCheck.UnhealthyThreshold = u
+	}
+
+	id, err := l.resolveSingleID("load_balancer", args["NAME"])
+	if err != nil {
+		return err
+	}
+
+	loadBalancer, err := l.Client.GetLoadBalancer(id)
+	if err != nil {
+		return err
+	}
+
+	if updateIsRequired {
+		if healthCheck.Target != "" {
+			loadBalancer.HealthCheck.Target = healthCheck.Target
+		}
+
+		if healthCheck.Interval != 0 {
+			loadBalancer.HealthCheck.Interval = healthCheck.Interval
+		}
+
+		if healthCheck.Timeout != 0 {
+			loadBalancer.HealthCheck.Timeout = healthCheck.Timeout
+		}
+
+		if healthCheck.HealthyThreshold != 0 {
+			loadBalancer.HealthCheck.HealthyThreshold = healthCheck.HealthyThreshold
+		}
+
+		if healthCheck.UnhealthyThreshold != 0 {
+			loadBalancer.HealthCheck.UnhealthyThreshold = healthCheck.UnhealthyThreshold
+		}
+
+		loadBalancer, err = l.Client.UpdateLoadBalancerHealthCheck(id, loadBalancer.HealthCheck)
+		if err != nil {
+			return err
+		}
+	}
+
+	return l.Printer.PrintLoadBalancerHealthCheck(loadBalancer)
 }
 
 func (l *LoadBalancerCommand) List(c *cli.Context) error {

--- a/cli/printer/interface.go
+++ b/cli/printer/interface.go
@@ -14,6 +14,7 @@ type Printer interface {
 	PrintJobs(jobs ...*models.Job) error
 	PrintLoadBalancers(loadBalancers ...*models.LoadBalancer) error
 	PrintLoadBalancerSummaries(loadBalancers ...*models.LoadBalancerSummary) error
+	PrintLoadBalancerHealthCheck(loadBalancer *models.LoadBalancer) error
 	PrintLogs(logs ...*models.LogFile) error
 	PrintServices(services ...*models.Service) error
 	PrintServiceSummaries(services ...*models.ServiceSummary) error

--- a/cli/printer/json.go
+++ b/cli/printer/json.go
@@ -78,6 +78,10 @@ func (j *JSONPrinter) PrintLoadBalancerSummaries(loadBalancers ...*models.LoadBa
 	return j.print(loadBalancers)
 }
 
+func (j *JSONPrinter) PrintLoadBalancerHealthCheck(loadBalancer *models.LoadBalancer) error {
+	return j.print(loadBalancer)
+}
+
 func (j *JSONPrinter) PrintLogs(logs ...*models.LogFile) error {
 	return j.print(logs)
 }

--- a/cli/printer/test.go
+++ b/cli/printer/test.go
@@ -1,7 +1,7 @@
 package printer
 
 import (
-	"github.com/quintilesims/layer0/common/models"
+    "github.com/quintilesims/layer0/common/models"
 )
 
 // we use a TestPrinter instead of a mock because gomock doesn't support
@@ -19,8 +19,9 @@ func (t *TestPrinter) PrintEnvironmentSummaries(...*models.EnvironmentSummary) e
 func (t *TestPrinter) PrintJobs(...*models.Job) error                                  { return nil }
 func (t *TestPrinter) PrintLoadBalancers(...*models.LoadBalancer) error                { return nil }
 func (t *TestPrinter) PrintLoadBalancerSummaries(...*models.LoadBalancerSummary) error { return nil }
+func (t *TestPrinter) PrintLoadBalancerHealthCheck(*models.LoadBalancer) error         { return nil }
 func (t *TestPrinter) PrintLogs(...*models.LogFile) error                              { return nil }
 func (t *TestPrinter) PrintServices(...*models.Service) error                          { return nil }
 func (t *TestPrinter) PrintServiceSummaries(...*models.ServiceSummary) error           { return nil }
 func (t *TestPrinter) PrintTasks(...*models.Task) error                                { return nil }
-func (t *TestPrinter) PrintTaskSummaries(...*models.TaskSummary) error     { return nil }
+func (t *TestPrinter) PrintTaskSummaries(...*models.TaskSummary) error                 { return nil }

--- a/cli/printer/text.go
+++ b/cli/printer/text.go
@@ -194,6 +194,32 @@ func (t *TextPrinter) PrintLoadBalancerSummaries(loadBalancers ...*models.LoadBa
 	return nil
 }
 
+func (t *TextPrinter) PrintLoadBalancerHealthCheck(loadBalancer *models.LoadBalancer) error {
+	getEnvironment := func(l *models.LoadBalancer) string {
+		if l.EnvironmentName != "" {
+			return l.EnvironmentName
+		}
+
+		return l.EnvironmentID
+	}
+
+	rows := []string{"LOADBALANCER ID | LOADBALANCER NAME | ENVIRONMENT | TARGET | INTERVAL | TIMEOUT | HEALTHY THRESHOLD | UNHEALTHY THRESHOLD "}
+	row := fmt.Sprintf("%s | %s | %s | %s | %d | %d | %d | %d",
+		loadBalancer.LoadBalancerID,
+		loadBalancer.LoadBalancerName,
+		getEnvironment(loadBalancer),
+		loadBalancer.HealthCheck.Target,
+		loadBalancer.HealthCheck.Interval,
+		loadBalancer.HealthCheck.Timeout,
+		loadBalancer.HealthCheck.HealthyThreshold,
+		loadBalancer.HealthCheck.UnhealthyThreshold)
+
+	rows = append(rows, row)
+
+	fmt.Println(columnize.SimpleFormat(rows))
+	return nil
+}
+
 func (t *TextPrinter) PrintLogs(logs ...*models.LogFile) error {
 	for _, l := range logs {
 		fmt.Println(l.Name)

--- a/common/aws/autoscaling/autoscaling_provider_decorator.go
+++ b/common/aws/autoscaling/autoscaling_provider_decorator.go
@@ -125,3 +125,4 @@ func (this *ProviderDecorator) TerminateInstanceInAutoScalingGroup(p0 string, p1
 	err = this.Decorator("TerminateInstanceInAutoScalingGroup", call)
 	return v0, err
 }
+

--- a/common/aws/autoscaling/mock_autoscaling/mock_autoscaling.go
+++ b/common/aws/autoscaling/mock_autoscaling/mock_autoscaling.go
@@ -4,8 +4,8 @@
 package mock_autoscaling
 
 import (
-	gomock "github.com/golang/mock/gomock"
 	autoscaling "github.com/quintilesims/layer0/common/aws/autoscaling"
+	gomock "github.com/golang/mock/gomock"
 )
 
 // Mock of Provider interface

--- a/common/aws/cloudwatchlogs/cloudwatchlogs_provider_decorator.go
+++ b/common/aws/cloudwatchlogs/cloudwatchlogs_provider_decorator.go
@@ -62,3 +62,4 @@ func (this *ProviderDecorator) FilterLogEvents(p0 *string, p1 *string, p2 *strin
 	err = this.Decorator("FilterLogEvents", call)
 	return v0, v1, err
 }
+

--- a/common/aws/cloudwatchlogs/mock_cloudwatchlogs/mock_cloudwatchlogs.go
+++ b/common/aws/cloudwatchlogs/mock_cloudwatchlogs/mock_cloudwatchlogs.go
@@ -4,8 +4,8 @@
 package mock_cloudwatchlogs
 
 import (
-	gomock "github.com/golang/mock/gomock"
 	cloudwatchlogs "github.com/quintilesims/layer0/common/aws/cloudwatchlogs"
+	gomock "github.com/golang/mock/gomock"
 )
 
 // Mock of Provider interface

--- a/common/aws/ec2/ec2_provider_decorator.go
+++ b/common/aws/ec2/ec2_provider_decorator.go
@@ -125,3 +125,4 @@ func (this *ProviderDecorator) DescribeVPCRoutes(p0 string) (v0 []*RouteTable, e
 	err = this.Decorator("DescribeVPCRoutes", call)
 	return v0, err
 }
+

--- a/common/aws/ecs/ecs_provider_decorator.go
+++ b/common/aws/ecs/ecs_provider_decorator.go
@@ -269,3 +269,4 @@ func (this *ProviderDecorator) UpdateService(p0 string, p1 string, p2 *string, p
 	err = this.Decorator("UpdateService", call)
 	return err
 }
+

--- a/common/aws/elb/elb.go
+++ b/common/aws/elb/elb.go
@@ -24,10 +24,6 @@ type Listener struct {
 	*elb.Listener
 }
 
-type HealthCheck struct {
-	*elb.HealthCheck
-}
-
 type ListenerDescription struct {
 	*elb.ListenerDescription
 }
@@ -38,6 +34,10 @@ func NewListenerDescription(listener *Listener) *ListenerDescription {
 			Listener: listener.Listener,
 		},
 	}
+}
+
+type HealthCheck struct {
+	*elb.HealthCheck
 }
 
 type LoadBalancerDescription struct {
@@ -56,6 +56,13 @@ func NewLoadBalancerDescription(name, scheme string, listeners []*Listener) *Loa
 			DNSName:              aws.String(name),
 			Scheme:               aws.String(scheme),
 			ListenerDescriptions: listenerDescriptions,
+			HealthCheck: &elb.HealthCheck{
+				Target:             aws.String("TCP:80"),
+				Interval:           aws.Int64(30),
+				Timeout:            aws.Int64(5),
+				HealthyThreshold:   aws.Int64(2),
+				UnhealthyThreshold: aws.Int64(2),
+			},
 		},
 	}
 }
@@ -66,18 +73,6 @@ type InstanceState struct {
 
 func NewInstanceState() *InstanceState {
 	return &InstanceState{&elb.InstanceState{}}
-}
-
-func NewHealthCheck(target string, healthyThresh, unhealthyThresh, interval, timeout int64) *HealthCheck {
-	return &HealthCheck{
-		&elb.HealthCheck{
-			Target:             aws.String(target),
-			Interval:           aws.Int64(interval),
-			Timeout:            aws.Int64(timeout),
-			UnhealthyThreshold: aws.Int64(unhealthyThresh),
-			HealthyThreshold:   aws.Int64(healthyThresh),
-		},
-	}
 }
 
 func NewListener(instancePort int64, instanceProtocol string, lbPort int64, lbProtocol, certificate string) *Listener {
@@ -95,6 +90,18 @@ func NewListener(instancePort int64, instanceProtocol string, lbPort int64, lbPr
 	}
 
 	return listener
+}
+
+func NewHealthCheck(target string, interval, timeout, healthyThresh, unhealthyThresh int64) *HealthCheck {
+	return &HealthCheck{
+		&elb.HealthCheck{
+			Target:             aws.String(target),
+			Interval:           aws.Int64(interval),
+			Timeout:            aws.Int64(timeout),
+			UnhealthyThreshold: aws.Int64(unhealthyThresh),
+			HealthyThreshold:   aws.Int64(healthyThresh),
+		},
+	}
 }
 
 type Tag struct {

--- a/common/aws/elb/elb_provider_decorator.go
+++ b/common/aws/elb/elb_provider_decorator.go
@@ -98,3 +98,4 @@ func (this *ProviderDecorator) DeleteLoadBalancerListeners(p0 string, p1 []*List
 	err = this.Decorator("DeleteLoadBalancerListeners", call)
 	return err
 }
+

--- a/common/aws/iam/mock_iam/mock_iam.go
+++ b/common/aws/iam/mock_iam/mock_iam.go
@@ -4,8 +4,8 @@
 package mock_iam
 
 import (
-	gomock "github.com/golang/mock/gomock"
 	iam "github.com/quintilesims/layer0/common/aws/iam"
+	gomock "github.com/golang/mock/gomock"
 )
 
 // Mock of Provider interface

--- a/common/aws/s3/mock_s3/mock_s3.go
+++ b/common/aws/s3/mock_s3/mock_s3.go
@@ -4,8 +4,8 @@
 package mock_s3
 
 import (
-	gomock "github.com/golang/mock/gomock"
 	os "os"
+	gomock "github.com/golang/mock/gomock"
 )
 
 // Mock of Provider interface

--- a/common/db/job_store/mock_job_store/mock_job_store.go
+++ b/common/db/job_store/mock_job_store/mock_job_store.go
@@ -4,9 +4,9 @@
 package mock_job_store
 
 import (
-	gomock "github.com/golang/mock/gomock"
 	models "github.com/quintilesims/layer0/common/models"
 	types "github.com/quintilesims/layer0/common/types"
+	gomock "github.com/golang/mock/gomock"
 )
 
 // Mock of JobStore interface

--- a/common/models/create_load_balancer_request.go
+++ b/common/models/create_load_balancer_request.go
@@ -1,8 +1,9 @@
 package models
 
 type CreateLoadBalancerRequest struct {
-	LoadBalancerName string `json:"load_balancer_name"`
-	EnvironmentID    string `json:"environment_id"`
-	IsPublic         bool   `json:"is_public"`
-	Ports            []Port `json:"ports"`
+    LoadBalancerName string      `json:"load_balancer_name"`
+    EnvironmentID    string      `json:"environment_id"`
+    IsPublic         bool        `json:"is_public"`
+    Ports            []Port      `json:"ports"`
+    HealthCheck      HealthCheck `json:"health_check"`
 }

--- a/common/models/health_check.go
+++ b/common/models/health_check.go
@@ -1,0 +1,9 @@
+package models
+
+type HealthCheck struct {
+    Target             string `json:"target"`
+    Interval           int    `json:"interval"`
+    Timeout            int    `json:"timeout"`
+    HealthyThreshold   int    `json:"healthy_threshold"`
+    UnhealthyThreshold int    `json:"unhealthy_threshold"`
+}

--- a/common/models/load_balancer.go
+++ b/common/models/load_balancer.go
@@ -1,13 +1,14 @@
 package models
 
 type LoadBalancer struct {
-	EnvironmentID    string `json:"environment_id"`
-	EnvironmentName  string `json:"environment_name"`
-	IsPublic         bool   `json:"is_public"`
-	LoadBalancerID   string `json:"load_balancer_id"`
-	LoadBalancerName string `json:"load_balancer_name"`
-	Ports            []Port `json:"ports"`
-	ServiceID        string `json:"service_id"`
-	ServiceName      string `json:"service_name"`
-	URL              string `json:"url"`
+    EnvironmentID    string      `json:"environment_id"`
+    EnvironmentName  string      `json:"environment_name"`
+    HealthCheck      HealthCheck `json:"health_check"`
+    IsPublic         bool        `json:"is_public"`
+    LoadBalancerID   string      `json:"load_balancer_id"`
+    LoadBalancerName string      `json:"load_balancer_name"`
+    Ports            []Port      `json:"ports"`
+    ServiceID        string      `json:"service_id"`
+    ServiceName      string      `json:"service_name"`
+    URL              string      `json:"url"`
 }

--- a/common/models/update_load_balancer_health_check_request.go
+++ b/common/models/update_load_balancer_health_check_request.go
@@ -1,0 +1,5 @@
+package models
+
+type UpdateLoadBalancerHealthCheckRequest struct {
+    HealthCheck HealthCheck `json:"health_check"`
+}

--- a/common/models/update_load_balancer_ports_request.go
+++ b/common/models/update_load_balancer_ports_request.go
@@ -1,0 +1,5 @@
+package models
+
+type UpdateLoadBalancerPortsRequest struct {
+    Ports []Port `json:"ports"`
+}

--- a/common/models/update_load_balancer_request.go
+++ b/common/models/update_load_balancer_request.go
@@ -1,5 +1,0 @@
-package models
-
-type UpdateLoadBalancerRequest struct {
-	Ports []Port `json:"ports"`
-}

--- a/scripts/flow.sh
+++ b/scripts/flow.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/local/bin/bash
 
 set -e
 
@@ -64,7 +64,7 @@ delete() {
     job_ids=$(l0 -o json job list | jq -r .[].job_id)
     for id in $job_ids; do
         l0 job delete $id
-        echo -e $BULLET "$id" 
+        echo -e $BULLET "$id"
     done
 }
 
@@ -80,7 +80,7 @@ run_jobs() {
             jobs[$!]=$id
         done
 
-        for pid in ${!jobs[@]}; do 
+        for pid in ${!jobs[@]}; do
             wait $pid
             echo -e $BULLET ${jobs[$pid]}
         done

--- a/tests/smoke/load_balancer.bats
+++ b/tests/smoke/load_balancer.bats
@@ -50,24 +50,40 @@ certificate_name="l0-$LAYER0_PREFIX-api"
     l0 loadbalancer delete --wait loadbalancer2
 }
 
-@test "loadbalancer create --port 80:80/http test loadbalancer3" {
-    l0 loadbalancer create --port 80:80/http test loadbalancer3
+@test "loadbalancer create --healthcheck-target TCP:80 --healthcheck-interval 30 --healthcheck-timeout 5 --healthcheck-healthy-threshold 2 --healthcheck-unhealthy-threshold 2 loadbalancer3" {
+    l0 loadbalancer create --healthcheck-target TCP:80 --healthcheck-interval 30 --healthcheck-timeout 5 --healthcheck-healthy-threshold 2 --healthcheck-unhealthy-threshold 2 test loadbalancer3
+}
+
+@test "loadbalancer healthcheck loadbalancer3" {
+    l0 loadbalancer healthcheck loadbalancer3
+}
+
+@test "loadbalancer healthcheck --set-target TCP:88 --set-interval 45 --set-timeout 10 --set-healthy-threshold 5 --set-unhealthy-threshold 3 loadbalancer3" {
+    l0 loadbalancer healthcheck --set-target TCP:88 --set-interval 45 --set-timeout 10 --set-healthy-threshold 5 --set-unhealthy-threshold 3 loadbalancer3
+}
+
+@test "loadbalancer delete --wait loadbalancer3" {
+    l0 loadbalancer delete --wait loadbalancer3
+}
+
+@test "loadbalancer create --port 80:80/http test loadbalancer4" {
+    l0 loadbalancer create --port 80:80/http test loadbalancer4
 }
 
 @test "deploy create guestbook" {
     l0 deploy create ./common/Dockerrun.aws.json guestbook
 }
 
-@test "service create --loadbalancer loadbalancer3 test service1 guestbook" {
-    l0 service create --loadbalancer loadbalancer3 test service1 guestbook
+@test "service create --loadbalancer loadbalancer4 test service1 guestbook" {
+    l0 service create --loadbalancer loadbalancer4 test service1 guestbook
 }
 
 @test "loadbalancer list" {
     l0 loadbalancer list
 }
 
-@test "loadbalancer get loadbalancer3" {
-    l0 loadbalancer get loadbalancer3
+@test "loadbalancer get loadbalancer4" {
+    l0 loadbalancer get loadbalancer4
 }
 
 @test "deploy delete guestbook" {
@@ -76,10 +92,5 @@ certificate_name="l0-$LAYER0_PREFIX-api"
 
 # this deletes the remaining service(s) and loadbalancer(s)
 @test "environment delete --wait test" {
-    l0 environment delete --wait test 
-}
-
-@test "certificate delete certificate1" {
-    delete_cert
-    l0 certificate delete certificate1
+    l0 environment delete --wait test
 }


### PR DESCRIPTION
There are a few things that still need working out, but here's the feature. I'm sure there are things that could be shored up and embetterified.

Still needs to pull in latest from `develop`.

The terraform aspect still needs to happen.

Running into an error when running smoketests: creating a lb with a cert fails with an error message of `invalid character 'r' looking for beginning of value`. Running the command with `-d` debug flag points at `backend/ecs/load_balancer_manager.go:612`, which is inside of the `getSubnetsAndAvailZones()` function. Cursory examination seems to indicate that `availZones` is an empty string slice at the point that it's used for `range`, captain.

References #13 