### PR TITLE
Removed storedBytes check

### DIFF
--- a/api/backend/ecs/utilities.go
+++ b/api/backend/ecs/utilities.go
@@ -177,14 +177,11 @@ var getTaskARNs = func(ecs ecs.Provider, ecsEnvironmentID id.ECSEnvironmentID, s
 var GetLogs = func(cloudWatchLogs cloudwatchlogs.Provider, taskARNs []*string, tail int) ([]*models.LogFile, error) {
 	taskIDCatalog := generateTaskIDCatalog(taskARNs)
 
-	fmt.Println("Getting streams")
-
 	orderBy := "LogStreamName"
 	logStreams, err := cloudWatchLogs.DescribeLogStreams(config.AWSLogGroupID(), orderBy)
 	if err != nil {
 		return nil, err
 	}
-	fmt.Println("done")
 
 	logFiles := []*models.LogFile{}
 	for _, logStream := range logStreams {
@@ -204,7 +201,6 @@ var GetLogs = func(cloudWatchLogs cloudwatchlogs.Provider, taskARNs []*string, t
 			Lines: []string{},
 		}
 
-		fmt.Println("Getting events")
 		// since the time range is exclusive, expand the range to get first/last events
 		logEvents, err := cloudWatchLogs.GetLogEvents(
 			config.AWSLogGroupID(),
@@ -219,7 +215,6 @@ var GetLogs = func(cloudWatchLogs cloudwatchlogs.Provider, taskARNs []*string, t
 			logFile.Lines = append(logFile.Lines, *logEvent.Message)
 		}
 
-		fmt.Println("done")
 		logFiles = append(logFiles, logFile)
 	}
 

--- a/api/backend/ecs/utilities.go
+++ b/api/backend/ecs/utilities.go
@@ -2,6 +2,8 @@ package ecsbackend
 
 import (
 	"fmt"
+	"strings"
+
 	"github.com/aws/aws-sdk-go/aws/awserr"
 	awsecs "github.com/aws/aws-sdk-go/service/ecs"
 	"github.com/quintilesims/layer0/api/backend/ecs/id"
@@ -9,7 +11,6 @@ import (
 	"github.com/quintilesims/layer0/common/aws/ecs"
 	"github.com/quintilesims/layer0/common/config"
 	"github.com/quintilesims/layer0/common/models"
-	"strings"
 )
 
 const MAX_TASK_IDS = 100
@@ -187,10 +188,6 @@ var GetLogs = func(cloudWatchLogs cloudwatchlogs.Provider, taskARNs []*string, t
 
 	logFiles := []*models.LogFile{}
 	for _, logStream := range logStreams {
-		if *logStream.StoredBytes == 0 {
-			continue
-		}
-
 		// filter by streams that have <prefix>/<container name>/<stream task id>
 		streamNameSplit := strings.Split(*logStream.LogStreamName, "/")
 		if len(streamNameSplit) != 3 {

--- a/api/backend/ecs/utilities.go
+++ b/api/backend/ecs/utilities.go
@@ -177,7 +177,7 @@ var getTaskARNs = func(ecs ecs.Provider, ecsEnvironmentID id.ECSEnvironmentID, s
 var GetLogs = func(cloudWatchLogs cloudwatchlogs.Provider, taskARNs []*string, tail int) ([]*models.LogFile, error) {
 	taskIDCatalog := generateTaskIDCatalog(taskARNs)
 
-	orderBy := "LogStreamName"
+	orderBy := "LastEventTime"
 	logStreams, err := cloudWatchLogs.DescribeLogStreams(config.AWSLogGroupID(), orderBy)
 	if err != nil {
 		return nil, err

--- a/api/backend/ecs/utilities.go
+++ b/api/backend/ecs/utilities.go
@@ -1,7 +1,6 @@
 package ecsbackend
 
 import (
-	"fmt"
 	"strings"
 
 	"github.com/aws/aws-sdk-go/aws/awserr"
@@ -211,7 +210,6 @@ var GetLogs = func(cloudWatchLogs cloudwatchlogs.Provider, taskARNs []*string, t
 		}
 
 		for _, logEvent := range logEvents {
-			fmt.Println(*logEvent.Message)
 			logFile.Lines = append(logFile.Lines, *logEvent.Message)
 		}
 

--- a/api/backend/ecs/utilities_test.go
+++ b/api/backend/ecs/utilities_test.go
@@ -1,13 +1,14 @@
 package ecsbackend
 
 import (
+	"testing"
+
 	"github.com/golang/mock/gomock"
 	"github.com/quintilesims/layer0/common/aws/cloudwatchlogs"
 	"github.com/quintilesims/layer0/common/aws/cloudwatchlogs/mock_cloudwatchlogs"
 	"github.com/quintilesims/layer0/common/config"
 	"github.com/quintilesims/layer0/common/models"
 	"github.com/quintilesims/layer0/common/testutils"
-	"testing"
 )
 
 func testCreateDeploy(models.CreateDeployRequest) (*models.Deploy, error) {
@@ -29,7 +30,6 @@ func TestGetLogs(t *testing.T) {
 				mockCW := mock_cloudwatchlogs.NewMockProvider(ctrl)
 
 				stream := cloudwatchlogs.NewLogStream("prefix/container_name/taskARN")
-				stream.StoredBytes = int64p(int64(1))
 
 				mockCW.EXPECT().
 					DescribeLogStreams(config.AWSLogGroupID(), "LogStreamName").

--- a/api/backend/ecs/utilities_test.go
+++ b/api/backend/ecs/utilities_test.go
@@ -32,7 +32,7 @@ func TestGetLogs(t *testing.T) {
 				stream := cloudwatchlogs.NewLogStream("prefix/container_name/taskARN")
 
 				mockCW.EXPECT().
-					DescribeLogStreams(config.AWSLogGroupID(), "LogStreamName").
+					DescribeLogStreams(config.AWSLogGroupID(), "LastEventTime").
 					Return([]*cloudwatchlogs.LogStream{stream}, nil)
 
 				event := cloudwatchlogs.NewOutputLogEvent("some_message")

--- a/api/logic/job_logic.go
+++ b/api/logic/job_logic.go
@@ -109,8 +109,8 @@ func (this *L0JobLogic) CreateJob(jobType types.JobType, request interface{}) (*
 	}
 
 	if err := this.JobStore.Insert(job); err != nil {
-                return nil, err
-        }
+		return nil, err
+	}
 
 	if err := this.TagStore.Insert(models.Tag{EntityID: jobID, EntityType: "job", Key: "task_id", Value: task.TaskID}); err != nil {
 		return nil, err

--- a/common/aws/cloudwatchlogs/cloudwatchlogs.go
+++ b/common/aws/cloudwatchlogs/cloudwatchlogs.go
@@ -171,12 +171,14 @@ func (this *CloudWatchLogs) DescribeLogStreams(logGroupName, orderBy string) ([]
 	}
 
 	result := []*LogStream{}
+	pageNum := 0
 	pagef := func(output *cloudwatchlogs.DescribeLogStreamsOutput, lastPage bool) bool {
+		pageNum++
 		for _, stream := range output.LogStreams {
 			result = append(result, &LogStream{stream})
 		}
 
-		return !lastPage
+		return !lastPage || pageNum <= 5
 	}
 
 	if err := connection.DescribeLogStreamsPages(input, pagef); err != nil {

--- a/common/aws/cloudwatchlogs/cloudwatchlogs.go
+++ b/common/aws/cloudwatchlogs/cloudwatchlogs.go
@@ -6,6 +6,12 @@ import (
 	"github.com/quintilesims/layer0/common/aws/provider"
 )
 
+const (
+	// DescribeLogStreams is throttled after five transactions per second.
+	// With 50 streams/transaction, 1000 gives a reasonable streams:time ratio
+	MAX_DESCRIBE_STREAMS_COUNT = 1000
+)
+
 type Provider interface {
 	CreateLogGroup(logGroupName string) error
 	DeleteLogGroup(logGroupName string) error
@@ -166,26 +172,29 @@ func (this *CloudWatchLogs) DescribeLogStreams(logGroupName, orderBy string) ([]
 	}
 
 	input := &cloudwatchlogs.DescribeLogStreamsInput{
-		LogGroupName: aws.String(logGroupName),
-		OrderBy:      aws.String(orderBy),
+		LogGroupName:        aws.String(logGroupName),
+		OrderBy:             aws.String(orderBy),
+		Descending:          aws.Bool(true),
 	}
 
-	result := []*LogStream{}
-	pageNum := 0
+	streams := []*LogStream{}
 	pagef := func(output *cloudwatchlogs.DescribeLogStreamsOutput, lastPage bool) bool {
-		pageNum++
 		for _, stream := range output.LogStreams {
-			result = append(result, &LogStream{stream})
+			streams = append(streams, &LogStream{stream})
 		}
 
-		return !lastPage && pageNum <= 5
+		if len(streams) >= MAX_DESCRIBE_STREAMS_COUNT {
+			return false
+		}
+
+		return !lastPage
 	}
 
 	if err := connection.DescribeLogStreamsPages(input, pagef); err != nil {
 		return nil, err
 	}
 
-	return result, nil
+	return streams, nil
 }
 
 func (this *CloudWatchLogs) GetLogEvents(

--- a/common/aws/cloudwatchlogs/cloudwatchlogs.go
+++ b/common/aws/cloudwatchlogs/cloudwatchlogs.go
@@ -178,7 +178,7 @@ func (this *CloudWatchLogs) DescribeLogStreams(logGroupName, orderBy string) ([]
 			result = append(result, &LogStream{stream})
 		}
 
-		return !lastPage || pageNum <= 5
+		return !lastPage && pageNum <= 5
 	}
 
 	if err := connection.DescribeLogStreamsPages(input, pagef); err != nil {


### PR DESCRIPTION
**What does this pull request do?**
Fixes a regression which caused `l0 task/service logs` command to return empty results. This regression was introduced by #241.


**How should this be tested?**
Create a l0 task or service that generates logs. For example, you can follow the [one-off-task guide](http://layer0.ims.io/guides/one_off_task/). Once the task is created, use `l0 task logs <taskid>` to confirm that the logs written are correctly being output as they are being written to cloudwatch logs.

The logs visible from the Cloudwatch logs sections in AWS console, should match the output generated by `l0 task logs <taskid>`.


**Checklist**
- [x] Unit tests
- [ ] Smoke tests (if applicable)
- [ ] System tests (if applicable)
- [ ] Documentation (if applicable)


closes #259 