### PR TITLE
limit streams to 1000/call

### DIFF
--- a/api/backend/ecs/utilities.go
+++ b/api/backend/ecs/utilities.go
@@ -1,7 +1,6 @@
 package ecsbackend
 
 import (
-	"fmt"
 	"strings"
 
 	"github.com/aws/aws-sdk-go/aws/awserr"
@@ -211,7 +210,6 @@ var GetLogs = func(cloudWatchLogs cloudwatchlogs.Provider, taskARNs []*string, t
 		}
 
 		for _, logEvent := range logEvents {
-			fmt.Println(*logEvent.Message)
 			logFile.Lines = append(logFile.Lines, *logEvent.Message)
 		}
 

--- a/api/logic/job_logic.go
+++ b/api/logic/job_logic.go
@@ -109,8 +109,8 @@ func (this *L0JobLogic) CreateJob(jobType types.JobType, request interface{}) (*
 	}
 
 	if err := this.JobStore.Insert(job); err != nil {
-                return nil, err
-        }
+		return nil, err
+	}
 
 	if err := this.TagStore.Insert(models.Tag{EntityID: jobID, EntityType: "job", Key: "task_id", Value: task.TaskID}); err != nil {
 		return nil, err

--- a/common/aws/cloudwatchlogs/cloudwatchlogs.go
+++ b/common/aws/cloudwatchlogs/cloudwatchlogs.go
@@ -6,6 +6,12 @@ import (
 	"github.com/quintilesims/layer0/common/aws/provider"
 )
 
+const (
+	// DescribeLogStreams is throttled after five transactions per second.
+	// With 50 streams/transaction, 1000 gives a reasonable streams:time ratio
+	MAX_DESCRIBE_STREAMS_COUNT = 1000
+)
+
 type Provider interface {
 	CreateLogGroup(logGroupName string) error
 	DeleteLogGroup(logGroupName string) error
@@ -166,26 +172,29 @@ func (this *CloudWatchLogs) DescribeLogStreams(logGroupName, orderBy string) ([]
 	}
 
 	input := &cloudwatchlogs.DescribeLogStreamsInput{
-		LogGroupName: aws.String(logGroupName),
-		OrderBy:      aws.String(orderBy),
+		LogGroupName:        aws.String(logGroupName),
+		OrderBy:             aws.String(orderBy),
+		Descending:          aws.Bool(true),
 	}
 
-	result := []*LogStream{}
-	pageNum := 0
+	streams := []*LogStream{}
 	pagef := func(output *cloudwatchlogs.DescribeLogStreamsOutput, lastPage bool) bool {
-		pageNum++
 		for _, stream := range output.LogStreams {
-			result = append(result, &LogStream{stream})
+			streams = append(streams, &LogStream{stream})
 		}
 
-		return !lastPage || pageNum <= 5
+		if len(streams) >= MAX_DESCRIBE_STREAMS_COUNT {
+			return false
+		}
+
+		return !lastPage
 	}
 
 	if err := connection.DescribeLogStreamsPages(input, pagef); err != nil {
 		return nil, err
 	}
 
-	return result, nil
+	return streams, nil
 }
 
 func (this *CloudWatchLogs) GetLogEvents(


### PR DESCRIPTION
**What does this pull request do?**
* Removes debug statements
* Limits number of streams to 1000. This takes between 2-4 seconds for a `l0 service logs` call. Seems a reasonable stream:time ratio to me - open to suggestions if it should be changed. 
* Fixed broken exit login on pagination function
