### PR TITLE
Display dynamodb variables for 'endpoint -d'

### DIFF
--- a/setup/command/endpoint.go
+++ b/setup/command/endpoint.go
@@ -2,6 +2,7 @@ package command
 
 import (
 	"fmt"
+
 	"github.com/quintilesims/layer0/common/config"
 	"github.com/quintilesims/layer0/setup/instance"
 	"github.com/urfave/cli"
@@ -52,6 +53,8 @@ func (f *CommandFactory) Endpoint() cli.Command {
 				outputEnvvars[instance.OUTPUT_ECS_INSTANCE_PROFILE] = config.AWS_ECS_INSTANCE_PROFILE
 				outputEnvvars[instance.OUTPUT_AWS_LINUX_SERVICE_AMI] = config.AWS_LINUX_SERVICE_AMI
 				outputEnvvars[instance.OUTPUT_WINDOWS_SERVICE_AMI] = config.AWS_WINDOWS_SERVICE_AMI
+				outputEnvvars[instance.OUTPUT_AWS_DYNAMO_TAG_TABLE] = config.AWS_DYNAMO_TAG_TABLE
+				outputEnvvars[instance.OUTPUT_AWS_DYNAMO_JOB_TABLE] = config.AWS_DYNAMO_JOB_TABLE
 			}
 
 			fmt.Println("# set the following environment variables in your current session: ")

--- a/setup/command/endpoint_test.go
+++ b/setup/command/endpoint_test.go
@@ -65,6 +65,8 @@ func TestEndpointDev(t *testing.T) {
 			instance.OUTPUT_ECS_INSTANCE_PROFILE,
 			instance.OUTPUT_AWS_LINUX_SERVICE_AMI,
 			instance.OUTPUT_WINDOWS_SERVICE_AMI,
+			instance.OUTPUT_AWS_DYNAMO_TAG_TABLE,
+			instance.OUTPUT_AWS_DYNAMO_JOB_TABLE,
 		}
 
 		for _, output := range outputs {

--- a/setup/instance/outputs.go
+++ b/setup/instance/outputs.go
@@ -17,4 +17,6 @@ const (
 	OUTPUT_ECS_INSTANCE_PROFILE        = "ecs_agent_instance_profile"
 	OUTPUT_AWS_LINUX_SERVICE_AMI       = "linux_service_ami"
 	OUTPUT_WINDOWS_SERVICE_AMI         = "windows_service_ami"
+	OUTPUT_AWS_DYNAMO_TAG_TABLE        = "dynamo_tag_table"
+	OUTPUT_AWS_DYNAMO_JOB_TABLE        = "dynamo_job_table"
 )

--- a/setup/module/api/outputs.tf
+++ b/setup/module/api/outputs.tf
@@ -45,3 +45,11 @@ output "user_access_key" {
 output "user_secret_key" {
   value = "${aws_iam_access_key.mod.secret}"
 }
+
+output "dynamo_tag_table" {
+    value = "${aws_dynamo_table.tags.id}"
+}
+
+output "dynamo_job_table" {
+    value = "${aws_dynamo_table.jobs.id}"
+}

--- a/setup/module/outputs.tf
+++ b/setup/module/outputs.tf
@@ -57,3 +57,11 @@ output "linux_service_ami" {
 output "windows_service_ami" {
   value = "${module.api.windows_service_ami}"
 }
+
+output "dynamo_tag_table" {
+    value = "${module.api.dynamo_tag_table}"
+}
+
+output "dynamo_job_table" {
+    value = "${module.api.dynamo_job_table}"
+}


### PR DESCRIPTION
## Checklist

- [x] Pull dynamo vars out of terraform as outputs
- [x] Configure `endpoint.go` to print out dynamo vars

## What's this PR do?
`l0-setup endpoint -d [name]` now displays `LAYER0_AWS_DYNAMO_TAG_TABLE` and `LAYER0_AWS_DYNAMO_JOB_TABLE` env vars.

Closes #257 

## Where should the reviewer start?
In `layer0/setup/`:
- `command/endpoint.go` (corresponding test in `command/endpoint_test.go`) and `instance/outputs.go` for the changes that display the env vars.
- `module/outputs.tf` and `module/api/outputs.tf` for pulling those vars out from the module as outputs.

## How should this be manually tested?
1. Update module source
    - Run `l0-setup init [name]`; when prompted for "Source:", enter the full path to `.../layer0/setup/module`
2. Populate .tfstate
    - Run `l0-setup apply [name]`
3. Confirm that dynamo env vars are displayed
    - Run `l0-setup endpoint -d [name]`