### PR TITLE
Fix download link in drawer

### DIFF
--- a/docs-src/material/drawer.html
+++ b/docs-src/material/drawer.html
@@ -22,7 +22,7 @@
         <ul class="repo">
           <li class="repo-download">
             {% set version = config.extra.version | default("master") %}
-            <a href="{{ repo_url }}/archive/{{ version }}.zip" target="_blank" title="Download" data-action="download">
+            <a href="{{ base_url }}/#download" title="Download">
               <i class="icon icon-download"></i> Download
             </a>
           </li>


### PR DESCRIPTION
The download link now points to [docs_site]/#download.

Closes #50