### PR TITLE
Issue 280 datasource system tests

### DIFF
--- a/plugins/terraform/data_source_layer0_loadbalancer.go
+++ b/plugins/terraform/data_source_layer0_loadbalancer.go
@@ -34,14 +34,6 @@ func dataSourcelayer0LoadBalancer() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
-			"service_id": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			"service_name": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
 		},
 	}
 }
@@ -70,8 +62,6 @@ func dataSourcelayer0LoadBalancerRead(d *schema.ResourceData, meta interface{}) 
 		"name":             loadbalancer.LoadBalancerName,
 		"private":          !loadbalancer.IsPublic,
 		"url":              loadbalancer.URL,
-		"service_id":       loadbalancer.ServiceID,
-		"service_name":     loadbalancer.ServiceName,
 		"environment_id":   loadbalancer.EnvironmentID,
 		"environment_name": loadbalancer.EnvironmentName,
 	})

--- a/plugins/terraform/data_source_layer0_service.go
+++ b/plugins/terraform/data_source_layer0_service.go
@@ -68,6 +68,7 @@ func dataSourcelayer0ServiceRead(d *schema.ResourceData, meta interface{}) error
 		"environment_id":     service.EnvironmentID,
 		"environment_name":   service.EnvironmentName,
 		"load_balancer_name": service.LoadBalancerName,
+		"load_balancer_id":   service.LoadBalancerID,
 		"scale":              service.DesiredCount,
 	})
 }

--- a/plugins/terraform/data_source_layer0_service.go
+++ b/plugins/terraform/data_source_layer0_service.go
@@ -26,14 +26,6 @@ func dataSourcelayer0Service() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
-			"load_balancer_id": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			"load_balancer_name": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
 			"scale": {
 				Type:     schema.TypeInt,
 				Computed: true,
@@ -64,11 +56,9 @@ func dataSourcelayer0ServiceRead(d *schema.ResourceData, meta interface{}) error
 	d.SetId(service.ServiceID)
 
 	return setResourceData(d.Set, map[string]interface{}{
-		"name":               service.ServiceName,
-		"environment_id":     service.EnvironmentID,
-		"environment_name":   service.EnvironmentName,
-		"load_balancer_name": service.LoadBalancerName,
-		"load_balancer_id":   service.LoadBalancerID,
-		"scale":              service.DesiredCount,
+		"name":             service.ServiceName,
+		"environment_id":   service.EnvironmentID,
+		"environment_name": service.EnvironmentName,
+		"scale":            service.DesiredCount,
 	})
 }

--- a/plugins/terraform/resource_deploy.go
+++ b/plugins/terraform/resource_deploy.go
@@ -25,6 +25,10 @@ func resourceLayer0Deploy() *schema.Resource {
 				Required: true,
 				ForceNew: true,
 			},
+			"version": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
 		},
 	}
 }

