### PR TITLE
Convert config.json to dockercfg format as needed (#55)

### DIFF
--- a/setup/context/dockerauth.go
+++ b/setup/context/dockerauth.go
@@ -46,7 +46,7 @@ func LoadDockerConfig(dockercfg string) (*DockerConfigFile, error) {
 	configFileType := filepath.Base(configFile.filename)
 
 	if _, err := os.Stat(configFile.filename); err != nil {
-		return nil, err // NOTE setting this to `nil, err` causes a runtime error nil pointer dereference
+		return nil, err
 	}
 
 	if configFileType == CONFIGFILE {
@@ -76,43 +76,6 @@ func LoadDockerConfig(dockercfg string) (*DockerConfigFile, error) {
 	}
 
 	return nil, fmt.Errorf("Could load docker config file.")
-
-	// // Try config.json file first
-	// if _, err := os.Stat(configFile.filename); err == nil {
-	// 	file, err := os.Open(configFile.filename)
-	// 	if err != nil {
-	// 		return &configFile, err
-	// 	}
-	// 	defer file.Close()
-	//
-	// 	if err := json.NewDecoder(file).Decode(&configFile); err != nil {
-	// 		return &configFile, err
-	// 	}
-	//
-	// 	return &configFile, nil
-	// } else if !os.IsNotExist(err) {
-	// 	// if file is there but we can't stat it for any reason other
-	// 	// than it doesn't exist then stop
-	// 	return &configFile, err
-	// }
-	//
-	// // Can't find latest config file so check for the old one
-	// configFile.filename = filepath.Join(dockercfg, OLD_CONFIGFILE)
-	//
-	// if _, err := os.Stat(configFile.filename); err != nil {
-	// 	return &configFile, fmt.Errorf("No docker config file found at: %v", dockercfg)
-	// }
-	//
-	// b, err := ioutil.ReadFile(configFile.filename)
-	// if err != nil {
-	// 	return &configFile, err
-	// }
-	//
-	// if err := json.Unmarshal(b, &configFile.AuthConfigs); err != nil {
-	// 	//TODO Case of cannot unmarshal; what to do here?
-	// 	return &configFile, fmt.Errorf("Invalid Auth config file")
-	// }
-	// return &configFile, nil
 }
 
 // Save a docker config file as `dockercfg` in JSON format.

--- a/setup/context/dockerauth.go
+++ b/setup/context/dockerauth.go
@@ -1,0 +1,116 @@
+package context
+
+// Utilities to load and save docker config files (config.json or dockercfg).
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+)
+
+const (
+	// CONFIGFILE supplies current docker config file name.
+	CONFIGFILE = "config.json"
+	// OLD_CONFIGFILE supplies old docker config file name.
+	OLD_CONFIGFILE = "dockercfg"
+)
+
+// AuthConfig contains authorization information for connecting to a Registry.
+type AuthConfig struct {
+	Username string `json:"username,omitempty"`
+	Password string `json:"password,omitempty"`
+	Auth     string `json:"auth,omitempty"`
+
+	// Email is an optional value associated with the username.
+	// This field is deprecated and will be removed in a later
+	// version of docker.
+	Email string `json:"email,omitempty"`
+
+	ServerAddress string `json:"serveraddress,omitempty"`
+
+	// IdentityToken is used to authenticate the user and get
+	// an access token for the registry.
+	IdentityToken string `json:"identitytoken,omitempty"`
+
+	// RegistryToken is a bearer token to be sent to a registry
+	RegistryToken string `json:"registrytoken,omitempty"`
+}
+
+// DockerConfigFile contains `config.json` file info.
+// `dockercfg` files use just the `AuthConfigs` field.
+type DockerConfigFile struct {
+	AuthConfigs map[string]AuthConfig `json:"auths"`
+	HTTPHeaders map[string]string     `json:"HttpHeaders,omitempty"`
+	filename    string                // Note: not serialized - for internal use only
+	Empty       bool                  // Note: not serialized - for internal use only
+}
+
+// LoadDockerConfig loads docker config files of config.json or dockercfg formats.
+func LoadDockerConfig(configDir string) (*DockerConfigFile, error) {
+	if configDir == "" {
+		return nil, fmt.Errorf("No configdir supplied.")
+	}
+
+	configFile := DockerConfigFile{
+		AuthConfigs: make(map[string]AuthConfig),
+		filename:    filepath.Join(configDir, CONFIGFILE),
+	}
+
+	// Try config.json file first
+	if _, err := os.Stat(configFile.filename); err == nil {
+		file, err := os.Open(configFile.filename)
+		if err != nil {
+			return &configFile, err
+		}
+		defer file.Close()
+
+		if err := json.NewDecoder(file).Decode(&configFile); err != nil {
+			return &configFile, err
+		}
+
+		return &configFile, nil
+	} else if !os.IsNotExist(err) {
+		// if file is there but we can't stat it for any reason other
+		// than it doesn't exist then stop
+		return &configFile, err
+	}
+
+	// Can't find latest config file so check for the old one
+	configFile.filename = filepath.Join(configDir, OLD_CONFIGFILE)
+
+	if _, err := os.Stat(configFile.filename); err != nil {
+		return &configFile, fmt.Errorf("No docker config file found at: %v", configDir)
+	}
+
+	b, err := ioutil.ReadFile(configFile.filename)
+	if err != nil {
+		return &configFile, err
+	}
+
+	if err := json.Unmarshal(b, &configFile.AuthConfigs); err != nil {
+		//TODO Case of cannot unmarshal; what to do here?
+		return &configFile, fmt.Errorf("Invalid Auth config file")
+	}
+	return &configFile, nil
+}
+
+// Save a docker config file as `dockercfg` in JSON format.
+func (configFile *DockerConfigFile) Save(saveDir string) error {
+	data, err := json.MarshalIndent(configFile.AuthConfigs, "", "\t")
+	if err != nil {
+		return err
+	}
+
+	if err := os.MkdirAll(filepath.Dir(saveDir), 0600); err != nil {
+		return err
+	}
+
+	err = ioutil.WriteFile(filepath.Join(saveDir, OLD_CONFIGFILE), data, 0600)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/setup/main.go
+++ b/setup/main.go
@@ -76,7 +76,7 @@ func main() {
 	app.Command("apply", "Create/Update a Layer0", func(cmd *cli.Cmd) {
 		flags := loadFlags(cmd, []string{"access_key", "secret_key", "region"})
 
-		dockercfg := cmd.StringOpt("dockercfg", "", "Path to valid dockercfg file")
+		dockerCfgDir := cmd.StringOpt("docker-config-dir", "", "Path to directory containing valid dockercfg or config.json file")
 
 		force := cmd.BoolOpt("force", false, "Set this flag to skip prompting on a missing dockercfg file")
 
@@ -84,7 +84,7 @@ func main() {
 		flags["vpc_id"] = vpc
 
 		command := func(c *context.Context) error {
-			return context.Apply(c, *force, *dockercfg)
+			return context.Apply(c, *force, *dockerCfgDir)
 		}
 
 		flagsCommand(cmd, command, flags)

--- a/setup/main.go
+++ b/setup/main.go
@@ -76,7 +76,7 @@ func main() {
 	app.Command("apply", "Create/Update a Layer0", func(cmd *cli.Cmd) {
 		flags := loadFlags(cmd, []string{"access_key", "secret_key", "region"})
 
-		dockerCfgDir := cmd.StringOpt("docker-config-dir", "", "Path to directory containing valid dockercfg or config.json file")
+		dockercfg := cmd.StringOpt("docker-config", "", "Path to a valid `dockercfg` or `config.json` file")
 
 		force := cmd.BoolOpt("force", false, "Set this flag to skip prompting on a missing dockercfg file")
 
@@ -84,7 +84,7 @@ func main() {
 		flags["vpc_id"] = vpc
 
 		command := func(c *context.Context) error {
-			return context.Apply(c, *force, *dockerCfgDir)
+			return context.Apply(c, *force, *dockercfg)
 		}
 
 		flagsCommand(cmd, command, flags)


### PR DESCRIPTION
* Allow l0-setup to read docker config from `config.json` or `dockercfg`
* Write `dockercfg` format to instance directory
* Allow `--docker-config-dir` flag to specify directory to read config from
* Attempt to read from global docker config dir if not found at given config directory
* Fall back to writing "empty" dockercfg file (`{}`) if needed
* Preserve `--force` flag, which disables alert on `empty` dockercfg

Would love any feedback you have, especially regarding preferences for where to organize the code additions such as `/setup/context/dockerauth.go`.