### PR TITLE
Updated suggested command output to take into account shell OS

### DIFF
--- a/setup/context/commands.go
+++ b/setup/context/commands.go
@@ -5,16 +5,18 @@ import (
 	"crypto/tls"
 	"encoding/json"
 	"fmt"
-	"github.com/docker/docker/pkg/homedir"
-	"github.com/quintilesims/layer0/common/aws/provider"
-	"github.com/quintilesims/layer0/common/aws/s3"
-	"github.com/quintilesims/layer0/common/config"
 	"io/ioutil"
 	"net/http"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"time"
+
+	"github.com/docker/docker/pkg/homedir"
+	"github.com/quintilesims/layer0/common/aws/provider"
+	"github.com/quintilesims/layer0/common/aws/s3"
+	"github.com/quintilesims/layer0/common/config"
 )
 
 type TFState struct {
@@ -393,8 +395,13 @@ func Endpoint(c *Context, syntax string, insecure, dev, quiet bool) error {
 	if quiet {
 		fmt.Printf(format, config.SKIP_VERSION_VERIFY, "1")
 	}
+
 	fmt.Println("# Run this command to configure your shell:")
-	fmt.Println("# eval $(./l0-setup endpoint -i", c.Instance, ")")
+	if runtime.GOOS == "windows" {
+		fmt.Println("# l0-setup endpoint --insecure --syntax=powershell", c.Instance, "| Out-String | Invoke-Expression")
+	} else {
+		fmt.Println("# eval $(./l0-setup endpoint -i", c.Instance, ")")
+	}
 
 	return nil
 }


### PR DESCRIPTION
Running the command outputs the following bash script suggestion 
```
# Run this command to configure your shell:
# eval $(./l0-setup endpoint -i curiosity )
```
which is invalid in a windows environment. Updated the code to take into account the operating system at runtime, to make an exception for windows and return output that is appropriate for a Powershell user in Windows.

Testing done:
- Confirmed that runtime checking of the flag works correctly in MacOS. 
- Confirmed that the command output will work in correctly in Powershell

#150 