### PR TITLE
159 bulk task fix

### DIFF
--- a/api/backend/ecs/task_manager.go
+++ b/api/backend/ecs/task_manager.go
@@ -2,7 +2,6 @@ package ecsbackend
 
 import (
 	"fmt"
-	log "github.com/Sirupsen/logrus"
 	"github.com/quintilesims/layer0/api/backend"
 	"github.com/quintilesims/layer0/api/backend/ecs/id"
 	"github.com/quintilesims/layer0/common/aws/cloudwatchlogs"
@@ -138,7 +137,6 @@ func (this *ECSTaskManager) CreateTask(
 	environmentID string,
 	taskName string,
 	deployID string,
-	copies int,
 	overrides []models.ContainerOverride,
 ) (*models.Task, error) {
 	ecsEnvironmentID := id.L0EnvironmentID(environmentID).ECSEnvironmentID()
@@ -153,47 +151,16 @@ func (this *ECSTaskManager) CreateTask(
 		ecsOverrides = append(ecsOverrides, o)
 	}
 
-	return this.runTask(ecsEnvironmentID, ecsDeployID, ecsTaskID, copies, ecsOverrides)
-}
-
-func (this *ECSTaskManager) runTask(environmentID id.ECSEnvironmentID, deployID id.ECSDeployID, taskID id.ECSTaskID, copies int, overrides []*ecs.ContainerOverride) (*models.Task, error) {
-	tasks, failed, err := this.ECS.RunTask(environmentID.String(), deployID.TaskDefinition(), int64(copies), stringp(taskID.String()), overrides)
-	if numFailed := len(failed); numFailed > 0 {
-		partialFailure := &PartialCreateTaskFailure{
-			NumFailed: numFailed,
-			Retry: func() (*models.Task, error) {
-				return this.runTask(environmentID, deployID, taskID, numFailed, overrides)
-			},
-		}
-
-		// return tasks that started correctly if possible
-		if len(tasks) == 0 {
-			return nil, partialFailure
-		}
-
-		// don't return error here since we need to return the partial failure
-		model, err := modelFromTasks(tasks)
-		if err != nil {
-			log.Errorf("Failed to get models from tasks in %s: %v", taskID, err)
-		}
-
-		return model, partialFailure
-	}
-
+	tasks, failed, err := this.ECS.RunTask(ecsEnvironmentID.String(), ecsDeployID.TaskDefinition(), 1, stringp(ecsTaskID.String()), ecsOverrides)
 	if err != nil {
 		return nil, err
 	}
 
+	if len(failed) > 0 {
+		return nil, fmt.Errorf("ECS failed to start the task!")
+	}
+
 	return modelFromTasks(tasks)
-}
-
-type PartialCreateTaskFailure struct {
-	NumFailed int
-	Retry     func() (*models.Task, error)
-}
-
-func (p *PartialCreateTaskFailure) Error() string {
-	return fmt.Sprintf("Failed to start %d tasks", p.NumFailed)
 }
 
 func (this *ECSTaskManager) GetTaskLogs(environmentID, taskID string, tail int) ([]*models.LogFile, error) {

--- a/api/backend/ecs/task_manager_test.go
+++ b/api/backend/ecs/task_manager_test.go
@@ -248,7 +248,7 @@ func TestCreateTask(t *testing.T) {
 			},
 			Run: func(reporter *testutils.Reporter, target interface{}) {
 				manager := target.(*ECSTaskManager)
-				manager.CreateTask("envid", "tsk_name", "dplyid.1", 1, nil)
+				manager.CreateTask("envid", "tsk_name", "dplyid.1", nil)
 			},
 		},
 		testutils.TestCase{
@@ -268,7 +268,7 @@ func TestCreateTask(t *testing.T) {
 			},
 			Run: func(reporter *testutils.Reporter, target interface{}) {
 				manager := target.(*ECSTaskManager)
-				manager.CreateTask("envid", "tsk_name", "dplyid.1", 1, nil)
+				manager.CreateTask("envid", "tsk_name", "dplyid.1", nil)
 			},
 		},
 		testutils.TestCase{
@@ -289,7 +289,7 @@ func TestCreateTask(t *testing.T) {
 			},
 			Run: func(reporter *testutils.Reporter, target interface{}) {
 				manager := target.(*ECSTaskManager)
-				manager.CreateTask("envid", "tsk_name", "dplyid.1", 1, nil)
+				manager.CreateTask("envid", "tsk_name", "dplyid.1", nil)
 			},
 		},
 	}

