### PR TITLE
Added new documentation for Terraform beyond Layer0

### DIFF
--- a/docs-src/docs/guides/one_off_task.md
+++ b/docs-src/docs/guides/one_off_task.md
@@ -23,17 +23,19 @@ one-off-task-dpl.1  one-off-task-dpl   1
 ```
 
 ## Part 3: Create the task
-At this point, you can use the **task create** command to begin an instance of the task deployed above.
+At this point, you can use the **task create** command to run a copy of the task.
 
 To run the task, use the following command:
 
-`l0 task create demo-env one-off-task-tsk one-off-task-dpl:latest`
+`l0 task create demo-env echo-tsk one-off-task-dpl:latest --wait`
 
 You will see the following output:
 ```
 TASK ID       TASK NAME         ENVIRONMENT  DEPLOY              SCALE
-one-off851c9  one-off-task-tsk  demo-env     one-off-task-dpl:1  0/1 (1)
+one-off851c9  echo-tsk          demo-env     one-off-task-dpl:1  0/1 (1)
 ```
+
+The `SCALE` column shows the running, desired and pending counts. A value of `0/1 (1)` indicates that running = 0, desired = 1 and (1) for 1 pending task that is about to transition to running state. After your task has finished running, note that the desired count will remain 1 and pending value will no longer be shown, so the value will be `0/1` for a finished task.
 
 ## Part 4: Check the status of the task
 
@@ -46,4 +48,60 @@ You will see the following output:
 alpine
 ------
 Task finished!
+```
+
+You can also use the following command for more information in the task.
+
+`l0 -o json task get echo-tsk`
+
+Outputs:
+
+```
+[
+    {
+        "copies": [
+            {
+                "details": [],
+                "reason": "Waiting for cluster capacity to run",
+                "task_copy_id": ""
+            }
+        ],
+        "deploy_id": "one-off-task-dpl.2",
+        "deploy_name": "one-off-task-dpl",
+        "deploy_version": "2",
+        "desired_count": 1,
+        "environment_id": "demoenv669e4",
+        "environment_name": "demo-env",
+        "pending_count": 1,
+        "running_count": 0,
+        "task_id": "echotsk1facd",
+        "task_name": "echo-tsk"
+    }
+]
+```
+
+After the task has finished, running `l0 -o json task get echo-tsk` will show a pending_count of 0.
+
+Outputs:
+
+```
+...
+"copies": [
+    {
+        "details": [
+            {
+                "container_name": "alpine",
+                "exit_code": 0,
+                "last_status": "STOPPED",
+                "reason": ""
+            }
+        ],
+        "reason": "Essential container in task exited",
+        "task_copy_id": "arn:aws:ecs:us-west-2:856306994068:task/0e723c3e-9cd1-4914-8393-b59abd40eb89"
+    }
+],
+...
+"pending_count": 0,
+"running_count": 0,
+...
 ```

--- a/docs-src/docs/guides/one_off_task.md
+++ b/docs-src/docs/guides/one_off_task.md
@@ -1,57 +1,49 @@
 # Deployment guide: Guestbook one-off task
 
