### PR TITLE
Added data sources: environment, loadbalancer, service & deploy

### DIFF
--- a/plugins/terraform/data_source_layer0_api.go
+++ b/plugins/terraform/data_source_layer0_api.go
@@ -33,7 +33,7 @@ func dataSourceLayer0API() *schema.Resource {
 }
 
 func dataSourceLayer0APIRead(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*client.APIClient)
+	client := meta.(client.Client)
 
 	apiConfig, err := client.GetConfig()
 	if err != nil {
@@ -41,10 +41,11 @@ func dataSourceLayer0APIRead(d *schema.ResourceData, meta interface{}) error {
 	}
 
 	d.SetId(apiConfig.Prefix)
-	d.Set("prefix", apiConfig.Prefix)
-	d.Set("vpc_id", apiConfig.VPCID)
-	d.Set("public_subnets", apiConfig.PublicSubnets)
-	d.Set("private_subnets", apiConfig.PrivateSubnets)
 
-	return nil
+	return setResourceData(d.Set, map[string]interface{}{
+		"prefix":          apiConfig.Prefix,
+		"vpc_id":          apiConfig.VPCID,
+		"public_subnets":  apiConfig.PublicSubnets,
+		"private_subnets": apiConfig.PrivateSubnets,
+	})
 }

--- a/plugins/terraform/data_source_layer0_deploy.go
+++ b/plugins/terraform/data_source_layer0_deploy.go
@@ -31,11 +31,11 @@ func datasourceLayer0DeployRead(d *schema.ResourceData, meta interface{}) error 
 
 	deployName := d.Get("name").(string)
 	version := d.Get("version").(string)
-
-	deployID, err := resolveTags(client, deployName, map[string]string{
-		"type":    "deploy",
+	params := map[string]string{
 		"version": version,
-	})
+	}
+
+	deployID, err := resolveTags(client, deployName, "deploy", params)
 	if err != nil {
 		return err
 	}
@@ -48,7 +48,6 @@ func datasourceLayer0DeployRead(d *schema.ResourceData, meta interface{}) error 
 	d.SetId(deploy.DeployID)
 
 	return setResourceData(d.Set, map[string]interface{}{
-		"id":      deploy.DeployID,
 		"name":    deploy.DeployName,
 		"version": deploy.Version,
 	})