--- a/plugins/terraform/resource_environment.go
+++ b/plugins/terraform/resource_environment.go
@@ -49,7 +49,7 @@ func resourceLayer0Environment() *schema.Resource {
 				Computed: true,
 			},
 			"cluster_count": {
-				Type:     schema.TypeString,
+				Type:     schema.TypeInt,
 				Computed: true,
 			},
 			"security_group_id": {

--- a/tests/system/cases/datasources/Dockerrun.aws.json
+++ b/tests/system/cases/datasources/Dockerrun.aws.json
@@ -1,0 +1,17 @@
+{
+    "AWSEBDockerrunVersion": 2,
+    "containerDefinitions": [
+        {
+            "name": "sts",
+            "image": "quintilesims/sts",
+            "essential": true,
+            "memory": 128,
+            "portMappings": [
+                {
+                    "hostPort": 80,
+                    "containerPort": 80
+                }
+            ]
+        }
+    ]
+}

--- a/tests/system/cases/datasources/main.tf
+++ b/tests/system/cases/datasources/main.tf
@@ -5,33 +5,57 @@ provider "layer0" {
 }
 
 resource "layer0_environment" "datasources" {
-  name = "datasources"
+  name = "dsrctest"
 }
 
-module "sts" {
-  source         = "../modules/sts"
-  environment_id = "${layer0_environment.datasources.id}"
+resource "layer0_load_balancer" "datasources" {
+  name        = "dsrctest_lb"
+  environment = "${layer0_environment.datasources.id}"
+
+  port {
+    host_port      = 80
+    container_port = 80
+    protocol       = "http"
+  }
+}
+
+resource "layer0_service" "datasources" {
+  name          = "dsrctest_svc"
+  environment   = "${layer0_environment.datasources.id}"
+  deploy        = "${layer0_deploy.datasources.id}"
+  load_balancer = "${layer0_load_balancer.datasources.id}"
+  scale         = "1"
+  wait          = true
+}
+
+resource "layer0_deploy" "datasources" {
+  name    = "dsrctest_dpl"
+  content = "${data.template_file.datasources.rendered}"
+}
+
+data "template_file" "datasources" {
+  template = "${file("${path.module}/Dockerrun.aws.json")}"
 }
 
 data "layer0_environment" "datasources" {
   depends_on = ["layer0_environment.datasources"]
-  name       = "datasources"
+  name       = "${layer0_environment.datasources.name}"
 }
 
 data "layer0_deploy" "datasources" {
-  depends_on = ["module.sts"]
-  name       = "${module.sts.deploy_name}"
-  version    = "1"
+  depends_on = ["layer0_deploy.datasources"]
+  name       = "${layer0_deploy.datasources.name}"
+  version    = "${layer0_deploy.datasources.version}"
 }
 
 data "layer0_service" "datasources" {
-  depends_on     = ["module.sts"]
-  name           = "${module.sts.service_id}"
+  depends_on     = ["layer0_service.datasources"]
+  name           = "${layer0_service.datasources.name}"
   environment_id = "${layer0_environment.datasources.id}"
 }
 
 data "layer0_load_balancer" "datasources" {
-  depends_on     = ["module.sts"]
-  name           = "${module.sts.load_balancer_id}"
+  depends_on     = ["layer0_load_balancer.datasources", "layer0_service.datasources"]
+  name           = "${layer0_load_balancer.datasources.id}"
   environment_id = "${layer0_environment.datasources.id}"
 }

--- a/tests/system/cases/datasources/main.tf
+++ b/tests/system/cases/datasources/main.tf
@@ -9,7 +9,7 @@ resource "layer0_environment" "datasources" {
 }
 
 resource "layer0_load_balancer" "datasources" {
-  name        = "dsrctest_lb"
+  name        = "dsrctest"
   environment = "${layer0_environment.datasources.id}"
 
   port {
@@ -20,21 +20,17 @@ resource "layer0_load_balancer" "datasources" {
 }
 
 resource "layer0_service" "datasources" {
-  name          = "dsrctest_svc"
+  name          = "dsrctest"
   environment   = "${layer0_environment.datasources.id}"
   deploy        = "${layer0_deploy.datasources.id}"
   load_balancer = "${layer0_load_balancer.datasources.id}"
   scale         = "1"
-  wait          = true
+  wait          = false
 }
 
 resource "layer0_deploy" "datasources" {
-  name    = "dsrctest_dpl"
-  content = "${data.template_file.datasources.rendered}"
-}
-
-data "template_file" "datasources" {
-  template = "${file("${path.module}/Dockerrun.aws.json")}"
+  name    = "dsrctest"
+  content = "${file("${path.module}/Dockerrun.aws.json")}"
 }
 
 data "layer0_environment" "datasources" {

--- a/tests/system/cases/datasources/main.tf
+++ b/tests/system/cases/datasources/main.tf
@@ -1,0 +1,37 @@
+provider "layer0" {
+  endpoint        = "${var.endpoint}"
+  token           = "${var.token}"
+  skip_ssl_verify = true
+}
+
+resource "layer0_environment" "datasources" {
+  name = "datasources"
+}
+
+module "sts" {
+  source         = "../modules/sts"
+  environment_id = "${layer0_environment.datasources.id}"
+}
+
+data "layer0_environment" "datasources" {
+  depends_on = ["layer0_environment.datasources"]
+  name       = "datasources"
+}
+
+data "layer0_deploy" "datasources" {
+  depends_on = ["module.sts"]
+  name       = "${module.sts.deploy_name}"
+  version    = "1"
+}
+
+data "layer0_service" "datasources" {
+  depends_on     = ["module.sts"]
+  name           = "${module.sts.service_id}"
+  environment_id = "${layer0_environment.datasources.id}"
+}
+
+data "layer0_load_balancer" "datasources" {
+  depends_on     = ["module.sts"]
+  name           = "${module.sts.load_balancer_id}"
+  environment_id = "${layer0_environment.datasources.id}"
+}

--- a/tests/system/cases/datasources/main.tf
+++ b/tests/system/cases/datasources/main.tf
@@ -56,6 +56,6 @@ data "layer0_service" "datasources" {
 
 data "layer0_load_balancer" "datasources" {
   depends_on     = ["layer0_load_balancer.datasources", "layer0_service.datasources"]
-  name           = "${layer0_load_balancer.datasources.id}"
+  name           = "${layer0_load_balancer.datasources.name}"
   environment_id = "${layer0_environment.datasources.id}"
 }

--- a/tests/system/cases/datasources/outputs.tf
+++ b/tests/system/cases/datasources/outputs.tf
@@ -1,0 +1,71 @@
+output "environment_id" {
+  value = "${data.layer0_environment.datasources.id}"
+}
+
+output "environment_size" {
+  value = "${data.layer0_environment.datasources.size}"
+}
+
+output "environment_min_count" {
+  value = "${data.layer0_environment.datasources.min_count}"
+}
+
+output "environment_os" {
+  value = "${data.layer0_environment.datasources.os}"
+}
+
+output "environment_ami" {
+  value = "${data.layer0_environment.datasources.ami}"
+}
+
+output "deploy_id" {
+  value = "${data.layer0_deploy.datasources.id}"
+}
+
+output "load_balancer_id" {
+  value = "${data.layer0_load_balancer.datasources.id}"
+}
+
+output "load_balancer_name" {
+  value = "${data.layer0_load_balancer.datasources.name}"
+}
+
+output "load_balancer_environment_name" {
+  value = "${data.layer0_load_balancer.datasources.environment_name}"
+}
+
+output "load_balancer_private" {
+  value = "${data.layer0_load_balancer.datasources.private}"
+}
+
+output "load_balancer_url" {
+  value = "${data.layer0_load_balancer.datasources.url}"
+}
+
+output "load_balancer_service_id" {
+  value = "${data.layer0_load_balancer.datasources.service_id}"
+}
+
+output "load_balancer_service_name" {
+  value = "${data.layer0_load_balancer.datasources.service_name}"
+}
+
+output "service_id" {
+  value = "${data.layer0_service.datasources.id}"
+}
+
+output "service_environment_name" {
+  value = "${data.layer0_service.datasources.environment_name}"
+}
+
+output "service_lb_name" {
+  value = "${data.layer0_service.datasources.load_balancer_name}"
+}
+
+output "service_lb_id" {
+  value = "${data.layer0_service.datasources.load_balancer_id}"
+}
+
+output "service_scale" {
+  value = "${data.layer0_service.datasources.scale}"
+}

--- a/tests/system/cases/datasources/outputs.tf
+++ b/tests/system/cases/datasources/outputs.tf
@@ -1,71 +1,151 @@
+# -- Environment --
+
 output "environment_id" {
   value = "${data.layer0_environment.datasources.id}"
+}
+
+output "environment_id_expected" {
+  value = "${layer0_environment.datasources.id}"
 }
 
 output "environment_size" {
   value = "${data.layer0_environment.datasources.size}"
 }
 
+output "environment_size_expected" {
+  value = "${layer0_environment.datasources.size}"
+}
+
 output "environment_min_count" {
   value = "${data.layer0_environment.datasources.min_count}"
+}
+
+output "environment_min_count_expected" {
+  value = "${layer0_environment.datasources.cluster_count}"
 }
 
 output "environment_os" {
   value = "${data.layer0_environment.datasources.os}"
 }
 
+output "environment_os_expected" {
+  value = "${layer0_environment.datasources.os}"
+}
+
 output "environment_ami" {
   value = "${data.layer0_environment.datasources.ami}"
 }
+
+output "environment_ami_expected" {
+  value = "${layer0_environment.datasources.ami}"
+}
+
+# -- Deploy --
 
 output "deploy_id" {
   value = "${data.layer0_deploy.datasources.id}"
 }
 
+output "deploy_id_expected" {
+  value = "${layer0_deploy.datasources.id}"
+}
+
+# -- Load Balancer --
+
 output "load_balancer_id" {
   value = "${data.layer0_load_balancer.datasources.id}"
+}
+
+output "load_balancer_id_expected" {
+  value = "${layer0_load_balancer.datasources.id}"
 }
 
 output "load_balancer_name" {
   value = "${data.layer0_load_balancer.datasources.name}"
 }
 
+output "load_balancer_name_expected" {
+  value = "${layer0_load_balancer.datasources.name}"
+}
+
 output "load_balancer_environment_name" {
   value = "${data.layer0_load_balancer.datasources.environment_name}"
+}
+
+output "load_balancer_environment_name_expected" {
+  value = "${layer0_environment.datasources.name}"
 }
 
 output "load_balancer_private" {
   value = "${data.layer0_load_balancer.datasources.private}"
 }
 
+output "load_balancer_private_expected" {
+  value = "${layer0_load_balancer.datasources.private}"
+}
+
 output "load_balancer_url" {
   value = "${data.layer0_load_balancer.datasources.url}"
+}
+
+output "load_balancer_url_expected" {
+  value = "${layer0_load_balancer.datasources.url}"
 }
 
 output "load_balancer_service_id" {
   value = "${data.layer0_load_balancer.datasources.service_id}"
 }
 
+output "load_balancer_service_id_expected" {
+  value = "${layer0_service.datasources.id}"
+}
+
 output "load_balancer_service_name" {
   value = "${data.layer0_load_balancer.datasources.service_name}"
 }
 
+output "load_balancer_service_name_expected" {
+  value = "${layer0_service.datasources.service_name}"
+}
+
+# -- Service --
+
 output "service_id" {
   value = "${data.layer0_service.datasources.id}"
+}
+
+output "service_id_expected" {
+  value = "${layer0_service.datasources.id}"
 }
 
 output "service_environment_name" {
   value = "${data.layer0_service.datasources.environment_name}"
 }
 
-output "service_lb_name" {
-  value = "${data.layer0_service.datasources.load_balancer_name}"
+output "service_environment_name_expected" {
+  value = "${layer0_environment.datasources.name}"
 }
 
 output "service_lb_id" {
   value = "${data.layer0_service.datasources.load_balancer_id}"
 }
 
+output "service_lb_id_expected" {
+  value = "${layer0_service.datasources.load_balancer}"
+}
+
+output "service_lb_name" {
+  value = "${data.layer0_service.datasources.load_balancer_name}"
+}
+
+output "service_lb_name_expected" {
+  value = "${layer0_load_balancer.datasources.name}"
+}
+
 output "service_scale" {
   value = "${data.layer0_service.datasources.scale}"
+}
+
+output "service_scale_expected" {
+  value = "${layer0_service.datasources.scale}"
 }

--- a/tests/system/cases/datasources/outputs.tf
+++ b/tests/system/cases/datasources/outputs.tf
@@ -8,6 +8,14 @@ output "environment_id_expected" {
   value = "${layer0_environment.datasources.id}"
 }
 
+output "environment_name" {
+  value = "${data.layer0_environment.datasources.name}"
+}
+
+output "environment_name_expected" {
+  value = "${layer0_environment.datasources.name}"
+}
+
 output "environment_size" {
   value = "${data.layer0_environment.datasources.size}"
 }
@@ -48,6 +56,22 @@ output "deploy_id" {
 
 output "deploy_id_expected" {
   value = "${layer0_deploy.datasources.id}"
+}
+
+output "deploy_name" {
+  value = "${data.layer0_deploy.datasources.version}"
+}
+
+output "deploy_name_expected" {
+  value = "${layer0_deploy.datasources.version}"
+}
+
+output "deploy_version" {
+  value = "${data.layer0_deploy.datasources.version}"
+}
+
+output "deploy_version_expected" {
+  value = "${layer0_deploy.datasources.version}"
 }
 
 # -- Load Balancer --
@@ -100,6 +124,22 @@ output "service_id" {
 
 output "service_id_expected" {
   value = "${layer0_service.datasources.id}"
+}
+
+output "service_name" {
+  value = "${data.layer0_service.datasources.name}"
+}
+
+output "service_name_expected" {
+  value = "${layer0_service.datasources.name}"
+}
+
+output "service_environment_id" {
+  value = "${data.layer0_service.datasources.environment_id}"
+}
+
+output "service_environment_id_expected" {
+  value = "${layer0_environment.datasources.id}"
 }
 
 output "service_environment_name" {

--- a/tests/system/cases/datasources/outputs.tf
+++ b/tests/system/cases/datasources/outputs.tf
@@ -92,22 +92,6 @@ output "load_balancer_url_expected" {
   value = "${layer0_load_balancer.datasources.url}"
 }
 
-output "load_balancer_service_id" {
-  value = "${data.layer0_load_balancer.datasources.service_id}"
-}
-
-output "load_balancer_service_id_expected" {
-  value = "${layer0_service.datasources.id}"
-}
-
-output "load_balancer_service_name" {
-  value = "${data.layer0_load_balancer.datasources.service_name}"
-}
-
-output "load_balancer_service_name_expected" {
-  value = "${layer0_service.datasources.service_name}"
-}
-
 # -- Service --
 
 output "service_id" {
@@ -124,22 +108,6 @@ output "service_environment_name" {
 
 output "service_environment_name_expected" {
   value = "${layer0_environment.datasources.name}"
-}
-
-output "service_lb_id" {
-  value = "${data.layer0_service.datasources.load_balancer_id}"
-}
-
-output "service_lb_id_expected" {
-  value = "${layer0_service.datasources.load_balancer}"
-}
-
-output "service_lb_name" {
-  value = "${data.layer0_service.datasources.load_balancer_name}"
-}
-
-output "service_lb_name_expected" {
-  value = "${layer0_load_balancer.datasources.name}"
 }
 
 output "service_scale" {

--- a/tests/system/cases/datasources/variables.tf
+++ b/tests/system/cases/datasources/variables.tf
@@ -1,0 +1,3 @@
+variable "endpoint" {}
+
+variable "token" {}

--- a/tests/system/cases/modules/sts/outputs.tf
+++ b/tests/system/cases/modules/sts/outputs.tf
@@ -13,7 +13,3 @@ output "load_balancer_url" {
 output "deploy_id" {
   value = "${layer0_deploy.sts.id}"
 }
-
-output "deploy_name" {
-  value = "${layer0_deploy.sts.name}"
-}

--- a/tests/system/cases/modules/sts/outputs.tf
+++ b/tests/system/cases/modules/sts/outputs.tf
@@ -13,3 +13,7 @@ output "load_balancer_url" {
 output "deploy_id" {
   value = "${layer0_deploy.sts.id}"
 }
+
+output "deploy_name" {
+  value = "${layer0_deploy.sts.name}"
+}

--- a/tests/system/datasources_test.go
+++ b/tests/system/datasources_test.go
@@ -11,9 +11,20 @@ func TestDataSources(t *testing.T) {
 	s.Terraform.Apply()
 	defer s.Terraform.Destroy()
 
+	// Compare outputs of data and resource values (resource
+	// values have the '_expected' suffix)
 	checkOutput := func(key string) {
-		log.Debugf("Checking output: %s", key)
-		s.Terraform.Output(key)
+		log.Debugf("Checking data source vs resource output for key: %s", key)
+		datasourceOutput := s.Terraform.Output(key)
+		resourceOutput := s.Terraform.Output(key + "_expected")
+
+		if datasourceOutput != resourceOutput {
+			log.Fatalf(
+				"Data value '%s' and Resource value '%s' do not match for key: %s",
+				datasourceOutput,
+				resourceOutput,
+				key)
+		}
 	}
 
 	//check environment outputs

--- a/tests/system/datasources_test.go
+++ b/tests/system/datasources_test.go
@@ -42,5 +42,5 @@ func TestDataSources(t *testing.T) {
 	checkOutput("service_lb_id")
 	checkOutput("service_scale")
 
-	log.Debugf("Tests passed?")
+	log.Debugf("L0 Terraform Provider Data sources Tests completed.")
 }

--- a/tests/system/datasources_test.go
+++ b/tests/system/datasources_test.go
@@ -4,6 +4,12 @@ import (
 	"testing"
 )
 
+// Test Resources:
+// This test creates the following:
+// - environment named dsrctest
+// - load balancer named dsrctest
+// - service named dsrctest
+// - deploy named dsrctest
 func TestDataSources(t *testing.T) {
 	t.Parallel()
 
@@ -15,20 +21,19 @@ func TestDataSources(t *testing.T) {
 	// values have the '_expected' suffix)
 	checkOutput := func(key string) {
 		log.Debugf("Checking data source vs resource output for key: %s", key)
-		datasourceOutput := s.Terraform.Output(key)
-		resourceOutput := s.Terraform.Output(key + "_expected")
 
-		if datasourceOutput != resourceOutput {
-			log.Fatalf(
+		if dVal, rVal := s.Terraform.Output(key), s.Terraform.Output(key+"_expected"); dVal != rVal {
+			t.Fatalf(
 				"Data value '%s' and Resource value '%s' do not match for key: %s",
-				datasourceOutput,
-				resourceOutput,
+				dVal,
+				rVal,
 				key)
 		}
 	}
 
 	//check environment outputs
 	checkOutput("environment_id")
+	checkOutput("environment_name")
 	checkOutput("environment_size")
 	checkOutput("environment_min_count")
 	checkOutput("environment_os")
@@ -36,6 +41,8 @@ func TestDataSources(t *testing.T) {
 
 	//check deploy output
 	checkOutput("deploy_id")
+	checkOutput("deploy_name")
+	checkOutput("deploy_version")
 
 	//check load balancer outputs
 	checkOutput("load_balancer_id")
@@ -46,6 +53,8 @@ func TestDataSources(t *testing.T) {
 
 	//check service outputs
 	checkOutput("service_id")
+	checkOutput("service_name")
+	checkOutput("service_environment_id")
 	checkOutput("service_environment_name")
 	checkOutput("service_scale")
 

--- a/tests/system/datasources_test.go
+++ b/tests/system/datasources_test.go
@@ -1,0 +1,46 @@
+package system
+
+import (
+	"testing"
+)
+
+func TestDataSources(t *testing.T) {
+	t.Parallel()
+
+	s := NewSystemTest(t, "cases/datasources", nil)
+	s.Terraform.Apply()
+	defer s.Terraform.Destroy()
+
+	checkOutput := func(key string) {
+		log.Debugf("Checking output: %s", key)
+		s.Terraform.Output(key)
+	}
+
+	//check environment outputs
+	checkOutput("environment_id")
+	checkOutput("environment_size")
+	checkOutput("environment_min_count")
+	checkOutput("environment_os")
+	checkOutput("environment_ami")
+
+	//check deploy output
+	checkOutput("deploy_id")
+
+	//check load balancer outputs
+	checkOutput("load_balancer_id")
+	checkOutput("load_balancer_name")
+	checkOutput("load_balancer_environment_name")
+	checkOutput("load_balancer_private")
+	checkOutput("load_balancer_url")
+	checkOutput("load_balancer_service_id")
+	checkOutput("load_balancer_service_name")
+
+	//check service outputs
+	checkOutput("service_id")
+	checkOutput("service_environment_name")
+	checkOutput("service_lb_name")
+	checkOutput("service_lb_id")
+	checkOutput("service_scale")
+
+	log.Debugf("Tests passed?")
+}

--- a/tests/system/datasources_test.go
+++ b/tests/system/datasources_test.go
@@ -43,14 +43,10 @@ func TestDataSources(t *testing.T) {
 	checkOutput("load_balancer_environment_name")
 	checkOutput("load_balancer_private")
 	checkOutput("load_balancer_url")
-	checkOutput("load_balancer_service_id")
-	checkOutput("load_balancer_service_name")
 
 	//check service outputs
 	checkOutput("service_id")
 	checkOutput("service_environment_name")
-	checkOutput("service_lb_name")
-	checkOutput("service_lb_id")
 	checkOutput("service_scale")
 
 	log.Debugf("L0 Terraform Provider Data sources Tests completed.")


### PR DESCRIPTION
**What does this pull request do?**
Adds systems tests to verify the output of Layer0 provider's Datasource entities added in #263 . Also fixes functionality that exposes `layer0_deploy.version` & `enviornment.cluster_count` resources.


**How should this be tested?**
From the `./tests/system` directory run `go test -v -debug -run TestDataSources`.


**Checklist**
- [ ] Unit tests
- [x] Smoke tests (if applicable)
- [ ] System tests (if applicable)
- [ ] Documentation (if applicable)


closes #280 