### PR TITLE
Added --os flag to l0 cli to allow specifying operating system when creating a new l0 environment

### DIFF
--- a/cli/client/environment.go
+++ b/cli/client/environment.go
@@ -4,12 +4,13 @@ import (
 	"github.com/quintilesims/layer0/common/models"
 )
 
-func (c *APIClient) CreateEnvironment(name, instanceSize string, minCount int, userData []byte) (*models.Environment, error) {
+func (c *APIClient) CreateEnvironment(name, instanceSize string, minCount int, userData []byte, os string) (*models.Environment, error) {
 	req := models.CreateEnvironmentRequest{
 		EnvironmentName:  name,
 		InstanceSize:     instanceSize,
 		MinClusterCount:  minCount,
 		UserDataTemplate: userData,
+		OperatingSystem:  os,
 	}
 
 	var environment *models.Environment

--- a/cli/client/environment_test.go
+++ b/cli/client/environment_test.go
@@ -1,10 +1,11 @@
 package client
 
 import (
-	"github.com/quintilesims/layer0/common/models"
-	"github.com/quintilesims/layer0/common/testutils"
 	"net/http"
 	"testing"
+
+	"github.com/quintilesims/layer0/common/models"
+	"github.com/quintilesims/layer0/common/testutils"
 )
 
 func TestCreateEnvironment(t *testing.T) {
@@ -19,6 +20,7 @@ func TestCreateEnvironment(t *testing.T) {
 		testutils.AssertEqual(t, req.InstanceSize, "m3.medium")
 		testutils.AssertEqual(t, req.MinClusterCount, 2)
 		testutils.AssertEqual(t, req.UserDataTemplate, []byte("user_data"))
+		testutils.AssertEqual(t, req.OperatingSystem, "linux")
 
 		MarshalAndWrite(t, w, models.Environment{EnvironmentID: "id"}, 200)
 	}
@@ -26,7 +28,7 @@ func TestCreateEnvironment(t *testing.T) {
 	client, server := newClientAndServer(handler)
 	defer server.Close()
 
-	environment, err := client.CreateEnvironment("name", "m3.medium", 2, []byte("user_data"))
+	environment, err := client.CreateEnvironment("name", "m3.medium", 2, []byte("user_data"), "linux")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/cli/client/interface.go
+++ b/cli/client/interface.go
@@ -1,8 +1,9 @@
 package client
 
 import (
-	"github.com/quintilesims/layer0/common/models"
 	"time"
+
+	"github.com/quintilesims/layer0/common/models"
 )
 
 type Client interface {
@@ -11,7 +12,7 @@ type Client interface {
 	GetDeploy(id string) (*models.Deploy, error)
 	ListDeploys() ([]*models.DeploySummary, error)
 
-	CreateEnvironment(name, instanceSize string, minCount int, userData []byte) (*models.Environment, error)
+	CreateEnvironment(name, instanceSize string, minCount int, userData []byte, os string) (*models.Environment, error)
 	DeleteEnvironment(id string) (string, error)
 	GetEnvironment(id string) (*models.Environment, error)
 	ListEnvironments() ([]*models.EnvironmentSummary, error)

--- a/cli/client/mock_client/mock_client.go
+++ b/cli/client/mock_client/mock_client.go
@@ -41,15 +41,15 @@ func (_mr *_MockClientRecorder) CreateDeploy(arg0, arg1 interface{}) *gomock.Cal
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "CreateDeploy", arg0, arg1)
 }
 
-func (_m *MockClient) CreateEnvironment(_param0 string, _param1 string, _param2 int, _param3 []byte) (*models.Environment, error) {
-	ret := _m.ctrl.Call(_m, "CreateEnvironment", _param0, _param1, _param2, _param3)
+func (_m *MockClient) CreateEnvironment(_param0 string, _param1 string, _param2 int, _param3 []byte, _param4 string) (*models.Environment, error) {
+	ret := _m.ctrl.Call(_m, "CreateEnvironment", _param0, _param1, _param2, _param3, _param4)
 	ret0, _ := ret[0].(*models.Environment)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockClientRecorder) CreateEnvironment(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "CreateEnvironment", arg0, arg1, arg2, arg3)
+func (_mr *_MockClientRecorder) CreateEnvironment(arg0, arg1, arg2, arg3, arg4 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "CreateEnvironment", arg0, arg1, arg2, arg3, arg4)
 }
 
 func (_m *MockClient) CreateLoadBalancer(_param0 string, _param1 string, _param2 models.HealthCheck, _param3 []models.Port, _param4 bool) (*models.LoadBalancer, error) {

--- a/cli/command/environment_command.go
+++ b/cli/command/environment_command.go
@@ -1,10 +1,11 @@
 package command
 
 import (
-	"github.com/quintilesims/layer0/common/models"
-	"github.com/urfave/cli"
 	"io/ioutil"
 	"strconv"
+
+	"github.com/quintilesims/layer0/common/models"
+	"github.com/urfave/cli"
 )
 
 type EnvironmentCommand struct {
@@ -39,6 +40,11 @@ func (e *EnvironmentCommand) GetCommand() cli.Command {
 					cli.StringFlag{
 						Name:  "user-data",
 						Usage: "path to user data file",
+					},
+					cli.StringFlag{
+						Name:  "os",
+						Value: "linux",
+						Usage: "specifies windows or linux container environment cluster",
 					},
 				},
 			},
@@ -92,7 +98,8 @@ func (e *EnvironmentCommand) Create(c *cli.Context) error {
 		userData = content
 	}
 
-	environment, err := e.Client.CreateEnvironment(args["NAME"], c.String("size"), c.Int("min-count"), userData)
+	//todo: add it here
+	environment, err := e.Client.CreateEnvironment(args["NAME"], c.String("size"), c.Int("min-count"), userData, c.String("os"))
 	if err != nil {
 		return err
 	}

--- a/cli/command/environment_command_test.go
+++ b/cli/command/environment_command_test.go
@@ -1,9 +1,10 @@
 package command
 
 import (
+	"testing"
+
 	"github.com/quintilesims/layer0/common/models"
 	"github.com/urfave/cli"
-	"testing"
 )
 
 func TestCreateEnvironment(t *testing.T) {
@@ -15,13 +16,14 @@ func TestCreateEnvironment(t *testing.T) {
 	defer close()
 
 	tc.Client.EXPECT().
-		CreateEnvironment("name", "m3.large", 2, []byte("user_data")).
+		CreateEnvironment("name", "m3.large", 2, []byte("user_data"), "linux").
 		Return(&models.Environment{}, nil)
 
 	flags := Flags{
 		"size":      "m3.large",
 		"min-count": 2,
 		"user-data": file.Name(),
+		"os":        "linux",
 	}
 
 	c := getCLIContext(t, Args{"name"}, flags)

--- a/common/models/create_environment_request.go
+++ b/common/models/create_environment_request.go
@@ -5,4 +5,5 @@ type CreateEnvironmentRequest struct {
 	InstanceSize     string `json:"instance_size"`
 	UserDataTemplate []byte `json:"user_data_template"`
 	MinClusterCount  int    `json:"min_cluster_count"`
+	OperatingSystem  string `json:"operating_system"`
 }

--- a/tests/smoke/environment.bats
+++ b/tests/smoke/environment.bats
@@ -24,6 +24,10 @@
     l0 environment create --min-count 2 test3
 }
 
+@test "environment create --os windows test4" {
+    l0 environment create --os windows test4
+}
+
 @test "environment list" {
     l0 environment list
 }
@@ -50,4 +54,8 @@
 
 @test "environment delete --wait test3" {
     l0 environment delete --wait test3
+}
+
+@test "environment delete --wait test4" {
+    l0 environment delete --wait test4
 }


### PR DESCRIPTION
#155 Added new --os flag to l0 CLI. --os flag's value maps to the OperatingSystem in the L0 Environment Create model to be consistent with #167.

Testing done:
 - Ran unit tests
 - Ran system tests with @zpatrick 's help