--- a/api/backend/interface.go
+++ b/api/backend/interface.go
@@ -24,7 +24,7 @@ type Backend interface {
 	UpdateService(environmentID, serviceID, deployID string) (*models.Service, error)
 	GetServiceLogs(environmentID, serviceID string, tail int) ([]*models.LogFile, error)
 
-	CreateTask(envID, taskName, deployVersion string, copies int, overrides []models.ContainerOverride) (*models.Task, error)
+	CreateTask(envID, taskName, deployVersion string, overrides []models.ContainerOverride) (*models.Task, error)
 	ListTasks() ([]*models.Task, error)
 	GetTask(envID, taskID string) (*models.Task, error)
 	DeleteTask(envID, taskID string) error

--- a/api/backend/mock_backend/mock_backend.go
+++ b/api/backend/mock_backend/mock_backend.go
@@ -73,15 +73,15 @@ func (_mr *_MockBackendRecorder) CreateService(arg0, arg1, arg2, arg3 interface{
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "CreateService", arg0, arg1, arg2, arg3)
 }
 
-func (_m *MockBackend) CreateTask(_param0 string, _param1 string, _param2 string, _param3 int, _param4 []models.ContainerOverride) (*models.Task, error) {
-	ret := _m.ctrl.Call(_m, "CreateTask", _param0, _param1, _param2, _param3, _param4)
+func (_m *MockBackend) CreateTask(_param0 string, _param1 string, _param2 string, _param3 []models.ContainerOverride) (*models.Task, error) {
+	ret := _m.ctrl.Call(_m, "CreateTask", _param0, _param1, _param2, _param3)
 	ret0, _ := ret[0].(*models.Task)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockBackendRecorder) CreateTask(arg0, arg1, arg2, arg3, arg4 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "CreateTask", arg0, arg1, arg2, arg3, arg4)
+func (_mr *_MockBackendRecorder) CreateTask(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "CreateTask", arg0, arg1, arg2, arg3)
 }
 
 func (_m *MockBackend) DeleteDeploy(_param0 string) error {

--- a/api/handlers/task_handler_test.go
+++ b/api/handlers/task_handler_test.go
@@ -231,7 +231,7 @@ func TestCreateTask(t *testing.T) {
 		TaskName:      "tsk_name",
 		DeployID:      "dply_id",
 		EnvironmentID: "env_id",
-		Copies:        int64(2),
+		Copies:        2,
 	}
 
 	testCase := HandlerTestCase{

--- a/api/logic/admin_logic.go
+++ b/api/logic/admin_logic.go
@@ -43,8 +43,8 @@ func (a *L0AdminLogic) createDefaultTags() error {
 	}
 
 	if err := a.upsertTagf(config.API_ENVIRONMENT_ID, "environment", "os", "linux"); err != nil {
-                return err
-        }
+		return err
+	}
 
 	// load_balancer
 	if err := a.upsertTagf(config.API_LOAD_BALANCER_ID, "load_balancer", "name", config.API_LOAD_BALANCER_NAME); err != nil {

--- a/api/logic/job_logic.go
+++ b/api/logic/job_logic.go
@@ -122,10 +122,6 @@ func (this *L0JobLogic) CreateJob(jobType types.JobType, request interface{}) (*
 			return nil, fmt.Errorf("Unexpected request type for 'CreateTask' job type!")
 		}
 
-		if req.Copies > 10 {
-			return nil, fmt.Errorf("ECS does not allow more than 10 copies of a task")
-		}
-
 		this.Logic.Scaler.ScheduleRun(req.EnvironmentID, time.Second*10)
 	}
 

--- a/api/logic/task_logic_test.go
+++ b/api/logic/task_logic_test.go
@@ -133,7 +133,7 @@ func TestCreateTask(t *testing.T) {
 	defer ctrl.Finish()
 
 	testLogic.Backend.EXPECT().
-		CreateTask("e1", "name", "d1", 2, nil).
+		CreateTask("e1", "name", "d1", nil).
 		Return(&models.Task{TaskID: "t1"}, nil)
 
 	request := models.CreateTaskRequest{

--- a/cli/client/task.go
+++ b/cli/client/task.go
@@ -16,7 +16,7 @@ func (c *APIClient) CreateTask(
 		TaskName:           name,
 		EnvironmentID:      environmentID,
 		DeployID:           deployID,
-		Copies:             int64(copies),
+		Copies:             copies,
 		ContainerOverrides: overrides,
 	}
 

--- a/cli/client/task_test.go
+++ b/cli/client/task_test.go
@@ -23,7 +23,7 @@ func TestCreateTask(t *testing.T) {
 		testutils.AssertEqual(t, req.TaskName, "name")
 		testutils.AssertEqual(t, req.EnvironmentID, "environmentID")
 		testutils.AssertEqual(t, req.DeployID, "deployID")
-		testutils.AssertEqual(t, req.Copies, int64(2))
+		testutils.AssertEqual(t, req.Copies, 2)
 		testutils.AssertEqual(t, req.ContainerOverrides, overrides)
 
 		headers := map[string]string{

--- a/cli/command/task_command.go
+++ b/cli/command/task_command.go
@@ -126,12 +126,24 @@ func (t *TaskCommand) Create(c *cli.Context) error {
 		return err
 	}
 
-	task, err := t.Client.GetTask(job.Meta["task_id"])
-	if err != nil {
-		return err
+	taskIDs := []string{}
+	for key, val := range job.Meta {	
+		if strings.HasPrefix(key, "task_"){
+			taskIDs = append(taskIDs, val)
+		}
+	}	
+
+	tasks := make([]*models.Task, len(taskIDs))
+	for i, taskID := range taskIDs {
+		task, err := t.Client.GetTask(taskID)
+		if err != nil {
+			return err
+		}
+
+		tasks[i] = task
 	}
 
-	return t.Printer.PrintTasks(task)
+	return t.Printer.PrintTasks(tasks...)
 }
 
 func (t *TaskCommand) Delete(c *cli.Context) error {

--- a/cli/command/task_command.go
+++ b/cli/command/task_command.go
@@ -127,11 +127,11 @@ func (t *TaskCommand) Create(c *cli.Context) error {
 	}
 
 	taskIDs := []string{}
-	for key, val := range job.Meta {	
-		if strings.HasPrefix(key, "task_"){
+	for key, val := range job.Meta {
+		if strings.HasPrefix(key, "task_") {
 			taskIDs = append(taskIDs, val)
 		}
-	}	
+	}
 
 	tasks := make([]*models.Task, len(taskIDs))
 	for i, taskID := range taskIDs {

--- a/cli/command/task_command_test.go
+++ b/cli/command/task_command_test.go
@@ -103,14 +103,18 @@ func TestCreateTaskWait(t *testing.T) {
 		WaitForJob("jobid", gomock.Any()).
 		Return(nil)
 
-	jobMeta := map[string]string{"task_id": "tid"}
+	jobMeta := map[string]string{"task_0": "tid0", "task_1": "tid1"}
 	tc.Client.EXPECT().
 		GetJob("jobid").
 		Return(&models.Job{Meta: jobMeta}, nil)
 
 	tc.Client.EXPECT().
-		GetTask("tid").
+		GetTask("tid0").
 		Return(&models.Task{}, nil)
+
+	 tc.Client.EXPECT().
+                GetTask("tid1").
+                Return(&models.Task{}, nil)
 
 	flags := Flags{
 		"wait": true,

--- a/cli/command/task_command_test.go
+++ b/cli/command/task_command_test.go
@@ -112,9 +112,9 @@ func TestCreateTaskWait(t *testing.T) {
 		GetTask("tid0").
 		Return(&models.Task{}, nil)
 
-	 tc.Client.EXPECT().
-                GetTask("tid1").
-                Return(&models.Task{}, nil)
+	tc.Client.EXPECT().
+		GetTask("tid1").
+		Return(&models.Task{}, nil)
 
 	flags := Flags{
 		"wait": true,

--- a/common/models/create_task_request.go
+++ b/common/models/create_task_request.go
@@ -2,7 +2,7 @@ package models
 
 type CreateTaskRequest struct {
 	ContainerOverrides []ContainerOverride `json:"container_overrides"`
-	Copies             int               `json:"copies"`
+	Copies             int                 `json:"copies"`
 	DeployID           string              `json:"deploy_id"`
 	EnvironmentID      string              `json:"environment_id"`
 	TaskName           string              `json:"task_name"`

--- a/common/models/create_task_request.go
+++ b/common/models/create_task_request.go
@@ -2,7 +2,7 @@ package models
 
 type CreateTaskRequest struct {
 	ContainerOverrides []ContainerOverride `json:"container_overrides"`
-	Copies             int64               `json:"copies"`
+	Copies             int               `json:"copies"`
 	DeployID           string              `json:"deploy_id"`
 	EnvironmentID      string              `json:"environment_id"`
 	TaskName           string              `json:"task_name"`

--- a/runner/job/context.go
+++ b/runner/job/context.go
@@ -42,6 +42,16 @@ func (j *JobContext) SetJobMeta(meta map[string]string) error {
 	return j.Logic.JobStore.SetJobMeta(j.jobID, meta)
 }
 
+func (j *JobContext) AddJobMeta(key, val string) error {
+	job, err := j.Logic.JobStore.SelectByID(j.jobID)
+	if err != nil {
+		return err
+	}
+
+	job.Meta[key] = val
+	return j.SetJobMeta(job.Meta)
+}
+
 func (j *JobContext) Request() string {
 	return j.request
 }

--- a/tests/smoke/task.bats
+++ b/tests/smoke/task.bats
@@ -8,12 +8,12 @@
     l0 deploy create ./common/Dockerrun.aws.json guestbook
 }
 
-@test "task create --wait test task1 guestbook" {
-    l0 task create --wait test task1  guestbook
+@test "task create test task1 guestbook" {
+    l0 task create test task1 guestbook
 }
 
-@test "task create --copies 2 --env guestbook:key=val test task2 guestbook" {
-    l0 task create --copies 2 --env guestbook:key=val test task2 guestbook 
+@test "task create --wait --copies 2 --env guestbook:key=val test task2 guestbook" {
+    l0 task create --wait --copies 2 --env guestbook:key=val test task2 guestbook 
 }
 
 @test "task list" {

--- a/tests/smoke/task.bats
+++ b/tests/smoke/task.bats
@@ -8,12 +8,12 @@
     l0 deploy create ./common/Dockerrun.aws.json guestbook
 }
 
-@test "task create test task1 guestbook" {
-    l0 task create test task1 guestbook
+@test "task create --wait test task1 guestbook" {
+    l0 task create --wait test task1 guestbook
 }
 
-@test "task create --wait --copies 2 --env guestbook:key=val test task2 guestbook" {
-    l0 task create --wait --copies 2 --env guestbook:key=val test task2 guestbook 
+@test "task create --copies 2 --env guestbook:key=val test task2 guestbook" {
+    l0 task create --copies 2 --env guestbook:key=val test task2 guestbook 
 }
 
 @test "task list" {
@@ -48,7 +48,7 @@
     l0 deploy delete guestbook
 }
 
-# this deletes the remaining service(s) and loadbalancer(s)
+# this deletes the remaining service(s), loadbalancer(s), and task(s)
 @test "environment delete --wait test" {
     l0 environment delete --wait test
 }

--- a/tests/system/taskPerformance_test.go
+++ b/tests/system/taskPerformance_test.go
@@ -10,7 +10,6 @@ import (
 // This test creates an environment named 'tp'
 // and a deploy named 'alpine'
 func TestTaskPerformance(t *testing.T) {
-	t.Skip("Task Performance updates are WIP")
 	t.Parallel()
 
 	s := NewSystemTest(t, "cases/task_performance", nil)
@@ -22,21 +21,16 @@ func TestTaskPerformance(t *testing.T) {
 
 	// create 100 tasks
 	taskNameCopies := map[string]int{
-		"TaskA": 10,
-		"TaskB": 10,
+		"TaskA": 50,
+		"TaskB": 25,
 		"TaskC": 10,
-		"TaskD": 10,
-		"TaskE": 10,
-		"TaskF": 10,
-		"TaskG": 10,
-		"TaskH": 10,
-		"TaskI": 10,
-		"TaskJ": 5,
-		"TaskK": 1,
-		"TaskL": 1,
-		"TaskM": 1,
-		"TaskN": 1,
-		"TaskO": 1,
+		"TaskD": 5,
+		"TaskE": 5,
+		"TaskF": 1,
+		"TaskG": 1,
+		"TaskH": 1,
+		"TaskI": 1,
+		"TaskJ": 1,
 	}
 
 	for taskName, copies := range taskNameCopies {
@@ -45,24 +39,31 @@ func TestTaskPerformance(t *testing.T) {
 	}
 
 	testutils.WaitFor(t, time.Second*30, time.Minute*10, func() bool {
-		log.Debugf("Waiting for tasks to run")
-		currentTaskNameCopies := map[string]int{}
+		log.Debugf("Waiting for all tasks to run")
+
+		var numTasks int
 		for _, taskSummary := range s.Layer0.ListTasks() {
 			if taskSummary.EnvironmentID == environmentID {
-				task := s.Layer0.GetTask(taskSummary.TaskID)
-				currentTaskNameCopies[task.TaskName] = int(task.DesiredCount)
+				numTasks++
 			}
 		}
 
-		ok := true
-		for taskName, expectedCopies := range taskNameCopies {
-			currentCopies := currentTaskNameCopies[taskName]
-			log.Debugf("Task '%s' has %d/%d copies", taskName, currentCopies, expectedCopies)
-			if currentCopies != expectedCopies {
-				ok = false
-			}
-		}
-
-		return ok
+		log.Debugf("%d/100 tasks have ran", numTasks)
+		return numTasks >= 100
 	})
+
+	// sleep for 10 seconds since thats the longest a task will take
+	time.Sleep(time.Second * 10)
+
+	log.Debugf("Checking task exit codes")
+	for _, taskSummary := range s.Layer0.ListTasks() {
+		if taskSummary.EnvironmentID == environmentID {
+			task := s.Layer0.GetTask(taskSummary.TaskID)
+			detail := task.Copies[0].Details[0]
+
+			if detail.ExitCode != 0 {
+				t.Fatalf("Task %s has unexpected exit code: %#v", task.TaskID, detail)
+			}
+		}
+	}
 }


### PR DESCRIPTION
After many attempts using ecs's builtin `copy` field, I've determined it's unreliable at best, and most likely broken. I switched over to managing the number of copies by creating them one at a time in the `CreateTask` job. This implementation has worked much more reliably and passes the system test. 

As an added benefit, users are no longer restricted to a maximum of 10 copies in `l0 task create` (which was a limit from ECS). They can now create as many copies as they want. 

closes #159 