### PR TITLE
Remove "Basic" prefix from client config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,4 @@ terraform.tfstate*
 .python-version
 **/.terraform/
 terraform-provider-layer0
+*terraform.tfstate*

--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ unittest:
 	$(MAKE) -C cli test
 	$(MAKE) -C runner test
 	$(MAKE) -C setup test
-	$(MAKE) -C plugins test
+	$(MAKE) -C plugins/terraform test
 
 smoketest:
 	$(MAKE) -C tests/smoke deps

--- a/cli/Makefile
+++ b/cli/Makefile
@@ -1,12 +1,13 @@
 SHELL:=/bin/bash
 L0_VERSION?=$(shell git describe --tags)
 
-build:
+build: 
+	go build -o l0
+
+release:
 	CGO_ENABLED=0 GOOS=linux   GOARCH=amd64 go build -ldflags "-s -X main.Version=$(L0_VERSION)" -a -o build/linux/l0 .
 	CGO_ENABLED=0 GOOS=darwin  GOARCH=amd64 go build -ldflags "-s -X main.Version=$(L0_VERSION)" -a -o build/darwin/l0 .
 	CGO_ENABLED=0 GOOS=windows GOARCH=amd64 go build -ldflags "-s -X main.Version=$(L0_VERSION)" -a -o build/windows/l0.exe .
-
-release: build
 
 test:
 	go test ./...

--- a/cli/client/api_client.go
+++ b/cli/client/api_client.go
@@ -101,7 +101,7 @@ func (c *APIClient) Sling(path string) *sling.Sling {
 		Client(c.httpClient).
 		Base(c.Endpoint).
 		Path(path).
-		Set("Authorization", c.Token).
+		Set("Authorization", fmt.Sprintf("Basic %s", c.Token)).
 		Doer(logSling(c.httpClient))
 }
 

--- a/cli/main.go
+++ b/cli/main.go
@@ -50,7 +50,7 @@ func RunApp() {
 
 	apiClient := client.NewAPIClient(client.Config{
 		Endpoint:      config.APIEndpoint(),
-		Token:         fmt.Sprintf("Basic %s", config.AuthToken()),
+		Token:         config.AuthToken(),
 		VerifySSL:     config.ShouldVerifySSL(),
 		VerifyVersion: config.ShouldVerifyVersion(),
 		Clock:         waitutils.RealClock{},

--- a/plugins/Makefile
+++ b/plugins/Makefile
@@ -1,4 +1,0 @@
-test:
-	go test ./...
-
-.PHONY: test

--- a/plugins/terraform/Makefile
+++ b/plugins/terraform/Makefile
@@ -7,7 +7,6 @@ release:
 	CGO_ENABLED=0 GOOS=windows GOARCH=amd64 go build  -a -o build/windows/terraform-provider-layer0.exe .
 
 test:
-	# run with `-v` flag as required by terraform acceptance testing:
-	go test -v .
+	go test ./...
 
 .PHONY: build release test

--- a/plugins/terraform/provider.go
+++ b/plugins/terraform/provider.go
@@ -44,7 +44,7 @@ func Provider() terraform.ResourceProvider {
 func providerConfigure(d *schema.ResourceData) (interface{}, error) {
 	client := client.NewAPIClient(client.Config{
 		Endpoint:  d.Get("endpoint").(string),
-		Token:     "Basic " + d.Get("token").(string),
+		Token:     d.Get("token").(string),
 		VerifySSL: !d.Get("skip_ssl_verify").(bool),
 	})
 

--- a/setup/Makefile
+++ b/setup/Makefile
@@ -5,6 +5,9 @@ TERRAFORM_VERSION=0.8.5
 deps:
 	sudo pip install awscli
 
+build:
+	go build -o l0-setup
+
 build-directories:
 	rm -rf build
 	for os in linux darwin windows; do \
@@ -22,7 +25,7 @@ download-terraform: build-directories
 		cd - ; \
     done
 
-build: download-terraform
+release: download-terraform
 	CGO_ENABLED=0 GOOS=linux   GOARCH=amd64 go build -ldflags "-s -X main.Version=$(L0_VERSION)" -a -o build/linux/l0-setup .
 	CGO_ENABLED=0 GOOS=darwin  GOARCH=amd64 go build -ldflags "-s -X main.Version=$(L0_VERSION)" -a -o build/darwin/l0-setup .
 	CGO_ENABLED=0 GOOS=windows GOARCH=amd64 go build -ldflags "-s -X main.Version=$(L0_VERSION)" -a -o build/windows/l0-setup.exe .
@@ -38,8 +41,6 @@ apply-smoketest:
 
 destroy-smoketest:
 	./l0-setup destroy --force smoketest
-
-release: build
 
 test:
 	go test ./...

--- a/tests/system/system_test.go
+++ b/tests/system/system_test.go
@@ -27,12 +27,10 @@ func NewSystemTest(t *testing.T, dir string, vars map[string]string) *SystemTest
 		tftest.DryRun(*dry),
 		tftest.Log(log))
 
+	 layer0 := clients.NewLayer0TestClient(t, vars["endpoint"], vars["token"])
+
 	// download modules using terraform get
 	tfContext.Terraformf("get")
-
-	layer0 := clients.NewLayer0TestClient(t,
-		vars["endpoint"],
-		fmt.Sprintf("Basic %s", vars["token"]))
 
 	return &SystemTest{
 		Terraform: tfContext,

--- a/tests/system/system_test.go
+++ b/tests/system/system_test.go
@@ -27,7 +27,7 @@ func NewSystemTest(t *testing.T, dir string, vars map[string]string) *SystemTest
 		tftest.DryRun(*dry),
 		tftest.Log(log))
 
-	 layer0 := clients.NewLayer0TestClient(t, vars["endpoint"], vars["token"])
+	layer0 := clients.NewLayer0TestClient(t, vars["endpoint"], vars["token"])
 
 	// download modules using terraform get
 	tfContext.Terraformf("get")


### PR DESCRIPTION
This also includes standardized makefile conventions for build/release

closes #198  