### PR TITLE
Warn user if the docker config files doesn't contain expected information

### DIFF
--- a/setup/docker/config.go
+++ b/setup/docker/config.go
@@ -5,7 +5,8 @@ import (
 )
 
 type Config struct {
-	Auths map[string]Auth `json:"auths,omitempty"`
+	Auths      map[string]Auth `json:"auths,omitempty"`
+	CredsStore string          `json:"credsStore,omitempty"`
 }
 
 type Auth map[string]interface{}

--- a/setup/docker/utils.go
+++ b/setup/docker/utils.go
@@ -19,6 +19,30 @@ func LoadConfig(path string) (*Config, error) {
 
 	if config.Auths == nil {
 		config.Auths = map[string]Auth{}
+	} else if len(config.Auths) == 0 {
+		fmt.Println("[WARNING] Even though you have specified a path to a docker config file, " +
+			"it does not contain any auth information. If you need to add auth information " +
+			"to the docker config file, you can do so and re-run the l0-setup init command to " +
+			"include private registry authentication.\n")
+
+		fmt.Println("Press 'enter' to continue without private registry authentication: ")
+
+		var input string
+		fmt.Scanln(&input)
+	} else if config.CredsStore != "" {
+		fmt.Printf("[WARNING] Even though you have specified a path to a docker config file, "+
+			"the config file is using a credential store '%s' to cache the credentials. This "+
+			"means the credentials for private registry authentication aren't in the docker "+
+			"config file. You can either not use a credential store by removing the 'credsStore' "+
+			"section or add a 'credHelpers' section and exclude your private docker repository "+
+			"so that the private registry credentials, for just your repository are stored in "+
+			"the file you have specified.\n\n",
+			config.CredsStore)
+
+		fmt.Println("Press 'enter' to continue without private registry authentication: ")
+
+		var input string
+		fmt.Scanln(&input)
 	}
 
 	return config, nil

--- a/setup/docker/utils.go
+++ b/setup/docker/utils.go
@@ -19,30 +19,6 @@ func LoadConfig(path string) (*Config, error) {
 
 	if config.Auths == nil {
 		config.Auths = map[string]Auth{}
-	} else if len(config.Auths) == 0 {
-		fmt.Println("[WARNING] Even though you have specified a path to a docker config file, " +
-			"it does not contain any auth information. If you need to add auth information " +
-			"to the docker config file, you can do so and re-run the l0-setup init command to " +
-			"include private registry authentication.\n")
-
-		fmt.Println("Press 'enter' to continue without private registry authentication: ")
-
-		var input string
-		fmt.Scanln(&input)
-	} else if config.CredsStore != "" {
-		fmt.Printf("[WARNING] Even though you have specified a path to a docker config file, "+
-			"the config file is using a credential store '%s' to cache the credentials. This "+
-			"means the credentials for private registry authentication aren't in the docker "+
-			"config file. You can either not use a credential store by removing the 'credsStore' "+
-			"section or add a 'credHelpers' section and exclude your private docker repository "+
-			"so that the private registry credentials, for just your repository are stored in "+
-			"the file you have specified.\n\n",
-			config.CredsStore)
-
-		fmt.Println("Press 'enter' to continue without private registry authentication: ")
-
-		var input string
-		fmt.Scanln(&input)
 	}
 
 	return config, nil

--- a/setup/instance/init.go
+++ b/setup/instance/init.go
@@ -2,10 +2,11 @@ package instance
 
 import (
 	"fmt"
+	"os"
+
 	"github.com/Sirupsen/logrus"
 	"github.com/quintilesims/layer0/setup/docker"
 	"github.com/quintilesims/layer0/setup/terraform"
-	"os"
 )
 
 func (l *LocalInstance) Init(dockerInputPath string, inputOverrides map[string]interface{}) error {
@@ -121,6 +122,32 @@ func (l *LocalInstance) createOrWriteDockerCFG(dockerInputPath string) error {
 	config, err := docker.LoadConfig(dockerInputPath)
 	if err != nil {
 		return err
+	}
+
+	if len(config.Auths) == 0 {
+		fmt.Println("[WARNING] Even though you have specified a path to a docker config file, " +
+			"it does not contain any auth information. If you need to add auth information " +
+			"to the docker config file, you can do so and re-run the l0-setup init command to " +
+			"include private registry authentication.\n")
+
+		fmt.Println("Press 'enter' to continue without private registry authentication: ")
+
+		var input string
+		fmt.Scanln(&input)
+	} else if config.CredsStore != "" {
+		fmt.Printf("[WARNING] Even though you have specified a path to a docker config file, "+
+			"the config file is using a credential store '%s' to cache the credentials. This "+
+			"means the credentials for private registry authentication aren't in the docker "+
+			"config file. You can either not use a credential store by removing the 'credsStore' "+
+			"section or add a 'credHelpers' section and exclude your private docker repository "+
+			"so that the private registry credentials, for just your repository are stored in "+
+			"the file you have specified.\n\n",
+			config.CredsStore)
+
+		fmt.Println("Press 'enter' to continue without private registry authentication: ")
+
+		var input string
+		fmt.Scanln(&input)
 	}
 
 	return docker.WriteConfig(dockerOutputPath, config)

--- a/setup/instance/init.go
+++ b/setup/instance/init.go
@@ -135,13 +135,8 @@ func (l *LocalInstance) createOrWriteDockerCFG(dockerInputPath string) error {
 		var input string
 		fmt.Scanln(&input)
 	} else if config.CredsStore != "" {
-		fmt.Printf("[WARNING] Even though you have specified a path to a docker config file, "+
-			"the config file is using a credential store '%s' to cache the credentials. This "+
-			"means the credentials for private registry authentication aren't in the docker "+
-			"config file. You can either not use a credential store by removing the 'credsStore' "+
-			"section or add a 'credHelpers' section and exclude your private docker repository "+
-			"so that the private registry credentials, for just your repository are stored in "+
-			"the file you have specified.\n\n",
+		fmt.Printf("[WARNING] You are using a credential store '%s'. "+
+			"Layer0 does not support credential store authentication.\n\n",
 			config.CredsStore)
 
 		fmt.Println("Press 'enter' to continue without private registry authentication: ")


### PR DESCRIPTION
**What does this pull request do?**
Warns the user when running `l0-setup init` if the following is cases are met:

- if the auth property in the docker config file is empty
- if the docker config file is using a credential store

The warning message informs the user about the issue and suggests a potential solution.


**How should this be tested?**
Run l0-setup init with the docker config:

**Case 1: Missing Auth information**
```
{
	"auths": {}
}
```

**Case 2: Using a credential store**
```
{
	"auths": {
		"private-docker-repository.io": {}
	},
	"credsStore": "osxkeychain"
}
```

**Checklist**
- [ ] Unit tests
- [ ] Smoke tests (if applicable)
- [ ] System tests (if applicable)
- [ ] Documentation (if applicable)


closes #255 