### PR TITLE
fix bad 'aws_dynamo_table' var name

### DIFF
--- a/setup/module/api/outputs.tf
+++ b/setup/module/api/outputs.tf
@@ -47,9 +47,9 @@ output "user_secret_key" {
 }
 
 output "dynamo_tag_table" {
-    value = "${aws_dynamo_table.tags.id}"
+    value = "${aws_dynamodb_table.tags.id}"
 }
 
 output "dynamo_job_table" {
-    value = "${aws_dynamo_table.jobs.id}"
+    value = "${aws_dynamodb_table.jobs.id}"
 }


### PR DESCRIPTION
**What does this pull request do?**
Updates instances of `${aws_dynamo_table...}` in `setup/module/api/outputs.tf` with `${aws_dynamodb_table...}`.


**How should this be tested?**
1. Clone; `make build` l0-setup
2. `l0-setup init [name]`
3. `l0-setup apply [name]`


**Checklist**
- [ ] Unit tests
- [ ] Smoke tests (if applicable)
- [ ] System tests (if applicable)
- [ ] Documentation (if applicable)


closes #278