### PR TITLE
WIP: Advise that user may pass config.json format to dockercfg flag (#55)

### DIFF
--- a/setup/context/commands.go
+++ b/setup/context/commands.go
@@ -64,7 +64,7 @@ func Apply(c *Context, force bool, dockercfg string) error {
 	}
 
 	if dockercfg != "" {
-		fmt.Printf("Detected dockercfg: `%s`\n", dockercfg)
+		fmt.Printf("Detected provided dockercfg path: `%s`\n", dockercfg)
 		instancePath := fmt.Sprintf("%s/dockercfg", c.InstanceDir)
 
 		if err := CopyFile(dockercfg, instancePath); err != nil {

--- a/setup/main.go
+++ b/setup/main.go
@@ -76,7 +76,7 @@ func main() {
 	app.Command("apply", "Create/Update a Layer0", func(cmd *cli.Cmd) {
 		flags := loadFlags(cmd, []string{"access_key", "secret_key", "region"})
 
-		dockercfg := cmd.StringOpt("dockercfg", "", "Path to valid dockercfg file")
+		dockercfg := cmd.StringOpt("dockercfg", "", "Path to valid config.json or dockercfg file")
 
 		force := cmd.BoolOpt("force", false, "Set this flag to skip prompting on a missing dockercfg file")
 


### PR DESCRIPTION
Brandon determined that using a `config.json` format as a `dockercfg` file seemed to work without issue. Therefore, I am simply advising users that they may pass this format to the `--dockercfg` flag on apply.

TODO: Check for additional work based on feedback on issue #55 