### PR TITLE
add binpack strategy to start task/service

### DIFF
--- a/common/aws/ecs/ecs.go
+++ b/common/aws/ecs/ecs.go
@@ -392,6 +392,12 @@ func (this *ECS) RunTask(cluster, taskDefinition string, count int64, startedBy 
 		Count:          aws.Int64(count),
 		StartedBy:      startedBy,
 		Overrides:      taskOverride,
+		PlacementStrategy: []*ecs.PlacementStrategy{
+			{
+				Type:  aws.String(ecs.PlacementStrategyTypeBinpack),
+				Field: aws.String("memory"),
+			},
+		},
 	}
 
 	connection, err := this.Connect()
@@ -468,7 +474,14 @@ func (this *ECS) CreateService(cluster, serviceName, taskDefinition string, desi
 		DesiredCount:   aws.Int64(desiredCount),
 		LoadBalancers:  awsLoadBalancers,
 		Role:           loadBalancerRole,
+		PlacementStrategy: []*ecs.PlacementStrategy{
+			{
+				Type:  aws.String(ecs.PlacementStrategyTypeBinpack),
+				Field: aws.String("memory"),
+			},
+		},
 	}
+
 	connection, err := this.Connect()
 	if err != nil {
 		return nil, err

--- a/tests/system/environmentLink_test.go
+++ b/tests/system/environmentLink_test.go
@@ -1,6 +1,7 @@
 package system
 
 import (
+	"github.com/quintilesims/layer0/common/testutils"
 	"github.com/quintilesims/layer0/tests/system/clients"
 	"testing"
 	"time"
@@ -25,12 +26,20 @@ func TestEnvironmentLink(t *testing.T) {
 
 	// curl the private service in the private environment from the public service in the public environment
 	// the private service returns "Hello, World!" from its root path
-	output, err := publicService.RunCommand("curl", "-s", privateServiceURL)
-	if err != nil {
-		t.Fatal(err)
-	}
+	testutils.WaitFor(t, time.Second*10, time.Minute*5, func() bool {
+		output, err := publicService.RunCommand("curl", "-s", privateServiceURL)
+		if err != nil {
+			log.Printf("Error running curl: %v", err)
+			return false
+		}
 
-	if expected := "Hello, World!"; output != expected {
-		t.Fatalf("Output was '%s', expected '%s'", output, expected)
-	}
+		if expected := "Hello, World!"; output != expected {
+			log.Printf("Output from curl was '%s', expected '%s'", output, expected)
+			return false
+		}
+
+		return true
+	})
+
+	// todo: remove link, curl again with -m 10, expect no output
 }


### PR DESCRIPTION
Was able to run system tests to verify changes didn't break anything. 
Added some retry logic to env link test since it can sometimes fail if the private service is still coming up. 

closes https://github.com/quintilesims/layer0/issues/197