-In this example, you will learn how to use layer0 to run a one-off task. In this case, it will be to run a task to restore the [guestbook application](/guides/guestbook) from a backup.
+In this example, you will learn how to use layer0 to run a one-off task. A task is used to run a single instance of your Task Definition and is typically a short running job that will be stopped once finished.
 
 ---
 
 ## Before you start
 In order to complete the procedures in this section, you must install and configure Layer0 v0.8.4 or later. If you have not already configured Layer0, see the [installation guide](/setup/install). If you are running an older version of Layer0, see the [upgrade instructions](/setup/upgrade#upgrading-older-versions-of-layer0).
 
-This guide expands upon the [Guestbook deployment guide](/guides/guestbook) deployment guide. You must complete the procedures in that guide before you can complete the procedures listed here. After completing the procedures in the Guestbook guide, your Layer0 should contain a service named "guestbooksvc", running a deploy named "guestbook", behind a load balancer named "guestbooklb", all within an environment named "demo".
-
 ## Part 1: Prepare the task definition
 
-1. Download the [Guestbook One-off Task Definition](https://github.com/quintilesims/layer0-examples/blob/master/1offtask/Dockerrun.aws.json) and save it to your computer as **GuestbookRestore.Dockerrun.aws.json**.
-2. Edit the `GUESTBOOK_URL` environment variable for the `l0-guestbook-restore` container to the url of the loadbalancer running your guestbook application. This url can be obtained by looking at the output of the command
-
-<span style="padding-left:2em">**l0 loadbalancer get guestbooklb**</span>
-
-3. Edit the `BACKUP_FILE_URL` environment variable for the `l0-guestbook-restore` container to the url of the backup file that you wish to restore from. A sample backup file is provided at [https://github.com/quintilesims/layer0-examples/raw/master/1offtask/backup.txt](https://github.com/quintilesims/layer0-examples/raw/master/1offtask/backup.txt).
+1. Download the [Guestbook One-off Task Definition](https://github.com/quintilesims/layer0-examples/blob/master/one-off-task/Dockerrun.aws.json) and save it to your computer as **Dockerrun.aws.json**.
 
 ## Part 2: Create a deploy
-Next, you will create a new deploy for the task.
+Next, you will create a new deploy for the task using the **deploy create** command. At the command prompt, run the following command:
 
-**To create a new deploy:**
-
-At the command prompt, run the following command:
-
-<span style="padding-left:2em">**l0 deploy create GuestbookRestore.Dockerrun.aws.json guestbookrestore**</span>
+`l0 deploy create Dockerrun.aws.json one-off-task-dpl`
 
 You will see the following output:
 ```
 DEPLOY ID           DEPLOY NAME        VERSION
-guestbookrestore.1  guestbookrestore   1
+one-off-task-dpl.1  one-off-task-dpl   1
 ```
 
 ## Part 3: Create the task
-At this point, you can use the **task create** command to begin an instance of the task deployed above. This task requires two environment variables to be supplied to the `l0-guestbook-restore` container: `GUESTBOOK_URL` and `BACKUP_FILE_URL`. These were collected in Part 1 of this guide.
+At this point, you can use the **task create** command to begin an instance of the task deployed above.
 
 To run the task, use the following command:
 
-<span style="padding-left:2em">**l0 task create demo guestbookrestore guestbookrestore**</span>
+`l0 task create demo-env one-off-task-tsk one-off-task-dpl:latest`
 
 You will see the following output:
 ```
 TASK ID       TASK NAME         ENVIRONMENT  DEPLOY              SCALE
-guestbo851c9  guestbookrestore  demo         guestbookrestore:2  0/1 (1)
+one-off851c9  one-off-task-tsk  demo-env     one-off-task-dpl:1  0/1 (1)
 ```
 
-## Part 4: Wait for the task to complete
+## Part 4: Check the status of the task
 
-### Check the logs for the task
+To view the logs for this task, and evaluate its progress, you can use the **task logs** command:
 
-To see the logs for this task, and evaluate progress, use the command:
+`l0 task logs one-off-task-tsk`  
 
-<span style="padding-left:2em">**l0 task logs guestbookrestore**</span>
-
-Once it has completed, check your guestbook url, and note that the entries have been replaced with the contents of your backup file.
+You will see the following output:
+```
+alpine
+------
+Task finished!
+```

--- a/docs-src/docs/guides/terraform_beyond_layer0.md
+++ b/docs-src/docs/guides/terraform_beyond_layer0.md
@@ -1,5 +1,5 @@
 # Deployment guide: Terraform beyond Layer0
- In this example, we'll learn how you can use Terraform to create a Layer0 service as well as a persistent data store. The main goal of this example is to explore how you can combine Layer0 with other Terraform providers.
+ In this example, we'll learn how you can use Terraform to create a Layer0 service as well as a persistent data store. The main goal of this example is to explore how you can combine Layer0 with other Terraform providers and best practices around how you can leverage functionality provided by Terraform.
 
 ## Before you start
 To complete the procedures in this section, you must have the following installed and configured correctly:
@@ -18,21 +18,22 @@ See the [Terraform installation guide](/reference/terraform-plugin#install) to i
 Using Terraform, you will deploy a simple guestbook application, which is backed by AWS DynamoDB Table, for persistent storage. The terraform configuration file will use both the Layer0 and AWS Terraform providers, to deploy the guestbook application and provision a new DynamoDB Table.
 
 ## Part 1: Clone the Layer0 examples repository
-Run this command to clone the `quintilesims/layer0-examples` repository
+Run this command to clone the `quintilesims/layer0-examples` repository. Once you have cloned the repository, navigate to `.terraform-beyond-layer0/example-1` folder for the rest of this example.
 
 `git clone https://github.com/quintilesims/layer0-examples.git`  
 
 ## Part 2: Terraform Plan
-As we're using modules in our Terraform configuration we need to run `terraform get` before performing other terraform operations. Running get will download the modules to your local folder named `.terraform`. See here for more information on [terraform get](https://www.terraform.io/docs/commands/get.html).
+!!! Note
+	As we're using modules in our Terraform configuration we need to run `terraform get` before performing other terraform operations. Running get will download the modules to your local folder named `.terraform`. See here for more information on [terraform get](https://www.terraform.io/docs/commands/get.html).
 
-`terraform get`
+	`terraform get`
 
 Before deploying, we can run the following command to see what changes Terraform will make to your infrastructure should you go ahead and apply. If you had any errors in your layer0.tf file, running `terraform plan` would output those errors so that you can address them. Also, Terraform will prompt you for configuration values that it does not have.
 
 `terraform plan`
 
-!!! Note
-  There are a few ways to configure Terraform so that you don't have to keep entering these values every time you run a Terraform command (editing the `terraform.tfvars` file, or exporting environment variables like `TF_VAR_endpoint` and `TF_VAR_token`, for example). See the [Terraform Docs](https://www.terraform.io/docs/configuration/variables.html) for more.
+!!! Tip
+	There are a few ways to configure Terraform so that you don't have to keep entering these values every time you run a Terraform command (editing the `terraform.tfvars` file, or exporting environment variables like `TF_VAR_endpoint` and `TF_VAR_token`, for example). See the [Terraform Docs](https://www.terraform.io/docs/configuration/variables.html) for more.
 
 ```
 var.endpoint
@@ -84,14 +85,14 @@ guestbook_url = <http endpoint for the sample application>
 ```
 
 !!! Note
-  It may take a few minutes for the guestbook service to launch and the load balancer to become available. During that time, you may get HTTP 503 errors when making HTTP requests against the load balancer URL.
+	It may take a few minutes for the guestbook service to launch and the load balancer to become available. During that time, you may get HTTP 503 errors when making HTTP requests against the load balancer URL.
 
 Terraform will set up the entire environment for you and then output a link to the application's load balancer.
 
 ### What's happening
-Terraform using the AWS provider, provisions a new DynamoDB Table (with the name you have configured) and configures environment variables for the Layer0 application to use the newly provisioned table, and deploys the application into a Layer0 environment using the Layer0 provider.
+Terraform using the AWS provider, provisions a new DynamoDB Table (with the name you have configured) and configures environment variables for the Layer0 application to use the newly provisioned table and deploys the application into a Layer0 environment using the Layer0 provider.
 
-Looking at an excerpt of [layer0.tf](https://github.com/quintilesims/layer0-examples/blob/master/guestbook-db/layer0.tf) file, we can see the following definitions:
+Looking at an excerpt of [./terraform-beyond-layer0/example-1/modules/guestbook_service/main.tf](https://github.com/quintilesims/layer0-examples/blob/master/guestbook-db/layer0.tf) file, we can see the following definitions:
 
 ```
 resource "aws_DynamoDB_table" "guestbook" {
@@ -118,7 +119,7 @@ data "template_file" "guestbook" {
     access_key = "${var.access_key}"
     secret_key = "${var.secret_key}"
     region     = "${var.region}"
-    table_name = "${aws_DynamoDB_table.guestbook.name}"
+    table_name = "${aws_dynamodb_table.guestbook.name}"
   }
 }
 ```
@@ -144,13 +145,13 @@ This is then used to populate the template fields in our [Dockerrun.aws.json](ht
                 ...
 ```
 
-The Layer0 configuration referencing the AWS DynamoDB configuration `table_name = "${aws_DynamoDB_table.guestbook.name}"`, infers an implicit dependency. Before Terraform creates the infrastructure, it will use this information to order the resources created and create resources in parallel where there are no dependencies. In this example, the AWS DynamoDB table will be created before the Layer0 deploy. See [Terraform Dependencies](https://www.terraform.io/intro/getting-started/dependencies.html) for more information.
+The Layer0 configuration referencing the AWS DynamoDB configuration `table_name = "${aws_DynamoDB_table.guestbook.name}"`, infers an implicit dependency. Before Terraform creates the infrastructure, it will use this information to order the resource creation and create resources in parallel, where there are no dependencies. In this example, the AWS DynamoDB table will be created before the Layer0 deploy. See [Terraform Resource Dependencies](https://www.terraform.io/intro/getting-started/dependencies.html) for more information.
 
 ## Part 4: Scaling a Layer0 Service
 The workflow to make changes to your infrastructure generally involves updating your Terraform configuration file followed by a `terraform plan` and `terraform apply`.
 
 ### Update the Terraform configuration
-Open the file `main.tf` in a text editor and make the change to add a `scale` property with a value of `3` to the `layer0_service` section. For more information about the `scale` property, see [Layer0 Terraform Plugin](http://layer0.ims.io/reference/terraform-plugin/#service) documentation. The result should look like the below:
+Open the file `./example-1/modules/guestbook_service/main.tf` in a text editor and make the change to add a `scale` property with a value of `3` to the `layer0_service` section. For more information about the `scale` property, see [Layer0 Terraform Plugin](http://layer0.ims.io/reference/terraform-plugin/#service) documentation. The result should look like the below:
 
 example-1/modules/guestbook_service/main.tf
 
@@ -166,8 +167,8 @@ resource "layer0_service" "guestbook" {
 
 ```
 
-### Get, Plan and Apply
-As you're updating Terraform configuration in a module, you'll need to run `terraform get` to update the copy of the module in `.terraform`. Once you have done so, execute the following command to understand the changes that you will be making. Note that if you did not specify `scale` it defaults to '1'.
+### Plan and Apply
+Execute the plan command to understand the changes that you will be making. Note that if you did not specify `scale`, it defaults to '1'.
 
 `terraform plan`
 
@@ -176,7 +177,7 @@ Outputs:
 ```
 ...
 
-~ layer0_service.guestbook
+~ module.guestbook.layer0_service.guestbook
     scale: "1" => "3"
 ```
 
@@ -207,23 +208,25 @@ State path:
 
 Outputs:
 
-guestbook_url = <guestbook_service_url>
+services = <guestbook_service_url>
 ```
 
-To confirm your service has scaled, you can run the following layer0 command. Note desired scale for the guestbook service should be eventually be 3/3.
+To confirm your service has been updated to the desired scale, you can run the following layer0 command. Note desired scale for the guestbook service should be eventually be 3/3.
 
-`l0 service get demo-env:guestbook`
+`l0 service get guestbook1_guestbook_svc`
 
 Outputs:
 
 ```
 SERVICE ID    SERVICE NAME  ENVIRONMENT  LOADBALANCER  DEPLOYMENTS  SCALE
-api           api           api          api           api:3        1/1
-guestboebca1  guestbook     demo-env     guestbook     guestbook:6  3/3
+SERVICE ID    SERVICE NAME              ENVIRONMENT  LOADBALANCER             DEPLOYMENTS                  SCALE
+guestbo4fd3b  guestbook1_guestbook_svc  demo         guestbook1_guestbook_lb  guestbook1_guestbook_dpl:3*  1/3 (2)
 ```
 
+As scale is parameter we are likely to change in the future, rather than hardcoding it to 3 as we have done just now, it would be better to use a variable to store  `service_scale`. The following Best Practices sections will show how you can achieve this.
+
 !!! Tip "Best Practices with Terraform + Layer0"
-  The following sections outline some of the best practices and tips to take into consideration, when using Layer0 with Terraform.
+	The following sections outline some of the best practices and tips to take into consideration, when using Layer0 with Terraform.
 
 ## Part 5: Terraform Remote State
 
@@ -234,10 +237,10 @@ How state is loaded and used for operations such as `terraform apply` is determi
 ### Remote State
 In scenarios where you are working as part of a team to provision and manage services deployed by Terraform, all the members of the team will need access to the state file to apply new changes. You would also want resiliency against losing the state file. You can cater for provisioning and managing Terraform in a team environment and providing redundancy for the state file by using a remote backend. A remote backend can also provide locking mechanisms to ensure multiple users can't change resources at the same time. Backends such as [Consul](https://www.terraform.io/docs/backends/types/consul.html) & [S3](https://www.terraform.io/docs/backends/types/s3.html) among others, are backends that you can use to store master Terraform state in a remote location.
 
-To configure a remote backend, append the `terraform` section below to your terraform file `layer0.tf`. Update the `path` property to a GUID to avoid a potential conflict as demo.consul.io is a public consul endpoint.
+To configure a remote backend, append the `terraform` section below to your terraform file `./example-1/main.tf`. Populate the `bucket` property to an existing s3 bucket.
 
 !!! Tip
-  If you have been following along with the guide, layer0.tf should already have the below section commented out. You can simply uncomment the `terraform` section and populate the properties with the appropriate values.
+	If you have been following along with the guide, `./example-1/main.tf` should already have the below section commented out. You can uncomment the `terraform` section and populate the bucket property with an appropriate value.
 
 ```
 terraform {
@@ -249,7 +252,7 @@ terraform {
 }
 ```
 
-Once you have modified `layer0.tf`, you will need to initialize the newly configured backend by running the following command.
+Once you have modified `main.tf`, you will need to initialize the newly configured backend by running the following command.
 
 `terraform init`
 
@@ -280,23 +283,23 @@ Terraform has been successfully initialized!
 ```
 
 ### What's happening
-As you are configuring a backend for the first time, Terraform will give you an option to migrate your state to the new backend. From now on, any further changes to your infrastructure made by Terraform will result in the remote state file being updated. For more information see (Terraform backends)[https://www.terraform.io/docs/backends/index.html].
+As you are configuring a backend for the first time, Terraform will give you an option to migrate your state to the new backend. From now on, any further changes to your infrastructure made by Terraform will result in the remote state file being updated. For more information see [Terraform backends](https://www.terraform.io/docs/backends/index.html).
 
-A new team member can use the `layer0.tf` from their own machine without obtaining a copy of the state file `terraform.tfstate` as the configuration will retrieve the state file from the remote backend.
+A new team member can use the `main.tf` from their own machine without obtaining a copy of the state file `terraform.tfstate` as the configuration will retrieve the state file from the remote backend.
 
 ### Locking
-Not all remote backends support locking (locking ensures only one person is able to change the state at a time). The `S3` backend we used earlier in the example also supports locking which is disabled by default. To enable locking, you need to specify `locking_table` property with the name of an existing DynamoDB table. The DynamoDB table also needs primary key named `LockID` of type `String`.
+Not all remote backends support locking (locking ensures only one person is able to change the state at a time). The `S3` backend we used earlier in the example supports locking which is disabled by default. The `S3` backend uses a DynamoDB table to acquire a lock before making a change to the state file. To enable locking, you need to specify `locking_table` property with the name of an existing DynamoDB table. The DynamoDB table also needs primary key named `LockID` of type `String`.
 
 ### Security
 A Terraform state file is written in plain text. This can lead to a situation where deploying resources that require sensitive data can result in the sensitive data being stored in the state file. To minimize exposure of sensitive data, you can enable [server side encryption](https://docs.aws.amazon.com/AmazonS3/latest/dev/UsingServerSideEncryption.html) of the state file by adding property `encrypt` set to `true`.
 
 This will ensure that the file is encrypted in S3 and by using a remote backend, you will also have the added benefit of the state file not being persisted to disk locally as it will only ever be held in memory by Terraform.
 
-For securing the state file further, you can also enable access logging on the S3 bucket you are using for the remote backend which can help track down invalid access should it occur.
+For securing the state file further, you can also enable access logging on the S3 bucket you are using for the remote backend, which can help track down invalid access should it occur.
 
 ## Part 6: Terraform Configuration Structure
 
-There are many different approaches to setup your Terraform code structure. There is no single best prescribed way to structure your infrastructure code. Whatever approach you take needs to be catered for the needs of your particular project. Keeping that in mind; the file structure for [Terraform beyond Layer0 example](https://github.com/quintilesims/layer0-examples/blob/master/terraform-beyond-layer0/example-1) is as below:
+There are many different approaches to setup your Terraform code structure. Although there is no one prescrived approach, whatever approach you take needs to be catered for the needs of your particular project. Keeping that in mind; the file structure for [Terraform beyond Layer0 example](https://github.com/quintilesims/layer0-examples/blob/master/terraform-beyond-layer0/example-1) is as below:
 
 ```
 example1/
@@ -317,6 +320,9 @@ Here we are making use of Terraform [Modules](https://www.terraform.io/docs/modu
 If you wanted to add a new service, you can create new folder service folder inside the ./modules. If you wanted to you could even run multiple copies of the same service. See here for more information about [Creating Modules](https://www.terraform.io/docs/modules/create.html).
 
 When creating a module, ensure that resources you are creating are prefixed with the environment and the module's name variable to ensure your resources are unique for each layer0 environment and each reference to a module.
+
+For example
+
 ```
 resource "layer0_load_balancer" "guestbook" {
   name        = "${var.name}_guestbook_lb"
@@ -329,6 +335,8 @@ resource "layer0_load_balancer" "guestbook" {
   }
 }
 
+# note we are prefixing with the environment name also to ensure there won't be conflicts
+# if multiple instance of this application were deployed
 resource "aws_dynamodb_table" "guestbook" {
   name           = "${var.layer0_environment_name}_${var.name}_${var.table_name}"
   read_capacity  = 20
@@ -348,10 +356,10 @@ Also see the below repositories for ideas on different ways you can organize you
 * [Best Pratices Ops](https://github.com/hashicorp/best-practices)
 
 ## Part 7: State Environments
-Layer0 recommends that you typically make a single environment for each tier of your application, such as `dev`, `staging` and `production`. That recommendation still holds when using Terraform with Layer0. Using Layer0 CLI, you can target a specific environment most commands. This enables you to service each tier relatively easily. In Terraform, there a few approaches you can take to enable a similar workflow.
+Layer0 recommends that you typically make a single environment for each tier of your application, such as `dev`, `staging` and `production`. That recommendation still holds when using Terraform with Layer0. Using Layer0 CLI, you can target a specific environment for most CLI commands. This enables you to service each tier relatively easily. In Terraform, there a few approaches you can take to enable a similar workflow.
 
 ### Single Terraform Configuration
-You can use a single set of Terraform configuration to create and maintain multiple environments by making use of the [Count](https://www.terraform.io/docs/configuration/resources.html#count) parameter of a Resource. Count enables you to create multiple copies of a given resource. 
+You can use a single Terraform configuration to create and maintain multiple environments by making use of the [Count](https://www.terraform.io/docs/configuration/resources.html#count) parameter, inside a Resource. Count enables you to create multiple copies of a given resource. 
 
 For example
 
@@ -373,7 +381,7 @@ resource "layer0_environment" "demo" {
 }
 ```
 
-Let's have a more in-depth look in how this works. You can start buy navigating to `./terraform-beyond-layer0/example-2' folder. Start by running the plan command:
+Let's have a more in-depth look in how this works. You can start buy navigating to `./terraform-beyond-layer0/example-2' folder. Start by running the plan command.
 
 `terraform plan`
 
@@ -389,7 +397,7 @@ Outputs:
 ...
 ```
 
-Note that you will a copy of each resource for each environment specified in your environments file in `variables.tf`. Go ahead and run apply.
+Note that you will a copy of each resource for each environment specified in your environments file in `./example-2/variables.tf`. Go ahead and run apply.
 
 `terraform apply`
 
@@ -404,9 +412,9 @@ guestbook_urls =
 <staging_url>
 ```
 
-You have now created two separate environments using a single terraform configuration: dev & staging. You can navigate to the two urls output and you should note that they are separate instances of the guestbook application backed with their own separate data store.
+You have now created two separate environments using a single terraform configuration: dev & staging. You can navigate to both the urls output and you should note that they are separate instances of the guestbook application backed with their own separate data store.
 
-A common use case for maintaining different environments is configure each environment slightly differently. For example, might want to scale your Layer0 service to 3 (defaults to 1) for staging and leave it as 1 for the dev environment. This can be done easily by using conditional logic to set our `scale` parameter the layer0 service configuration in `main.tf`. Go ahead and open `main.tf` in a text editor. Navigate to the `layer0_service guestbook` section. Uncomment the scale parameter so that your configuration looks like below.
+A common use case for maintaining different environments is configure each environment slightly differently. For example, might want to scale your Layer0 service to 3 for staging and leave it as 1 for the dev environment. This can be done easily by using conditional logic to set our `scale` parameter in the layer0 service configuration in `./example-2/main.tf`. Go ahead and open `main.tf` in a text editor. Navigate to the `layer0_service guestbook` section. Uncomment the scale parameter so that your configuration looks like below.
 
 ```
 resource "layer0_service" "guestbook" {
@@ -420,7 +428,7 @@ resource "layer0_service" "guestbook" {
 }
 ```
 
-The reference to the variable `service_scale` is already defined in `variables.tf`. If you now go ahead and run plan, you will see that the `guestbook` service for only the `staging` environment will be scaled up.
+The variable `service_scale` is already defined in `variables.tf`. If you now go ahead and run plan, you will see that the `guestbook` service for only the `staging` environment will be scaled up.
 
 `terraform plan`
 
@@ -431,7 +439,12 @@ Outputs:
     scale: "1" => "3"
 ```
 
-The downside of this approach however is that all your environments are using the same state file. Ideally you would want each environment to be completely isolated from other environments. Sharing a state file breaks some of this encapsulation. Should there ever be a situation where your state file becomes corrupt, it would affect your ability to service all the environments till you resolve the issue by potentially rolling back to a previous copy of the state file.
+The downside of this approach however is that all your environments are using the same state file. Ideally you would want each environment to be completely isolated from other environments, which they mostly are. But sharing a state file breaks some of this encapsulation. Should there ever be a situation where your state file becomes corrupt, it would affect your ability to service all the environments till you resolve the issue by potentially rolling back to a previous copy of the state file. 
+
+The next section will show you how you can separate your Terraform environment configuration such that each environment will have its own state file.
+
+!!! Note
+	As previously mentioned, you will want to avoid hardcoding resource parameter configuration values as much as possible. As an example the scale property of a layer0 service. But this extends to other properties as well like docker image version etc. You should avoid using `latest` and specify a explicit version via configurable variable when possible.
 
 ### Multiple Terraform Configurations
 The previous example used a single set of Terraform Configuration files which to create and maintain multiple environments. This resulted in a single state file which had the state information for all the environments. Another approach you can take to increase encapsulation of the state file is to have a unique state file for each environment tier of your application.
@@ -441,7 +454,7 @@ Go ahead and navigate to `./terraform-beyond-layer0/example-3` folder. Here we a
 Open the env-dev folder inside a text editor. Note that `main.tf` doesn't contain any resource definitions. Instead, we only have one module definition which has various variables being passed in, which is also how we are passing in the `environment` variable. To create a `dev` and `staging` environments for our guestbook application, go ahead and run terraform plan and apply commands from `env-dev` and `env-staging` folders.
 
 ```
-# assuming you are in the terraform-beyond-layer0/example3 folder
+# assuming you are in the terraform-beyond-layer0/example-3 folder
 cd env-dev
 terraform get
 terraform plan
@@ -453,11 +466,11 @@ terraform plan
 terraform apply
 ```
 
-You should now have two instance of the guestbook application running. Note that our guestbook service in our staging environment has been scaled to 3. We have done this by specifying a map variable `service_scale` in `./example-3/dev-staging/variables.tf` which has scale values for each environment.
+You should now have two instance of the guestbook application running. Note that our guestbook service in our staging environment has been scaled to 3. We have done this by specifying a map variable `service_scale` in `./example-3/dev-staging/variables.tf` which can have different scale values for each environment.
 
 ## Part 8: Multiple Provider Instances
 
-You can define multiple instances of the same provider to enable uniquely customized providers. For example, you can have an `aws` provider to support multiple regions, different roles etc or in the case of the `layer0` provider, to support multiple layer0 endpoints.
+You can define multiple instances of the same provider that is uniquely customized. For example, you can have an `aws` provider to support multiple regions, different roles etc or in the case of the `layer0` provider, to support multiple layer0 endpoints.
 
 For example:
 
@@ -502,5 +515,5 @@ Directories:
 
 `terraform destroy`
 
-!!! tip "Remote Backend Resources"
-  If you created additional resources (S3 bucket and a DynamoDB Table) separately when configuring a [Remote Backend](#part-5-terraform-remote-state), do not forget to delete those if they are no longer needed. You should be able to look at your Terraform configuration file `layer0.tf` to determine the name of the bucket and table.
+!!! Tip "Remote Backend Resources"
+	If you created additional resources (S3 bucket and a DynamoDB Table) separately when configuring a [Remote Backend](#part-5-terraform-remote-state), do not forget to delete those if they are no longer needed. You should be able to look at your Terraform configuration file `layer0.tf` to determine the name of the bucket and table.

--- a/docs-src/docs/guides/terraform_beyond_layer0.md
+++ b/docs-src/docs/guides/terraform_beyond_layer0.md
@@ -28,9 +28,9 @@ Inside a terminal window, navigate to the `terraform-beyond-layer0 folder`. You 
 
 |Filename|Purpose|
 |----|----|
-|[terraform.tfvars](https://github.com/quintilesims/layer0-examples/blob/master/guestbook-db/terraform.tfvars)|Variables specific to the environment and guestbook application|
-|[Dockerrun.aws.json](https://github.com/quintilesims/layer0-examples/blob/master/guestbook-db/Dockerrun.aws.json)|Template for running the guestbook application in a Layer0 environment|
-|[layer0.tf](https://github.com/quintilesims/layer0-examples/blob/master/guestbook-db/layer0.tf)|Provision Layer0 resources and AWS resources|
+|[terraform.tfvars](https://github.com/quintilesims/layer0-examples/blob/master/terraform-beyond-layer0/terraform.tfvars)|Variables specific to the environment and guestbook application|
+|[Dockerrun.aws.json](https://github.com/quintilesims/layer0-examples/blob/master/terraform-beyond-layer0/Dockerrun.aws.json)|Template for running the guestbook application in a Layer0 environment|
+|[layer0.tf](https://github.com/quintilesims/layer0-examples/blob/master/terraform-beyond-layer0/layer0.tf)|Provision Layer0 resources and AWS resources|
 
 ## Part 2: Terraform Plan
 Before deploying, we can run the follwing command to see what changes Terraform will make to your infrastructure should you go ahead and apply. If you had any errors in your layer0.tf file, running `terraform plan` would output those errors so that you can address them. Also, Terraform will prompt you for configuration values that it does not have.

--- a/docs-src/docs/guides/terraform_beyond_layer0.md
+++ b/docs-src/docs/guides/terraform_beyond_layer0.md
@@ -1,0 +1,162 @@
+# Deployment guide: Guestbook sample application
+In this example, you will learn how you can use Terraform to create a Layer0 service as well as supporting infrastructure in the form of a persistent data store. This example does not cover the details of application being deployed but focuses on how you can combine Layer0 and other Terraform providers as part of a Terraform workflow.
+
+## Before you start
+In order to complete the procedures in this section, you must have following installed and configured correctly:
+
+ * Layer0
+ * Terraform
+ * Layer0 Terraform Provider
+
+Layer0 v0.8.4 or later installed and configured. If you have not already configured Layer0, see the [Layer0 installation guide](/setup/install). If you are running an older version of Layer0, see the [Layer0 upgrade instructions](/setup/upgrade#upgrading-older-versions-of-layer0).
+
+See the [Terraform installation guide](/reference/terraform-plugin#install) to install Terraform and the Layer0 Terraform Plugin.
+
+---
+
+## Deploy with Terraform
+Using Terraform, you will deploy a simple guestbook application, which is backed by AWS DynamoDb Table, for persistant storage. The terraform configuration file will use both the Layer0 and AWS Terraform providers, to deploy the guestbook application and provision a new DynamoDb Table.
+
+## Part 1: Clone the Layer0 examples repository
+Run this command to clone the `quintilesims/layer0-examples` repository
+
+<ul>
+  <li class="command">git clone https://github.com/quintilesims/layer0-examples.git</li>
+</ul>
+
+Inside a terminal window, navigate to the `terraform-beyond-layer0 folder`. You should find the following files once you are in the folder. We use these files to set up a Layer0 envrionment and deploy AWS resources with Terraform:
+
+|Filename|Purpose|
+|----|----|
+|[terraform.tfvars](https://github.com/quintilesims/layer0-examples/blob/master/guestbook-db/terraform.tfvars)|Variables specific to the environment and guestbook application|
+|[Dockerrun.aws.json](https://github.com/quintilesims/layer0-examples/blob/master/guestbook-db/Dockerrun.aws.json)|Template for running the guestbook application in a Layer0 environment|
+|[layer0.tf](https://github.com/quintilesims/layer0-examples/blob/master/guestbook-db/layer0.tf)|Provision Layer0 resources|
+
+## Part 2: Terraform Plan
+Before deploying, we can run the follwing command to see what changes Terraform will make to your infrastructure should you go ahead and apply. If you had any errors in your layer0.tf file, running `terraform plan` would output those errors so that you can address them.
+
+<ul>
+  <li class="command">terraform plan</li>
+</ul>
+
+```
++ aws_dynamodb_table.guestbook
+    arn:                       "<computed>"
+    attribute.#:               "1"
+    attribute.4228504427.name: "id"
+    attribute.4228504427.type: "S"
+    hash_key:                  "id"
+    name:                      "guestbook"
+    read_capacity:             "20"
+    stream_arn:                "<computed>"
+    stream_enabled:            "<computed>"
+    stream_view_type:          "<computed>"
+    write_capacity:            "20"
+
+...
+```
+
+## Part 3: Terraform Apply
+Run the follwing command to begin the deploy process. Terraform will prompt you for configuration values that it does not have.
+
+<ul>
+  <li class="command">terraform apply</li>
+</ul>
+
+_To avoid entering these values manually each time you run terraform, you can set the terraform variables by editing the `terraform.tfvars` file._
+
+```
+var.endpoint
+  Enter a value: <enter your Layer0 endpoint>
+
+var.token
+  Enter a value: <enter your Layer0 token>
+
+layer0_environment.demo: Refreshing state...
+...
+...
+...
+layer0_service.guestbook: Creation complete
+
+Apply complete! Resources: 7 added, 0 changed, 0 destroyed.
+
+The state of your infrastructure has been saved to the path
+below. This state is required to modify and destroy your
+infrastructure, so keep it safe. To inspect the complete state
+use the `terraform show` command.
+
+State path: terraform.tfstate
+
+Outputs:
+
+guestbook_url = <http endpoint for the sample application>
+```
+
+__It may take a few minutes for the guestbook service to launch and the load balancer to become available. During that time you may get HTTP 503 errors when making HTTP requests against the load balancer URL.__
+
+Terraform will set up the entire environment for you and then output a link to the application's load balancer.
+
+### What's happening
+Terraform using the AWS provider, provisions a new DynamoDb Table (with the name you have configured) and configures environment variables for the layer0 application to use the newly provisioned table, and deploys the application into a Layer0 environment using the Layer0 provider.
+
+Looking at excerpt of [layer0.tf](https://github.com/quintilesims/layer0-examples/blob/master/guestbook-db/layer0.tf) file, we can see the following definitions:
+
+```
+resource "aws_dynamodb_table" "guestbook" {
+  name           = "${var.table_name}"
+  read_capacity  = 20
+  write_capacity = 20
+  hash_key       = "id"
+
+  attribute {
+    name = "id"
+    type = "S"
+  }
+}
+
+resource "layer0_deploy" "guestbook" {
+  name    = "guestbook"
+  content = "${data.template_file.guestbook.rendered}"
+}
+
+data "template_file" "guestbook" {
+  template = "${file("Dockerrun.aws.json")}"
+
+  vars {
+    access_key = "${var.access_key}"
+    secret_key = "${var.secret_key}"
+    region     = "${var.region}"
+    table_name = "${aws_dynamodb_table.guestbook.name}"
+  }
+}
+```
+
+Note the resources definitions for `aws_dynamodb_table` and `layer0_deploy`. To configure the guestbook application to use the provisioned dynamodb table, we reference the `name` property from the dynamodb definition `table_name = "${aws_dynamodb_table.guestbook.name}"`. 
+
+This is then used to populate the template fields in our [Dockerrun.aws.json](https://github.com/quintilesims/layer0-examples/blob/master/guestbook-db/Dockerrun.aws.json) file. 
+
+```
+{
+    "AWSEBDockerrunVersion": 2,
+    "containerDefinitions": [
+        {
+            "name": "guestbook",
+            "image": "quintilesims/guestbook-db",
+            "essential": true,
+            "memory": 128,
+            "environment": [
+                {
+                    "name": "DYNAMO_TABLE",
+                    "value": "${table_name}"
+                }
+                ...
+```
+
+The Layer0 configuration referencing the Aws DynamoDb configuration `table_name = "${aws_dynamodb_table.guestbook.name}"`, infers an implicit dependency. Before Terraform creates the infrastructre, it will use this information to order the resources created and also create resources in parallel where there are no dependencies. In this example, the AWS DynamoDb table will be created before the Layer0 deploy. See [Terraform Dependencies](https://www.terraform.io/intro/getting-started/dependencies.html) for more information.
+
+## Part 4: Terraform Destroy
+When you're finished with the example run the following command in the same directory to destroy the Layer0 environment, application and the DynamoDb Table.
+
+<ul>
+  <li class="command">terraform destroy</li>
+</ul>

--- a/docs-src/docs/guides/terraform_beyond_layer0.md
+++ b/docs-src/docs/guides/terraform_beyond_layer0.md
@@ -104,7 +104,7 @@ Terraform using the [AWS provider](https://www.terraform.io/docs/providers/aws/i
 Looking at an excerpt of the file [./terraform-beyond-layer0/example-1/modules/guestbook_service/main.tf](https://github.com/quintilesims/layer0-examples/blob/master/terraform-beyond-layer0/example-1/modules/guestbook_service/main.tf), we can see the following definitions:
 
 ```
-resource "aws_DynamoDB_table" "guestbook" {
+resource "aws_dynamodb_table" "guestbook" {
   name           = "${var.table_name}"
   read_capacity  = 20
   write_capacity = 20
@@ -351,19 +351,19 @@ For example
 
 ```
 variable "environments" {
-  type = "map"
+  type = "list"
 
-  default = {
-    "0" = "dev"
-    "1" = "staging"
-    "2" = "production"
-  }
-} 
+  default = [
+    "dev",
+    "staging"
+    "production"
+  ]
+}
 
 resource "layer0_environment" "demo" {
   count = "${length(var.environments)}"
 
-  name = "${lookup(var.environments, count.index)}_demo"
+  name = "${var.environments[count.index]}_demo"
 }
 ```
 
@@ -410,7 +410,7 @@ resource "layer0_service" "guestbook" {
   environment   = "${element(layer0_environment.demo.*.id, count.index)}"
   deploy        = "${element(layer0_deploy.guestbook.*.id, count.index)}"
   load_balancer = "${element(layer0_load_balancer.guestbook.*.id, count.index)}"
-  scale         = "${lookup(var.service_scale, lookup(var.environments, count.index), "1")}"
+  scale         = scale         = "${lookup(var.service_scale, var.environments[count.index]), "1")}"
 }
 ```
 

--- a/docs-src/docs/guides/terraform_beyond_layer0.md
+++ b/docs-src/docs/guides/terraform_beyond_layer0.md
@@ -20,11 +20,9 @@ Using Terraform, you will deploy a simple guestbook application, which is backed
 ## Part 1: Clone the Layer0 examples repository
 Run this command to clone the `quintilesims/layer0-examples` repository
 
-<ul>
-  <li class="command">git clone https://github.com/quintilesims/layer0-examples.git</li>
-</ul>
+`git clone https://github.com/quintilesims/layer0-examples.git`  
 
-Inside a terminal window, navigate to the `terraform-beyond-layer0 folder`. You should find the following files once you are in the folder. We use these files to set up a Layer0 envrionment and deploy AWS resources with Terraform:
+Inside a terminal window, navigate to the `terraform-beyond-layer0 folder`. You should find the following files once you are in the folder. We use these files to set up a Layer0 environment and deploy AWS resources with Terraform:
 
 |Filename|Purpose|
 |----|----|

--- a/docs-src/docs/guides/terraform_beyond_layer0.md
+++ b/docs-src/docs/guides/terraform_beyond_layer0.md
@@ -2,7 +2,7 @@
  In this example, we'll learn how you can use Terraform to create a Layer0 service as well as a persistent data store. The main goal of this example is to explore how you can combine Layer0 with other Terraform providers.
 
 ## Before you start
-In order to complete the procedures in this section, you must have the following installed and configured correctly:
+To complete the procedures in this section, you must have the following installed and configured correctly:
 
  * Layer0 v0.8.4 or later
  * Terraform v0.9.0 or later
@@ -15,28 +15,24 @@ See the [Terraform installation guide](/reference/terraform-plugin#install) to i
 ---
 
 ## Deploy with Terraform
-Using Terraform, you will deploy a simple guestbook application, which is backed by AWS DynamoDB Table, for persistant storage. The terraform configuration file will use both the Layer0 and AWS Terraform providers, to deploy the guestbook application and provision a new DynamoDB Table.
+Using Terraform, you will deploy a simple guestbook application, which is backed by AWS DynamoDB Table, for persistent storage. The terraform configuration file will use both the Layer0 and AWS Terraform providers, to deploy the guestbook application and provision a new DynamoDB Table.
 
 ## Part 1: Clone the Layer0 examples repository
 Run this command to clone the `quintilesims/layer0-examples` repository
 
 `git clone https://github.com/quintilesims/layer0-examples.git`  
 
-Inside a terminal window, navigate to the `terraform-beyond-layer0 folder`. You should find the following files once you are in the folder. We use these files to set up a Layer0 environment and deploy AWS resources with Terraform:
-
-|Filename|Purpose|
-|----|----|
-|[terraform.tfvars](https://github.com/quintilesims/layer0-examples/blob/master/terraform-beyond-layer0/terraform.tfvars)|Variables specific to the environment and guestbook application|
-|[Dockerrun.aws.json](https://github.com/quintilesims/layer0-examples/blob/master/terraform-beyond-layer0/Dockerrun.aws.json)|Template for running the guestbook application in a Layer0 environment|
-|[layer0.tf](https://github.com/quintilesims/layer0-examples/blob/master/terraform-beyond-layer0/layer0.tf)|Provision Layer0 resources and AWS resources|
-
 ## Part 2: Terraform Plan
-Before deploying, we can run the follwing command to see what changes Terraform will make to your infrastructure should you go ahead and apply. If you had any errors in your layer0.tf file, running `terraform plan` would output those errors so that you can address them. Also, Terraform will prompt you for configuration values that it does not have.
+As we're using modules in our Terraform configuration we need to run `terraform get` before performing other terraform operations. Running get will download the modules to your local folder named `.terraform`. See here for more information on [terraform get](https://www.terraform.io/docs/commands/get.html).
+
+`terraform get`
+
+Before deploying, we can run the following command to see what changes Terraform will make to your infrastructure should you go ahead and apply. If you had any errors in your layer0.tf file, running `terraform plan` would output those errors so that you can address them. Also, Terraform will prompt you for configuration values that it does not have.
 
 `terraform plan`
 
 !!! Note
-	There are a few ways to configure Terraform so that you don't have to keep entering these values every time you run a Terraform command (editing the `terraform.tfvars` file, or exporting evironment variables like `TF_VAR_endpoint` and `TF_VAR_token`, for example). See the [Terraform Docs](https://www.terraform.io/docs/configuration/variables.html) for more.
+  There are a few ways to configure Terraform so that you don't have to keep entering these values every time you run a Terraform command (editing the `terraform.tfvars` file, or exporting environment variables like `TF_VAR_endpoint` and `TF_VAR_token`, for example). See the [Terraform Docs](https://www.terraform.io/docs/configuration/variables.html) for more.
 
 ```
 var.endpoint
@@ -88,7 +84,7 @@ guestbook_url = <http endpoint for the sample application>
 ```
 
 !!! Note
-	It may take a few minutes for the guestbook service to launch and the load balancer to become available. During that time you may get HTTP 503 errors when making HTTP requests against the load balancer URL.
+  It may take a few minutes for the guestbook service to launch and the load balancer to become available. During that time, you may get HTTP 503 errors when making HTTP requests against the load balancer URL.
 
 Terraform will set up the entire environment for you and then output a link to the application's load balancer.
 
@@ -148,16 +144,15 @@ This is then used to populate the template fields in our [Dockerrun.aws.json](ht
                 ...
 ```
 
-The Layer0 configuration referencing the AWS DynamoDB configuration `table_name = "${aws_DynamoDB_table.guestbook.name}"`, infers an implicit dependency. Before Terraform creates the infrastructre, it will use this information to order the resources created and also create resources in parallel where there are no dependencies. In this example, the AWS DynamoDB table will be created before the Layer0 deploy. See [Terraform Dependencies](https://www.terraform.io/intro/getting-started/dependencies.html) for more information.
+The Layer0 configuration referencing the AWS DynamoDB configuration `table_name = "${aws_DynamoDB_table.guestbook.name}"`, infers an implicit dependency. Before Terraform creates the infrastructure, it will use this information to order the resources created and create resources in parallel where there are no dependencies. In this example, the AWS DynamoDB table will be created before the Layer0 deploy. See [Terraform Dependencies](https://www.terraform.io/intro/getting-started/dependencies.html) for more information.
 
 ## Part 4: Scaling a Layer0 Service
 The workflow to make changes to your infrastructure generally involves updating your Terraform configuration file followed by a `terraform plan` and `terraform apply`.
 
 ### Update the Terraform configuration
-Open the file `layer0.tf` in a text editor and make the change to add a `scale` property with a value of `3` to the `layer0_service` section. For more information about the `scale` property, see [Layer0 Terraform Plugin](http://layer0.ims.io/reference/terraform-plugin/#service) documenation. The end result should look like the below:
+Open the file `main.tf` in a text editor and make the change to add a `scale` property with a value of `3` to the `layer0_service` section. For more information about the `scale` property, see [Layer0 Terraform Plugin](http://layer0.ims.io/reference/terraform-plugin/#service) documentation. The result should look like the below:
 
-
-layer0.tf
+example-1/modules/guestbook_service/main.tf
 
 ```
 # Create a service named "guestbook"
@@ -171,8 +166,8 @@ resource "layer0_service" "guestbook" {
 
 ```
 
-### Plan and Apply
-Once you have updated the following command to understand the changes that you will be making. Note that if you did not specify `scale` it defaults to '1'.
+### Get, Plan and Apply
+As you're updating Terraform configuration in a module, you'll need to run `terraform get` to update the copy of the module in `.terraform`. Once you have done so, execute the following command to understand the changes that you will be making. Note that if you did not specify `scale` it defaults to '1'.
 
 `terraform plan`
 
@@ -227,9 +222,8 @@ api           api           api          api           api:3        1/1
 guestboebca1  guestbook     demo-env     guestbook     guestbook:6  3/3
 ```
 
-
 !!! Tip "Best Practices with Terraform + Layer0"
-	The following sections outline some of the best practices and tips to take into consideration, when using Layer0 with Terraform.
+  The following sections outline some of the best practices and tips to take into consideration, when using Layer0 with Terraform.
 
 ## Part 5: Terraform Remote State
 
@@ -238,12 +232,12 @@ Terraform stores the state of the deployed infrastructure in a local file named 
 How state is loaded and used for operations such as `terraform apply` is determined by a [Backend](https://www.terraform.io/docs/backends). As mentioned, by default the state is stored locally which is enabled by a "local" backend.
 
 ### Remote State
-In scenarios where you are working as part of a team to provision and manage a services deployed by Terraform, all the members of the team will need access to the state file to apply new changes. You would also want resiliency against losing the state file. You can cater for provisioning and managing Terraform in a team environment and providing redundancy for the state file by using a remote backend. A remote backend can also provide locking mehcanisms to ensure multiple users can't change resources at the same time. Backends such as [Consul](https://www.terraform.io/docs/backends/types/consul.html) & [S3](https://www.terraform.io/docs/backends/types/s3.html) among others, are backends that you can use to store master Terraform state in a remote location.
+In scenarios where you are working as part of a team to provision and manage services deployed by Terraform, all the members of the team will need access to the state file to apply new changes. You would also want resiliency against losing the state file. You can cater for provisioning and managing Terraform in a team environment and providing redundancy for the state file by using a remote backend. A remote backend can also provide locking mechanisms to ensure multiple users can't change resources at the same time. Backends such as [Consul](https://www.terraform.io/docs/backends/types/consul.html) & [S3](https://www.terraform.io/docs/backends/types/s3.html) among others, are backends that you can use to store master Terraform state in a remote location.
 
 To configure a remote backend, append the `terraform` section below to your terraform file `layer0.tf`. Update the `path` property to a GUID to avoid a potential conflict as demo.consul.io is a public consul endpoint.
 
 !!! Tip
-	If you have been following along with the guide, layer0.tf should already have the below section commented out. You can simply uncomment the `terraform` section and populate the properties with the appropriate values.
+  If you have been following along with the guide, layer0.tf should already have the below section commented out. You can simply uncomment the `terraform` section and populate the properties with the appropriate values.
 
 ```
 terraform {
@@ -255,7 +249,7 @@ terraform {
 }
 ```
 
-Once you have modified `layer0.tf`, you will need to initailize the newly configured backend by running the following command.
+Once you have modified `layer0.tf`, you will need to initialize the newly configured backend by running the following command.
 
 `terraform init`
 
@@ -294,19 +288,18 @@ A new team member can use the `layer0.tf` from their own machine without obtaini
 Not all remote backends support locking (locking ensures only one person is able to change the state at a time). The `S3` backend we used earlier in the example also supports locking which is disabled by default. To enable locking, you need to specify `locking_table` property with the name of an existing DynamoDB table. The DynamoDB table also needs primary key named `LockID` of type `String`.
 
 ### Security
-A Terraform state file is written in plain text. This can lead to a situation where deploying resources that require sensitive data can result in the sensitive data being stored in the state file. To minimize exposure of senstive data, you can enable [server side encryption](https://docs.aws.amazon.com/AmazonS3/latest/dev/UsingServerSideEncryption.html) of the state file by adding property `encrypt` set to `true`.
+A Terraform state file is written in plain text. This can lead to a situation where deploying resources that require sensitive data can result in the sensitive data being stored in the state file. To minimize exposure of sensitive data, you can enable [server side encryption](https://docs.aws.amazon.com/AmazonS3/latest/dev/UsingServerSideEncryption.html) of the state file by adding property `encrypt` set to `true`.
 
 This will ensure that the file is encrypted in S3 and by using a remote backend, you will also have the added benefit of the state file not being persisted to disk locally as it will only ever be held in memory by Terraform.
 
 For securing the state file further, you can also enable access logging on the S3 bucket you are using for the remote backend which can help track down invalid access should it occur.
 
-
 ## Part 6: Terraform Configuration Structure
 
-There are many different approaches to setup your Terraform code structure. There is no single best precribed way to structure your infrastructure code. Whatever approach you take needs to be catered for the needs of your particular project. Keeping that in mind; the file structure for [Terraform beyond Layer0 example](https://github.com/quintilesims/layer0-examples/blob/master/terraform-beyond-layer0) is as below:
+There are many different approaches to setup your Terraform code structure. There is no single best prescribed way to structure your infrastructure code. Whatever approach you take needs to be catered for the needs of your particular project. Keeping that in mind; the file structure for [Terraform beyond Layer0 example](https://github.com/quintilesims/layer0-examples/blob/master/terraform-beyond-layer0/example-1) is as below:
 
 ```
-root/
+example1/
   ─ main.tf  
   ─ variables.tf  
   ─ output.tf  
@@ -354,8 +347,115 @@ Also see the below repositories for ideas on different ways you can organize you
 * [Terraform Community Modules](https://github.com/terraform-community-modules)
 * [Best Pratices Ops](https://github.com/hashicorp/best-practices)
 
+## Part 7: State Environments
+Layer0 recommends that you typically make a single environment for each tier of your application, such as `dev`, `staging` and `production`. That recommendation still holds when using Terraform with Layer0. Using Layer0 CLI, you can target a specific environment most commands. This enables you to service each tier relatively easily. In Terraform, there a few approaches you can take to enable a similar workflow.
 
-## Part 7: Multiple Provider Instances
+### Single Terraform Configuration
+You can use a single set of Terraform configuration to create and maintain multiple environments by making use of the [Count](https://www.terraform.io/docs/configuration/resources.html#count) parameter of a Resource. Count enables you to create multiple copies of a given resource. 
+
+For example
+
+```
+variable "environments" {
+  type = "map"
+
+  default = {
+    "0" = "dev"
+    "1" = "staging"
+    "2" = "production"
+  }
+} 
+
+resource "layer0_environment" "demo" {
+  count = "${length(var.environments)}"
+
+  name = "${lookup(var.environments, count.index)}_demo"
+}
+```
+
+Let's have a more in-depth look in how this works. You can start buy navigating to `./terraform-beyond-layer0/example-2' folder. Start by running the plan command:
+
+`terraform plan`
+
+Outputs:
+```
++ module.environment.aws_dynamodb_table.guestbook.0
+    ...
+    name:                      "dev_guestbook"
+...
++ module.environment.aws_dynamodb_table.guestbook.1
+    ..
+    name:                      "staging_guestbook"
+...
+```
+
+Note that you will a copy of each resource for each environment specified in your environments file in `variables.tf`. Go ahead and run apply.
+
+`terraform apply`
+
+Outputs:
+```
+Apply complete! Resources: 10 added, 0 changed, 0 destroyed.
+
+Outputs:
+
+guestbook_urls = 
+<dev_url>
+<staging_url>
+```
+
+You have now created two separate environments using a single terraform configuration: dev & staging. You can navigate to the two urls output and you should note that they are separate instances of the guestbook application backed with their own separate data store.
+
+A common use case for maintaining different environments is configure each environment slightly differently. For example, might want to scale your Layer0 service to 3 (defaults to 1) for staging and leave it as 1 for the dev environment. This can be done easily by using conditional logic to set our `scale` parameter the layer0 service configuration in `main.tf`. Go ahead and open `main.tf` in a text editor. Navigate to the `layer0_service guestbook` section. Uncomment the scale parameter so that your configuration looks like below.
+
+```
+resource "layer0_service" "guestbook" {
+  count = "${length(var.environments)}"
+
+  name          = "${element(layer0_environment.demo.*.name, count.index)}_guestbook_svc"
+  environment   = "${element(layer0_environment.demo.*.id, count.index)}"
+  deploy        = "${element(layer0_deploy.guestbook.*.id, count.index)}"
+  load_balancer = "${element(layer0_load_balancer.guestbook.*.id, count.index)}"
+  scale         = "${lookup(var.service_scale, lookup(var.environments, count.index), "1")}"
+}
+```
+
+The reference to the variable `service_scale` is already defined in `variables.tf`. If you now go ahead and run plan, you will see that the `guestbook` service for only the `staging` environment will be scaled up.
+
+`terraform plan`
+
+Outputs:
+
+```
+~ layer0_service.guestbook.1
+    scale: "1" => "3"
+```
+
+The downside of this approach however is that all your environments are using the same state file. Ideally you would want each environment to be completely isolated from other environments. Sharing a state file breaks some of this encapsulation. Should there ever be a situation where your state file becomes corrupt, it would affect your ability to service all the environments till you resolve the issue by potentially rolling back to a previous copy of the state file.
+
+### Multiple Terraform Configurations
+The previous example used a single set of Terraform Configuration files which to create and maintain multiple environments. This resulted in a single state file which had the state information for all the environments. Another approach you can take to increase encapsulation of the state file is to have a unique state file for each environment tier of your application.
+
+Go ahead and navigate to `./terraform-beyond-layer0/example-3` folder. Here we are using a folder to separate each environment. So `env-dev` and `env-staging` represent a `dev` and `staging` environment. To work with either of the environments, you will need to navigate into the desired environment's folder and run Terraform commands. This will ensure that each environment will have its own state file.
+
+Open the env-dev folder inside a text editor. Note that `main.tf` doesn't contain any resource definitions. Instead, we only have one module definition which has various variables being passed in, which is also how we are passing in the `environment` variable. To create a `dev` and `staging` environments for our guestbook application, go ahead and run terraform plan and apply commands from `env-dev` and `env-staging` folders.
+
+```
+# assuming you are in the terraform-beyond-layer0/example3 folder
+cd env-dev
+terraform get
+terraform plan
+terraform apply
+
+cd ../env-staging
+terraform get
+terraform plan
+terraform apply
+```
+
+You should now have two instance of the guestbook application running. Note that our guestbook service in our staging environment has been scaled to 3. We have done this by specifying a map variable `service_scale` in `./example-3/dev-staging/variables.tf` which has scale values for each environment.
+
+## Part 8: Multiple Provider Instances
 
 You can define multiple instances of the same provider to enable uniquely customized providers. For example, you can have an `aws` provider to support multiple regions, different roles etc or in the case of the `layer0` provider, to support multiple layer0 endpoints.
 
@@ -389,11 +489,18 @@ resource "aws.west_instance" "bar" {
 }
 ```
 
-## Part 8: Terraform Destroy
+## Part 9: Cleanup
 
-When you're finished with the example run the following command in the same directory to destroy the Layer0 environment, application and the DynamoDB Table.
+When you're finished with the examples in this guide, run the following destroy command in all the following directories to destroy the Layer0 environment, application and the DynamoDB Table.
+
+Directories:  
+
+ * /example-1  
+ * /example-2  
+ * /example-3/env-dev  
+ * /example-3/env-staging  
 
 `terraform destroy`
 
 !!! tip "Remote Backend Resources"
-	If you created additional resources (S3 bucket and a DynamoDB Table) separately when configuring a [Remote Backend](#part-5-terraform-remote-state), do not forget to delete those if they are no longer needed. You should be able to look at your Terraform configuration file `layer0.tf` to determine the name of the bucket and table.
+  If you created additional resources (S3 bucket and a DynamoDB Table) separately when configuring a [Remote Backend](#part-5-terraform-remote-state), do not forget to delete those if they are no longer needed. You should be able to look at your Terraform configuration file `layer0.tf` to determine the name of the bucket and table.

--- a/docs-src/docs/guides/terraform_beyond_layer0.md
+++ b/docs-src/docs/guides/terraform_beyond_layer0.md
@@ -1,4 +1,4 @@
-# Deployment guide: Guestbook sample application
+# Deployment guide: Terraform beyond Layer0
 In this example, you will learn how you can use Terraform to create a Layer0 service as well as supporting infrastructure in the form of a persistent data store. This example does not cover the details of the application being deployed but focuses on how you can combine Layer0 and other Terraform providers as part of a Terraform workflow.
 
 ## Before you start
@@ -150,7 +150,180 @@ This is then used to populate the template fields in our [Dockerrun.aws.json](ht
 
 The Layer0 configuration referencing the AWS DynamoDB configuration `table_name = "${aws_DynamoDB_table.guestbook.name}"`, infers an implicit dependency. Before Terraform creates the infrastructre, it will use this information to order the resources created and also create resources in parallel where there are no dependencies. In this example, the AWS DynamoDB table will be created before the Layer0 deploy. See [Terraform Dependencies](https://www.terraform.io/intro/getting-started/dependencies.html) for more information.
 
-## Part 4: Terraform Destroy
+## Part 4: Terraform Remote State
+
+Terraform stores the state of the deployed infrastructure in a local file named `terraform.tfstate` by default. This includes not only information about the resources deployed but also metadata such as resource dependencies. To find out more about why Terraform needs to store state see [Purpose of Terraform State](https://www.terraform.io/docs/state/purpose.html). 
+
+How state is loaded and used for operations such as `terraform apply` is determined by a [Backend](https://www.terraform.io/docs/backends). As mentioned, by default the state is stored locally which is enabled by a "local" backend.
+
+### Remote State
+In scenarios where you are working as part of a team to provision and manage a services deployed by Terraform, all the members of the team will need access to the state file to apply new changes. You would also want resiliency against losing the state file. You can cater for provisioning and managing Terraform in a team environment and providing redundancy for the state file by using a remote backend. Backends such as [Consul](https://www.terraform.io/docs/backends/types/consul.html) & [S3](https://www.terraform.io/docs/backends/types/s3.html) among others, are backends that you can use to store master Terraform state in a remote location.
+
+To configure a remote backend, append the `terraform` section below to your terraform file `layer0.tf`. Update the `path` property to a GUID to avoid a potential conflict as demo.consul.io is a public consul endpoint.
+
+```
+terraform {
+  backend "consul" {
+    address = "demo.consul.io"
+    path    = "a-unique-random-string"
+    lock    = false
+  }
+}
+```
+
+Once you have modified `layer0.tf`, you will need to initailize the newly configured backend by running the following command.
+
+`terraform init`
+
+Outputs:
+
+```
+Initializing the backend...
+
+Do you want to copy state from "local" to "consul"?
+  Pre-existing state was found in "local" while migrating to "consul". An existing
+  non-empty state exists in "consul". The two states have been saved to temporary
+  files that will be removed after responding to this query.
+  
+  One ("local"): /var/folders/n0/19h9crxn2v75g70bl0txdj1wm05615/T/terraform529524247/1-local.tfstate
+  Two ("consul"): /var/folders/n0/19h9crxn2v75g70bl0txdj1wm05615/T/terraform529524247/2-consul.tfstate
+  
+  Do you want to copy the state from "local" to "consul"? Enter "yes" to copy
+  and "no" to start with the existing state in "consul".
+
+  Enter a value: 
+
+```
+
+Go ahead and enter: `yes`.
+
+```
+
+Successfully configured the backend "consul"! Terraform will automatically
+use this backend unless the backend configuration changes.
+
+Terraform has been successfully initialized!
+
+You may now begin working with Terraform. Try running "terraform plan" to see
+any changes that are required for your infrastructure. All Terraform commands
+should now work.
+
+If you ever set or change modules or backend configuration for Terraform,
+rerun this command to reinitialize your environment. If you forget, other
+commands will detect it and remind you to do so if necessary.
+
+```
+
+### What's happening
+As you are configuring a backend for the first time, Terraform will give you an option to migrate your state to the new backend. From now on, any further changes to your infrastructure made by Terraform will result in the remote state file being updated. For more information about see (Terraform backends)[https://www.terraform.io/docs/backends/index.html].
+
+A new team member can use the `layer0.tf` from their own machine without obtaining a copy of the state file `terraform.tfstate` as the configuration points to a remote backend where the state file will be retrieved from.
+
+The command `terraform init` must be called:
+ * on any new environment that configures a backend
+ * on any change of the backend configuration (including type of backend)
+ * on removing backend configuration completely
+
+## Part 5: Scaling a Layer0 service
+The workflow to make changes to your infrastructure generally involves updating your Terraform configuration file followed by a `terraform plan` and `terraform apply`.
+
+### Update the Terraform configuration
+Open the file `layer0.tf` in a text editor and make the change to add a `scale` property with a value of `3` to the `layer0_service` section. For more information about the `scale` property, see [Layer0 Terraform Plugin](http://layer0.ims.io/reference/terraform-plugin/#service) documenation. The end result should look like the below:
+
+
+layer0.tf
+
+```
+# Create a service named "guestbook"
+resource "layer0_service" "guestbook" {
+  name          = "guestbook"
+  environment   = "${layer0_environment.demo.id}"
+  deploy        = "${layer0_deploy.guestbook.id}"
+  load_balancer = "${layer0_load_balancer.guestbook.id}"
+  scale         = 3
+}
+
+```
+
+### Plan and Apply
+Once you have updated the following command to understand the changes that you will be making. Note that if you did not specify `scale` it defaults to '1'.
+
+`terraform plan`
+
+Outputs:
+
+```
+Refreshing Terraform state in-memory prior to plan...
+The refreshed state will be used to calculate this plan, but will not be
+persisted to local or remote state storage.
+
+layer0_environment.demo: Refreshing state... (ID: demoenvbb9f6)
+data.template_file.guestbook: Refreshing state...
+layer0_deploy.guestbook: Refreshing state... (ID: guestbook.6)
+layer0_load_balancer.guestbook: Refreshing state... (ID: guestbo43ab0)
+layer0_service.guestbook: Refreshing state... (ID: guestboebca1)
+The Terraform execution plan has been generated and is shown below.
+Resources are shown in alphabetical order for quick scanning. Green resources
+will be created (or destroyed and then created if an existing resource
+exists), yellow resources are being changed in-place, and red resources
+will be destroyed. Cyan entries are data sources to be read.
+
+Note: You didn't specify an "-out" parameter to save this plan, so when
+"apply" is called, Terraform can't guarantee this is what will execute.
+
+~ layer0_service.guestbook
+    scale: "1" => "3"
+```
+
+Now run the following command to deploy your changes:
+
+`terraform apply`
+
+Outputs:
+
+```
+layer0_environment.demo: Refreshing state... (ID: demoenvbb9f6)
+data.template_file.guestbook: Refreshing state...
+layer0_deploy.guestbook: Refreshing state... (ID: guestbook.6)
+layer0_load_balancer.guestbook: Refreshing state... (ID: guestbo43ab0)
+layer0_service.guestbook: Refreshing state... (ID: guestboebca1)
+layer0_service.guestbook: Modifying... (ID: guestboebca1)
+  scale: "1" => "3"
+layer0_service.guestbook: Modifications complete (ID: guestboebca1)
+
+Apply complete! Resources: 0 added, 1 changed, 0 destroyed.
+
+The state of your infrastructure has been saved to the path
+below. This state is required to modify and destroy your
+infrastructure, so keep it safe. To inspect the complete state
+use the `terraform show` command.
+
+State path: 
+
+Outputs:
+
+guestbook_url = <guestbook_service_url>
+```
+
+To confirm your service has scaled, you can run the following layer0 command. Note desired scale for the guestbook service should be eventually be 3/3.
+
+`l0 service get \*`
+
+Outputs:
+
+```
+SERVICE ID    SERVICE NAME  ENVIRONMENT  LOADBALANCER  DEPLOYMENTS  SCALE
+api           api           api          api           api:3        1/1
+guestboebca1  guestbook     demo-env     guestbook     guestbook:6  3/3
+```
+
+
+
+## Part 6: Terraform Destroy
 When you're finished with the example run the following command in the same directory to destroy the Layer0 environment, application and the DynamoDB Table.
 
 `terraform destroy`
+
+## Best Practices with Terraform + Layer0
+
+

--- a/docs-src/docs/guides/terraform_beyond_layer0.md
+++ b/docs-src/docs/guides/terraform_beyond_layer0.md
@@ -222,7 +222,7 @@ Outputs:
 services = <guestbook_service_url>
 ```
 
-To confirm your service has been updated to the desired scale, you can run the following layer0 command. Note desired scale for the guestbook service should be eventually be 3/3.
+To confirm your service has been updated to the desired scale, you can run the following layer0 command. Note that the desired scale for the guestbook service should be eventually be 3/3.
 
 `l0 service get guestbook1_guestbook_svc`
 
@@ -234,7 +234,7 @@ SERVICE ID    SERVICE NAME              ENVIRONMENT  LOADBALANCER             DE
 guestbo4fd3b  guestbook1_guestbook_svc  demo         guestbook1_guestbook_lb  guestbook1_guestbook_dpl:3*  1/3 (2)
 ```
 
-As scale is parameter we are likely to change in the future, rather than hardcoding it to 3 as we have done just now, it would be better to use a variable to store  `service_scale`. The following Best Practices sections will show how you can achieve this.
+As scale is a parameter we are likely to change in the future, rather than hardcoding it to 3 as we have done just now, it would be better to use a variable to store  `service_scale`. The following Best Practices sections will show how you can achieve this.
 
 !!! Note "Best Practices with Terraform + Layer0"
 	The following sections outline some of the best practices and tips to take into consideration, when using Layer0 with Terraform.
@@ -332,7 +332,7 @@ example1/
 
 Here we are making use of Terraform [Modules](https://www.terraform.io/docs/modules/index.html). Modules in Terraform are self-contained packages of Terraform configurations, that are managed as a group. Modules are used to create reusable components in Terraform as well as for basic code organization. In this example, we are using modules to separate each service and making it consumable as a module.
 
-If you wanted to add a new service, you can create new folder service folder inside the ./modules. If you wanted to you could even run multiple copies of the same service. See here for more information about [Creating Modules](https://www.terraform.io/docs/modules/create.html).
+If you wanted to add a new service, you can create a new service folder inside the ./modules. If you wanted to you could even run multiple copies of the same service. See here for more information about [Creating Modules](https://www.terraform.io/docs/modules/create.html).
 
 When creating a module, ensure that resources you are creating are prefixed with the environment and the module's name variable to ensure your resources are unique for each layer0 environment and each reference to a module.
 
@@ -414,7 +414,7 @@ Outputs:
 ...
 ```
 
-Note that you will a copy of each resource for each environment specified in your environments file in `./example-2/variables.tf`. Go ahead and run apply.
+Note that you will see a copy of each resource for each environment specified in your environments file in `./example-2/variables.tf`. Go ahead and run apply.
 
 `terraform apply`
 
@@ -431,7 +431,7 @@ guestbook_urls =
 
 You have now created two separate environments using a single terraform configuration: dev & staging. You can navigate to both the urls output and you should note that they are separate instances of the guestbook application backed with their own separate data store.
 
-A common use case for maintaining different environments is configure each environment slightly differently. For example, might want to scale your Layer0 service to 3 for staging and leave it as 1 for the dev environment. This can be done easily by using conditional logic to set our `scale` parameter in the layer0 service configuration in `./example-2/main.tf`. Go ahead and open `main.tf` in a text editor. Navigate to the `layer0_service guestbook` section. Uncomment the scale parameter so that your configuration looks like below.
+A common use case for maintaining different environments is to configure each environment slightly differently. For example, you might want to scale your Layer0 service to 3 for staging and leave it as 1 for the dev environment. This can be done easily by using conditional logic to set our `scale` parameter in the layer0 service configuration in `./example-2/main.tf`. Go ahead and open `main.tf` in a text editor. Navigate to the `layer0_service guestbook` section. Uncomment the scale parameter so that your configuration looks like below.
 
 ```
 resource "layer0_service" "guestbook" {
@@ -484,7 +484,7 @@ terraform plan
 terraform apply
 ```
 
-You should now have two instance of the guestbook application running. Note that our guestbook service in our staging environment has been scaled to 3. We have done this by specifying a map variable `service_scale` in `./example-3/dev-staging/variables.tf` which can have different scale values for each environment.
+You should now have two instances of the guestbook application running. Note that our guestbook service in our staging environment has been scaled to 3. We have done this by specifying a map variable `service_scale` in `./example-3/dev-staging/variables.tf` which can have different scale values for each environment.
 
 ## Part 8: Multiple Provider Instances
 
@@ -508,7 +508,7 @@ provider "aws" {
 }
 ```
 
-This will now allow you to reference aws providers configured to a different region. You can do so by referencing the provider using the naming scheme `TYPE.ALIAS`, which in the above example result in `aws.west`. See [Provider Configuration](https://www.terraform.io/docs/configuration/providers.html) for more information.
+This will now allow you to reference aws providers configured to a different region. You can do so by referencing the provider using the naming scheme `TYPE.ALIAS`, which in the above example results in `aws.west`. See [Provider Configuration](https://www.terraform.io/docs/configuration/providers.html) for more information.
 
 ```
 resource "aws.east_instance" "foo" {

--- a/docs-src/docs/guides/terraform_beyond_layer0.md
+++ b/docs-src/docs/guides/terraform_beyond_layer0.md
@@ -135,7 +135,7 @@ data "template_file" "guestbook" {
 
 Note the resource definitions for `aws_dynamodb_table` and `layer0_deploy`. To configure the guestbook application to use the provisioned DynamoDB table, we reference the `name` property from the DynamoDB definition `table_name = "${aws_dynamodb_table.guestbook.name}"`. 
 
-This is then used to populate the template fields in our [Dockerrun.aws.json](https://github.com/quintilesims/layer0-examples/blob/master/guestbook-db/Dockerrun.aws.json) file. 
+This is then used to populate the template fields in our [Dockerrun.aws.json](https://github.com/quintilesims/layer0-examples/blob/master/terraform-beyond-layer0/example-1/modules/guestbook_service/Dockerrun.aws.json) file. 
 
 ```
 {
@@ -333,37 +333,6 @@ example1/
 Here we are making use of Terraform [Modules](https://www.terraform.io/docs/modules/index.html). Modules in Terraform are self-contained packages of Terraform configurations, that are managed as a group. Modules are used to create reusable components in Terraform as well as for basic code organization. In this example, we are using modules to separate each service and making it consumable as a module.
 
 If you wanted to add a new service, you can create a new service folder inside the ./modules. If you wanted to you could even run multiple copies of the same service. See here for more information about [Creating Modules](https://www.terraform.io/docs/modules/create.html).
-
-When creating a module, ensure that resources you are creating are prefixed with the environment and the module's name variable to ensure your resources are unique for each layer0 environment and each reference to a module.
-
-For example
-
-```
-resource "layer0_load_balancer" "guestbook" {
-  name        = "${var.name}_guestbook_lb"
-  environment = "${var.layer0_environment_id}"
-
-  port {
-    host_port      = 80
-    container_port = 80
-    protocol       = "http"
-  }
-}
-
-# note we are prefixing with the environment name also to ensure there won't be conflicts
-# if multiple instance of this application were deployed
-resource "aws_dynamodb_table" "guestbook" {
-  name           = "${var.layer0_environment_name}_${var.name}_${var.table_name}"
-  read_capacity  = 20
-  write_capacity = 20
-  hash_key       = "id"
-
-  attribute {
-    name = "id"
-    type = "S"
-  }
-}
-```
 
 Also see the below repositories for ideas on different ways you can organize your Terraform configuration files for the needs of your specific project: 
 

--- a/docs-src/mkdocs.yml
+++ b/docs-src/mkdocs.yml
@@ -19,6 +19,7 @@ pages:
     - Destroy: setup/destroy.md
   - Guides:
     - An Iterative Walkthrough: guides/walkthrough.md
+    - Terraform beyond Layer0: guides/terraform_beyond_layer0.md
     - One-off Task: guides/one_off_task.md
   - Reference:
     - Layer0 CLI: reference/cli.md


### PR DESCRIPTION
Closes #173 & #174 

WIP: Note change to remove the default for table_name in the terraform file. I think having a default here would lead to the `terraform apply` failing due to a DynamoDb Table already existing; especially in a byoo environment where multiple team members could be running through the walkthrough at the same time or fail to clean up deployed resources.

I'm not sure how to style the commands. @tlake did mention that we're moving away from embedding html in the markdown files but I'm not sure what the desired style for commands is?

Also this requires a corresponding change in layer0-examples.