### PR TITLE
Fixed smoketests - service create needs deploy_name:latest

### DIFF
--- a/tests/smoke/deploy.bats
+++ b/tests/smoke/deploy.bats
@@ -16,6 +16,10 @@
     l0 deploy get guestbook1
 }
 
+@test "deploy get guestbook1:latest" {
+    l0 deploy get guestbook1:latest
+}
+
 @test "deploy get guest*" {
     l0 deploy get guest\*
 }

--- a/tests/smoke/load_balancer.bats
+++ b/tests/smoke/load_balancer.bats
@@ -74,8 +74,8 @@ certificate_name="l0-$LAYER0_PREFIX-api"
     l0 deploy create ./common/Service.Dockerrun.aws.json guestbook
 }
 
-@test "service create --loadbalancer loadbalancer4 test service1 guestbook" {
-    l0 service create --loadbalancer loadbalancer4 test service1 guestbook
+@test "service create --loadbalancer loadbalancer4 test service1 guestbook:latest" {
+    l0 service create --loadbalancer loadbalancer4 test service1 guestbook:latest
 }
 
 @test "loadbalancer list" {
@@ -86,8 +86,8 @@ certificate_name="l0-$LAYER0_PREFIX-api"
     l0 loadbalancer get loadbalancer4
 }
 
-@test "deploy delete guestbook" {
-    l0 deploy delete guestbook
+@test "deploy delete guestbook:latest" {
+    l0 deploy delete guestbook:latest
 }
 
 # this deletes the remaining service(s) and loadbalancer(s)

--- a/tests/smoke/service.bats
+++ b/tests/smoke/service.bats
@@ -44,15 +44,15 @@
     l0 deploy create ./common/Service.Dockerrun.aws.json guestbook
 }
 
-@test "service update service1 guestbook" {
+@test "service update service1 guestbook:latest" {
     l0 service update service1 guestbook:latest
 }
 
-@test "service update --wait service2 guestbook" {
+@test "service update --wait service2 guestbook:latest" {
     l0 service update --wait service2 guestbook:latest
 }
 
-@test "service update service3 guestbook" {
+@test "service update service3 guestbook:latest" {
     l0 service update service3 guestbook:latest
 }
 

--- a/tests/smoke/service.bats
+++ b/tests/smoke/service.bats
@@ -12,16 +12,16 @@
     l0 deploy create ./common/Service.Dockerrun.aws.json guestbook
 }
 
-@test "service create --loadbalancer loadbalancer1 test service1 guestbook" {
-    l0 service create --loadbalancer loadbalancer1 test service1 guestbook
+@test "service create --loadbalancer loadbalancer1 test service1 guestbook:latest" {
+    l0 service create --loadbalancer loadbalancer1 test service1 guestbook:latest
 }
 
-@test "service create --wait test service2 guestbook" {
-    l0 service create --wait test service2 guestbook
+@test "service create --wait test service2 guestbook:latest" {
+    l0 service create --wait test service2 guestbook:latest
 }
 
-@test "service create test service3 guestbook" {
-    l0 service create test service3 guestbook
+@test "service create test service3 guestbook:latest" {
+    l0 service create test service3 guestbook:latest
 }
 
 @test "service list" {

--- a/tests/smoke/task.bats
+++ b/tests/smoke/task.bats
@@ -8,12 +8,12 @@
     l0 deploy create ./common/Task.Dockerrun.aws.json alpine
 }
 
-@test "task create --wait test task1 alpine" {
-    l0 task create --wait test task1 alpine
+@test "task create --wait test task1 alpine:latest" {
+    l0 task create --wait test task1 alpine:latest
 }
 
-@test "task create --copies 2 --env alpine:key=val test task2 alpine" {
-    l0 task create --copies 2 --env alpine:key=val test task2 alpine 
+@test "task create --copies 2 --env alpine:key=val test task2 alpine:latest" {
+    l0 task create --copies 2 --env alpine:key=val test task2 alpine:latest
 }
 
 @test "task list" {
@@ -48,8 +48,8 @@
     l0 task delete task1
 }
 
-@test "deploy delete alpine" {
-    l0 deploy delete alpine
+@test "deploy delete alpine:latest" {
+    l0 deploy delete alpine:latest
 }
 
 # this deletes the remaining service(s), loadbalancer(s), and task(s)


### PR DESCRIPTION
**What does this pull request do?**
Fixes smoke tests that were failing on service create commands due to deploy version or deploy:latest no being explicitly specified.


**Checklist**
- [ ] ~Unit tests~
- [x] Smoke tests (if applicable)
- [ ] ~System tests (if applicable)~
- [ ] ~Documentation (if applicable)~