--- a/plugins/terraform/data_source_layer0_deploy.go
+++ b/plugins/terraform/data_source_layer0_deploy.go
@@ -1,0 +1,55 @@
+package main
+
+import (
+	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/quintilesims/layer0/cli/client"
+)
+
+func dataSourceLayer0Deploy() *schema.Resource {
+	return &schema.Resource{
+		Read: datasourceLayer0DeployRead,
+
+		Schema: map[string]*schema.Schema{
+			"name": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"version": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func datasourceLayer0DeployRead(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(client.Client)
+
+	deployName := d.Get("name").(string)
+	version := d.Get("version").(string)
+
+	deployID, err := resolveTags(client, deployName, map[string]string{
+		"type":    "deploy",
+		"version": version,
+	})
+	if err != nil {
+		return err
+	}
+
+	deploy, err := client.GetDeploy(deployID)
+	if err != nil {
+		return err
+	}
+
+	d.SetId(deploy.DeployID)
+
+	return setResourceData(d.Set, map[string]interface{}{
+		"id":      deploy.DeployID,
+		"name":    deploy.DeployName,
+		"version": deploy.Version,
+	})
+}

--- a/plugins/terraform/data_source_layer0_deploy_test.go
+++ b/plugins/terraform/data_source_layer0_deploy_test.go
@@ -1,0 +1,34 @@
+package main
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+func TestDeployDataResourceSelectByQueryParams(t *testing.T) {
+	ctrl, mockClient, provider := setupUnitTest(t)
+	defer ctrl.Finish()
+
+	deployName := "deploy-name"
+	version := "1"
+
+	params := map[string]string{
+		"type":    "deploy",
+		"version": version,
+		"fuzz":    deployName,
+	}
+
+	mockClient.EXPECT().
+		SelectByQuery(params)
+
+	deployResource := provider.DataSourcesMap["layer0_deploy"]
+	d := schema.TestResourceDataRaw(t, deployResource.Schema, map[string]interface{}{})
+	d.Set("name", deployName)
+	d.Set("version", version)
+
+	if err := deployResource.Read(d, mockClient); err.Error() != fmt.Errorf("No entities found").Error() {
+		t.Fatal(err)
+	}
+}

--- a/plugins/terraform/data_source_layer0_environment.go
+++ b/plugins/terraform/data_source_layer0_environment.go
@@ -43,9 +43,7 @@ func datasourceLayer0EnvironmentRead(d *schema.ResourceData, meta interface{}) e
 
 	environmentName := d.Get("name").(string)
 
-	environmentID, err := resolveTags(client, environmentName, map[string]string{
-		"type": "environment",
-	})
+	environmentID, err := resolveTags(client, environmentName, "environment", map[string]string{})
 	if err != nil {
 		return err
 	}
@@ -58,7 +56,6 @@ func datasourceLayer0EnvironmentRead(d *schema.ResourceData, meta interface{}) e
 	d.SetId(environment.EnvironmentID)
 
 	return setResourceData(d.Set, map[string]interface{}{
-		"id":        environment.EnvironmentID,
 		"size":      environment.InstanceSize,
 		"min_count": environment.ClusterCount,
 		"os":        environment.OperatingSystem,

--- a/plugins/terraform/data_source_layer0_environment.go
+++ b/plugins/terraform/data_source_layer0_environment.go
@@ -1,0 +1,67 @@
+package main
+
+import (
+	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/quintilesims/layer0/cli/client"
+)
+
+func dataSourceLayer0Environment() *schema.Resource {
+	return &schema.Resource{
+		Read: datasourceLayer0EnvironmentRead,
+
+		Schema: map[string]*schema.Schema{
+			"name": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"size": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"min_count": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+			"os": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"ami": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func datasourceLayer0EnvironmentRead(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(client.Client)
+
+	environmentName := d.Get("name").(string)
+
+	environmentID, err := resolveTags(client, environmentName, map[string]string{
+		"type": "environment",
+	})
+	if err != nil {
+		return err
+	}
+
+	environment, err := client.GetEnvironment(environmentID)
+	if err != nil {
+		return err
+	}
+
+	d.SetId(environment.EnvironmentID)
+
+	return setResourceData(d.Set, map[string]interface{}{
+		"id":        environment.EnvironmentID,
+		"size":      environment.InstanceSize,
+		"min_count": environment.ClusterCount,
+		"os":        environment.OperatingSystem,
+		"ami":       environment.AMIID,
+	})
+}

--- a/plugins/terraform/data_source_layer0_environment_test.go
+++ b/plugins/terraform/data_source_layer0_environment_test.go
@@ -1,16 +1,17 @@
 package main
 
 import (
-	"fmt"
 	"testing"
 
 	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/quintilesims/layer0/common/models"
 )
 
 func TestEnvironmentDataResourceSelectByQueryParams(t *testing.T) {
 	ctrl, mockClient, provider := setupUnitTest(t)
 	defer ctrl.Finish()
 
+	environmentId := "environment-id"
 	environmentName := "environment-name"
 
 	params := map[string]string{
@@ -19,13 +20,24 @@ func TestEnvironmentDataResourceSelectByQueryParams(t *testing.T) {
 	}
 
 	mockClient.EXPECT().
-		SelectByQuery(params)
+		SelectByQuery(params).
+		Return([]*models.EntityWithTags{
+			&models.EntityWithTags{
+				EntityID:   environmentId,
+				EntityType: "environment",
+			},
+		}, nil)
+
+	mockClient.EXPECT().
+		GetEnvironment(environmentId).
+		Return(&models.Environment{}, nil)
 
 	environmentResource := provider.DataSourcesMap["layer0_environment"]
-	d := schema.TestResourceDataRaw(t, environmentResource.Schema, map[string]interface{}{})
-	d.Set("name", environmentName)
+	d := schema.TestResourceDataRaw(t, environmentResource.Schema, map[string]interface{}{
+		"name": environmentName,
+	})
 
-	if err := environmentResource.Read(d, mockClient); err.Error() != fmt.Errorf("No entities found").Error() {
+	if err := environmentResource.Read(d, mockClient); err != nil {
 		t.Fatal(err)
 	}
 }

--- a/plugins/terraform/data_source_layer0_environment_test.go
+++ b/plugins/terraform/data_source_layer0_environment_test.go
@@ -1,0 +1,31 @@
+package main
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+func TestEnvironmentDataResourceSelectByQueryParams(t *testing.T) {
+	ctrl, mockClient, provider := setupUnitTest(t)
+	defer ctrl.Finish()
+
+	environmentName := "environment-name"
+
+	params := map[string]string{
+		"type": "environment",
+		"fuzz": environmentName,
+	}
+
+	mockClient.EXPECT().
+		SelectByQuery(params)
+
+	environmentResource := provider.DataSourcesMap["layer0_environment"]
+	d := schema.TestResourceDataRaw(t, environmentResource.Schema, map[string]interface{}{})
+	d.Set("name", environmentName)
+
+	if err := environmentResource.Read(d, mockClient); err.Error() != fmt.Errorf("No entities found").Error() {
+		t.Fatal(err)
+	}
+}

--- a/plugins/terraform/data_source_layer0_environment_test.go
+++ b/plugins/terraform/data_source_layer0_environment_test.go
@@ -11,7 +11,7 @@ func TestEnvironmentDataResourceSelectByQueryParams(t *testing.T) {
 	ctrl, mockClient, provider := setupUnitTest(t)
 	defer ctrl.Finish()
 
-	environmentId := "environment-id"
+	environmentID := "environment-id"
 	environmentName := "environment-name"
 
 	params := map[string]string{
@@ -23,13 +23,13 @@ func TestEnvironmentDataResourceSelectByQueryParams(t *testing.T) {
 		SelectByQuery(params).
 		Return([]*models.EntityWithTags{
 			&models.EntityWithTags{
-				EntityID:   environmentId,
+				EntityID:   environmentID,
 				EntityType: "environment",
 			},
 		}, nil)
 
 	mockClient.EXPECT().
-		GetEnvironment(environmentId).
+		GetEnvironment(environmentID).
 		Return(&models.Environment{}, nil)
 
 	environmentResource := provider.DataSourcesMap["layer0_environment"]

--- a/plugins/terraform/data_source_layer0_loadbalancer.go
+++ b/plugins/terraform/data_source_layer0_loadbalancer.go
@@ -20,7 +20,7 @@ func dataSourcelayer0LoadBalancer() *schema.Resource {
 			},
 			"environment_name": {
 				Type:     schema.TypeString,
-				Optional: true,
+				Computed: true,
 			},
 			"id": {
 				Type:     schema.TypeString,
@@ -42,26 +42,6 @@ func dataSourcelayer0LoadBalancer() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
-			"healthcheck_healthy_threshold": {
-				Type:     schema.TypeInt,
-				Computed: true,
-			},
-			"healthcheck_interval": {
-				Type:     schema.TypeInt,
-				Computed: true,
-			},
-			"healthcheck_target": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			"healthcheck_timeout": {
-				Type:     schema.TypeInt,
-				Computed: true,
-			},
-			"healthcheck_unhealthy_threshold": {
-				Type:     schema.TypeInt,
-				Computed: true,
-			},
 		},
 	}
 }
@@ -71,11 +51,11 @@ func dataSourcelayer0LoadBalancerRead(d *schema.ResourceData, meta interface{}) 
 
 	lbName := d.Get("name").(string)
 	environmentID := d.Get("environment_id").(string)
-
-	loadbalancerID, err := resolveTags(client, lbName, map[string]string{
-		"type":           "load_balancer",
+	params := map[string]string{
 		"environment_id": environmentID,
-	})
+	}
+
+	loadbalancerID, err := resolveTags(client, lbName, "load_balancer", params)
 	if err != nil {
 		return err
 	}
@@ -87,18 +67,12 @@ func dataSourcelayer0LoadBalancerRead(d *schema.ResourceData, meta interface{}) 
 
 	d.SetId(loadbalancer.LoadBalancerID)
 	return setResourceData(d.Set, map[string]interface{}{
-		"id":                              loadbalancer.LoadBalancerID,
-		"name":                            loadbalancer.LoadBalancerName,
-		"private":                         !loadbalancer.IsPublic,
-		"url":                             loadbalancer.URL,
-		"service_id":                      loadbalancer.ServiceID,
-		"service_name":                    loadbalancer.ServiceName,
-		"environment_id":                  loadbalancer.EnvironmentID,
-		"environment_name":                loadbalancer.EnvironmentName,
-		"healthcheck_healthy_threshold":   loadbalancer.HealthCheck.HealthyThreshold,
-		"healthcheck_interval":            loadbalancer.HealthCheck.Interval,
-		"healthcheck_target":              loadbalancer.HealthCheck.Target,
-		"healthcheck_timeout":             loadbalancer.HealthCheck.Timeout,
-		"healthcheck_unhealthy_threshold": loadbalancer.HealthCheck.UnhealthyThreshold,
+		"name":             loadbalancer.LoadBalancerName,
+		"private":          !loadbalancer.IsPublic,
+		"url":              loadbalancer.URL,
+		"service_id":       loadbalancer.ServiceID,
+		"service_name":     loadbalancer.ServiceName,
+		"environment_id":   loadbalancer.EnvironmentID,
+		"environment_name": loadbalancer.EnvironmentName,
 	})
 }

--- a/plugins/terraform/data_source_layer0_loadbalancer.go
+++ b/plugins/terraform/data_source_layer0_loadbalancer.go
@@ -1,0 +1,104 @@
+package main
+
+import (
+	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/quintilesims/layer0/cli/client"
+)
+
+func dataSourcelayer0LoadBalancer() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourcelayer0LoadBalancerRead,
+
+		Schema: map[string]*schema.Schema{
+			"name": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"environment_id": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"environment_name": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"private": {
+				Type:     schema.TypeBool,
+				Computed: true,
+			},
+			"url": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"service_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"service_name": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"healthcheck_healthy_threshold": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+			"healthcheck_interval": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+			"healthcheck_target": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"healthcheck_timeout": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+			"healthcheck_unhealthy_threshold": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func dataSourcelayer0LoadBalancerRead(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(client.Client)
+
+	lbName := d.Get("name").(string)
+	environmentID := d.Get("environment_id").(string)
+
+	loadbalancerID, err := resolveTags(client, lbName, map[string]string{
+		"type":           "load_balancer",
+		"environment_id": environmentID,
+	})
+	if err != nil {
+		return err
+	}
+
+	loadbalancer, err := client.GetLoadBalancer(loadbalancerID)
+	if err != nil {
+		return err
+	}
+
+	d.SetId(loadbalancer.LoadBalancerID)
+	return setResourceData(d.Set, map[string]interface{}{
+		"id":                              loadbalancer.LoadBalancerID,
+		"name":                            loadbalancer.LoadBalancerName,
+		"private":                         !loadbalancer.IsPublic,
+		"url":                             loadbalancer.URL,
+		"service_id":                      loadbalancer.ServiceID,
+		"service_name":                    loadbalancer.ServiceName,
+		"environment_id":                  loadbalancer.EnvironmentID,
+		"environment_name":                loadbalancer.EnvironmentName,
+		"healthcheck_healthy_threshold":   loadbalancer.HealthCheck.HealthyThreshold,
+		"healthcheck_interval":            loadbalancer.HealthCheck.Interval,
+		"healthcheck_target":              loadbalancer.HealthCheck.Target,
+		"healthcheck_timeout":             loadbalancer.HealthCheck.Timeout,
+		"healthcheck_unhealthy_threshold": loadbalancer.HealthCheck.UnhealthyThreshold,
+	})
+}

--- a/plugins/terraform/data_source_layer0_loadbalancer_test.go
+++ b/plugins/terraform/data_source_layer0_loadbalancer_test.go
@@ -1,0 +1,34 @@
+package main
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+func TestLoadBalancerDataResourceSelectByQueryParams(t *testing.T) {
+	ctrl, mockClient, provider := setupUnitTest(t)
+	defer ctrl.Finish()
+
+	loadbalancerName := "loadbalancer-name"
+	environmentID := "l0-env-id"
+
+	params := map[string]string{
+		"type":           "load_balancer",
+		"environment_id": environmentID,
+		"fuzz":           loadbalancerName,
+	}
+
+	mockClient.EXPECT().
+		SelectByQuery(params)
+
+	loadbalancerResource := provider.DataSourcesMap["layer0_load_balancer"]
+	d := schema.TestResourceDataRaw(t, loadbalancerResource.Schema, map[string]interface{}{})
+	d.Set("name", loadbalancerName)
+	d.Set("environment_id", environmentID)
+
+	if err := loadbalancerResource.Read(d, mockClient); err.Error() != fmt.Errorf("No entities found").Error() {
+		t.Fatal(err)
+	}
+}

--- a/plugins/terraform/data_source_layer0_service.go
+++ b/plugins/terraform/data_source_layer0_service.go
@@ -1,0 +1,74 @@
+package main
+
+import (
+	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/quintilesims/layer0/cli/client"
+)
+
+func dataSourcelayer0Service() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourcelayer0ServiceRead,
+
+		Schema: map[string]*schema.Schema{
+			"name": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"environment_id": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"environment_name": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"load_balancer_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"load_balancer_name": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"scale": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func dataSourcelayer0ServiceRead(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(client.Client)
+
+	serviceName := d.Get("name").(string)
+	environmentID := d.Get("environment_id").(string)
+
+	serviceID, err := resolveTags(client, serviceName, map[string]string{
+		"type":           "service",
+		"environment_id": environmentID,
+	})
+	if err != nil {
+		return err
+	}
+
+	service, err := client.GetService(serviceID)
+	if err != nil {
+		return err
+	}
+
+	d.SetId(service.ServiceID)
+
+	return setResourceData(d.Set, map[string]interface{}{
+		"name":               service.ServiceName,
+		"id":                 service.ServiceID,
+		"environment_id":     service.EnvironmentID,
+		"environment_name":   service.EnvironmentName,
+		"load_balancer_name": service.LoadBalancerName,
+		"scale":              service.DesiredCount,
+	})
+}

--- a/plugins/terraform/data_source_layer0_service.go
+++ b/plugins/terraform/data_source_layer0_service.go
@@ -47,11 +47,11 @@ func dataSourcelayer0ServiceRead(d *schema.ResourceData, meta interface{}) error
 
 	serviceName := d.Get("name").(string)
 	environmentID := d.Get("environment_id").(string)
-
-	serviceID, err := resolveTags(client, serviceName, map[string]string{
-		"type":           "service",
+	params := map[string]string{
 		"environment_id": environmentID,
-	})
+	}
+
+	serviceID, err := resolveTags(client, serviceName, "service", params)
 	if err != nil {
 		return err
 	}
@@ -65,7 +65,6 @@ func dataSourcelayer0ServiceRead(d *schema.ResourceData, meta interface{}) error
 
 	return setResourceData(d.Set, map[string]interface{}{
 		"name":               service.ServiceName,
-		"id":                 service.ServiceID,
 		"environment_id":     service.EnvironmentID,
 		"environment_name":   service.EnvironmentName,
 		"load_balancer_name": service.LoadBalancerName,

--- a/plugins/terraform/data_source_layer0_service_test.go
+++ b/plugins/terraform/data_source_layer0_service_test.go
@@ -1,0 +1,34 @@
+package main
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+func TestServiceDataResourceSelectByQueryParams(t *testing.T) {
+	ctrl, mockClient, provider := setupUnitTest(t)
+	defer ctrl.Finish()
+
+	serviceName := "service-name"
+	environmentID := "l0-env-id"
+
+	params := map[string]string{
+		"type":           "service",
+		"environment_id": environmentID,
+		"fuzz":           serviceName,
+	}
+
+	mockClient.EXPECT().
+		SelectByQuery(params)
+
+	serviceResource := provider.DataSourcesMap["layer0_service"]
+	d := schema.TestResourceDataRaw(t, serviceResource.Schema, map[string]interface{}{})
+	d.Set("name", serviceName)
+	d.Set("environment_id", environmentID)
+
+	if err := serviceResource.Read(d, mockClient); err.Error() != fmt.Errorf("No entities found").Error() {
+		t.Fatal(err)
+	}
+}

--- a/plugins/terraform/data_source_tag_resolver.go
+++ b/plugins/terraform/data_source_tag_resolver.go
@@ -6,8 +6,9 @@ import (
 	"github.com/quintilesims/layer0/cli/client"
 )
 
-func resolveTags(client client.Client, target string, params map[string]string) (string, error) {
+func resolveTags(client client.Client, target, entityType string, params map[string]string) (string, error) {
 	params["fuzz"] = target
+	params["type"] = entityType
 
 	taggedEntities, err := client.SelectByQuery(params)
 	if err != nil {
@@ -15,7 +16,7 @@ func resolveTags(client client.Client, target string, params map[string]string) 
 	}
 
 	if len(taggedEntities) == 0 {
-		return "", fmt.Errorf("No entities found")
+		return "", fmt.Errorf("No entities of type %s found matching %s", entityType, target)
 	}
 
 	if len(taggedEntities) == 1 {
@@ -33,7 +34,7 @@ func resolveTags(client client.Client, target string, params map[string]string) 
 		}
 	}
 
-	text := fmt.Sprintf("Multiple entities found: \n")
+	text := fmt.Sprintf("Multiple entities of type %s found matching %s: ", entityType, target)
 	for _, id := range entityIDs {
 		text += fmt.Sprintf("%s \n", id)
 	}
@@ -43,8 +44,7 @@ func resolveTags(client client.Client, target string, params map[string]string) 
 
 func setResourceData(setter func(string, interface{}) error, values map[string]interface{}) error {
 	for key, value := range values {
-		err := setter(key, value)
-		if err != nil {
+		if err := setter(key, value); err != nil {
 			return err
 		}
 	}

--- a/plugins/terraform/data_source_tag_resolver.go
+++ b/plugins/terraform/data_source_tag_resolver.go
@@ -1,0 +1,53 @@
+package main
+
+import (
+	"fmt"
+
+	"github.com/quintilesims/layer0/cli/client"
+)
+
+func resolveTags(client client.Client, target string, params map[string]string) (string, error) {
+	params["fuzz"] = target
+
+	taggedEntities, err := client.SelectByQuery(params)
+	if err != nil {
+		return "", err
+	}
+
+	if len(taggedEntities) == 0 {
+		return "", fmt.Errorf("No entities found")
+	}
+
+	if len(taggedEntities) == 1 {
+		return taggedEntities[0].EntityID, nil
+	}
+
+	entityIDs := []string{}
+	for _, taggedEntity := range taggedEntities {
+		entityIDs = append(entityIDs, taggedEntity.EntityID)
+
+		for _, tag := range taggedEntity.Tags {
+			if tag.Key == "name" && tag.Value == target {
+				return taggedEntity.EntityID, nil
+			}
+		}
+	}
+
+	text := fmt.Sprintf("Multiple entities found: \n")
+	for _, id := range entityIDs {
+		text += fmt.Sprintf("%s \n", id)
+	}
+
+	return "", fmt.Errorf(text)
+}
+
+func setResourceData(setter func(string, interface{}) error, values map[string]interface{}) error {
+	for key, value := range values {
+		err := setter(key, value)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}

--- a/plugins/terraform/provider.go
+++ b/plugins/terraform/provider.go
@@ -1,10 +1,11 @@
 package main
 
 import (
+	"time"
+
 	"github.com/hashicorp/terraform/helper/schema"
 	"github.com/hashicorp/terraform/terraform"
 	"github.com/quintilesims/layer0/cli/client"
-	"time"
 )
 
 var defaultTimeout = time.Minute * 15
@@ -36,7 +37,11 @@ func Provider() terraform.ResourceProvider {
 			"layer0_service":          resourceLayer0Service(),
 		},
 		DataSourcesMap: map[string]*schema.Resource{
-			"layer0_api": dataSourceLayer0API(),
+			"layer0_api":           dataSourceLayer0API(),
+			"layer0_environment":   dataSourceLayer0Environment(),
+			"layer0_load_balancer": dataSourcelayer0LoadBalancer(),
+			"layer0_deploy":        dataSourceLayer0Deploy(),
+			"layer0_service":       dataSourcelayer0Service(),
 		},
 		ConfigureFunc: providerConfigure,
 	}

--- a/plugins/terraform/provider_test.go
+++ b/plugins/terraform/provider_test.go
@@ -1,10 +1,11 @@
 package main
 
 import (
+	"testing"
+
 	"github.com/golang/mock/gomock"
 	"github.com/hashicorp/terraform/helper/schema"
 	"github.com/quintilesims/layer0/cli/client/mock_client"
-	"testing"
 )
 
 func setupUnitTest(t *testing.T) (*gomock.Controller, *mock_client.MockClient, *schema.Provider) {

--- a/plugins/terraform/resource_deploy.go
+++ b/plugins/terraform/resource_deploy.go
@@ -1,10 +1,11 @@
 package main
 
 import (
-	"github.com/hashicorp/terraform/helper/schema"
-	"github.com/quintilesims/layer0/cli/client"
 	"log"
 	"strings"
+
+	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/quintilesims/layer0/cli/client"
 )
 
 func resourceLayer0Deploy() *schema.Resource {

--- a/plugins/terraform/resource_deploy_test.go
+++ b/plugins/terraform/resource_deploy_test.go
@@ -1,9 +1,10 @@
 package main
 
 import (
+	"testing"
+
 	"github.com/hashicorp/terraform/helper/schema"
 	"github.com/quintilesims/layer0/common/models"
-	"testing"
 )
 
 func TestDeployCreate(t *testing.T) {

--- a/plugins/terraform/resource_environment_test.go
+++ b/plugins/terraform/resource_environment_test.go
@@ -1,10 +1,11 @@
 package main
 
 import (
+	"testing"
+
 	"github.com/golang/mock/gomock"
 	"github.com/hashicorp/terraform/helper/schema"
 	"github.com/quintilesims/layer0/common/models"
-	"testing"
 )
 
 func TestEnvironmentCreate_defaults(t *testing.T) {

--- a/plugins/terraform/resource_load_balancer_test.go
+++ b/plugins/terraform/resource_load_balancer_test.go
@@ -1,10 +1,11 @@
 package main
 
 import (
+	"testing"
+
 	"github.com/golang/mock/gomock"
 	"github.com/hashicorp/terraform/helper/schema"
 	"github.com/quintilesims/layer0/common/models"
-	"testing"
 )
 
 func TestLoadBalancerCreate_defaults(t *testing.T) {

--- a/plugins/terraform/resource_service_test.go
+++ b/plugins/terraform/resource_service_test.go
@@ -1,10 +1,11 @@
 package main
 
 import (
+	"testing"
+
 	"github.com/golang/mock/gomock"
 	"github.com/hashicorp/terraform/helper/schema"
 	"github.com/quintilesims/layer0/common/models"
-	"testing"
 )
 
 func TestServiceCreate_defaults(t *testing.T) {


### PR DESCRIPTION
**What does this pull request do?**
Modifies the Terraform Layer0 provider to add Data Source support for Layer0 created resources. Data Sources added:

- environment
- load balancer
- service
- deploy

**How should this be tested?**
Create a terraform file that references existing l0 environment, load balancer, service & deploy. In the output variables, output all the supported variables supported for a given resource. Execute `terraform apply` and check the output.

For example:
```
provider "layer0" {
  endpoint        = "${var.endpoint}"
  token             = "${var.token}"
  skip_ssl_verify = true
}

data "layer0_deploy" "service-a-dpl" {
  name    = "some-cool-service-dpl"
  version = "1"
}

output "deploy" {
  value = "${data.layer0_deploy.service-a-dpl.id}"
}
```


**Checklist**
- [x] Unit tests
- [ ] Smoke tests (if applicable)
- [ ] System tests (if applicable)
- [ ] Documentation (if applicable)


closes #263 