### PR TITLE
Consistently catch <Entity> does not exist errors

### DIFF
--- a/api/backend/ecs/deploy_manager.go
+++ b/api/backend/ecs/deploy_manager.go
@@ -45,7 +45,7 @@ func (this *ECSDeployManager) GetDeploy(deployID string) (*models.Deploy, error)
 	if err != nil {
 		if ContainsErrMsg(err, "Unable to describe task definition") {
 			err := fmt.Errorf("Deploy with id '%s' does not exist", deployID)
-			return nil, errors.New(errors.InvalidDeployID, err)
+			return nil, errors.New(errors.DeployDoesNotExist, err)
 		}
 
 		return nil, err

--- a/api/backend/ecs/environment_manager.go
+++ b/api/backend/ecs/environment_manager.go
@@ -70,7 +70,7 @@ func (e *ECSEnvironmentManager) GetEnvironment(environmentID string) (*models.En
 	cluster, err := e.ECS.DescribeCluster(ecsEnvironmentID.String())
 	if err != nil {
 		if ContainsErrCode(err, "ClusterNotFoundException") || ContainsErrMsg(err, "cluster not found") {
-			return nil, errors.Newf(errors.InvalidEnvironmentID, "Environment with id '%s' was not found", environmentID)
+			return nil, errors.Newf(errors.EnvironmentDoesNotExist, "Environment with id '%s' does not exist", environmentID)
 		}
 
 		return nil, err

--- a/api/backend/ecs/load_balancer_manager.go
+++ b/api/backend/ecs/load_balancer_manager.go
@@ -65,7 +65,7 @@ func (e *ECSLoadBalancerManager) GetLoadBalancer(loadBalancerID string) (*models
 	if err != nil {
 		if ContainsErrCode(err, "LoadBalancerNotFound") {
 			err := fmt.Errorf("LoadBalancer with id '%s' does not exist", loadBalancerID)
-			return nil, errors.New(errors.InvalidLoadBalancerID, err)
+			return nil, errors.New(errors.LoadBalancerDoesNotExist, err)
 		}
 
 		return nil, err

--- a/api/backend/ecs/service_manager.go
+++ b/api/backend/ecs/service_manager.go
@@ -65,7 +65,7 @@ func (this *ECSServiceManager) GetService(environmentID, serviceID string) (*mod
 	if err != nil {
 		if ContainsErrMsg(err, "Service Not Found") {
 			err := fmt.Errorf("Service with id '%s' does not exist", serviceID)
-			return nil, errors.New(errors.InvalidServiceID, err)
+			return nil, errors.New(errors.ServiceDoesNotExist, err)
 		}
 
 		return nil, err

--- a/api/logic/service_logic.go
+++ b/api/logic/service_logic.go
@@ -217,7 +217,7 @@ func (this *L0ServiceLogic) getEnvironmentID(serviceID string) (string, error) {
 		}
 	}
 
-	return "", errors.Newf(errors.InvalidServiceID, "Service %s does not exist", serviceID)
+	return "", errors.Newf(errors.ServiceDoesNotExist, "Service %s does not exist", serviceID)
 }
 
 func (this *L0ServiceLogic) doesServiceTagExist(environmentID, name string) (bool, error) {

--- a/cli/client/api_client.go
+++ b/cli/client/api_client.go
@@ -154,7 +154,7 @@ func (c *APIClient) execute(sling *sling.Sling, receive interface{}) (*http.Resp
 	}
 
 	if serverError != nil {
-		return nil, serverError
+		return nil, serverError.ToCommonError()
 	}
 
 	if resp.StatusCode < 200 || resp.StatusCode > 299 {

--- a/cli/client/api_client_test.go
+++ b/cli/client/api_client_test.go
@@ -4,6 +4,7 @@ import (
 	"net/http"
 	"testing"
 
+	"github.com/quintilesims/layer0/common/errors"
 	"github.com/quintilesims/layer0/common/models"
 	"github.com/quintilesims/layer0/common/testutils"
 )
@@ -22,13 +23,13 @@ func TestExecuteErrors(t *testing.T) {
 		t.Fatalf("Error was nil!")
 	}
 
-	se, ok := err.(*ServerError)
+	se, ok := err.(*errors.ServerError)
 	if !ok {
 		t.Fatalf("Error was not of type *ServerError")
 	}
 
-	testutils.AssertEqual(t, se.Message, "msg")
-	testutils.AssertEqual(t, se.ErrorCode, int64(1))
+	testutils.AssertEqual(t, se.Err.Error(), "msg")
+	testutils.AssertEqual(t, se.Code, errors.ErrorCode(1))
 }
 
 func TestExecuteWithJob(t *testing.T) {

--- a/cli/client/errors.go
+++ b/cli/client/errors.go
@@ -18,10 +18,10 @@ func sslError(err error) error {
 
 type ServerError models.ServerError
 
-func (this *ServerError) Error() string {
-	return this.Message
+func (s *ServerError) Error() string {
+	return s.Message
 }
 
-func (this *ServerError) ToCommonError() *errors.ServerError {
-	return errors.Newf(errors.ErrorCode(this.ErrorCode), this.Message)
+func (s *ServerError) ToCommonError() *errors.ServerError {
+	return errors.Newf(errors.ErrorCode(s.ErrorCode), s.Message)
 }

--- a/cli/client/errors.go
+++ b/cli/client/errors.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	"github.com/quintilesims/layer0/common/config"
+	"github.com/quintilesims/layer0/common/errors"
 	"github.com/quintilesims/layer0/common/models"
 )
 
@@ -19,4 +20,8 @@ type ServerError models.ServerError
 
 func (this *ServerError) Error() string {
 	return this.Message
+}
+
+func (this *ServerError) ToCommonError() *errors.ServerError {
+	return errors.Newf(errors.ErrorCode(this.ErrorCode), this.Message)
 }

--- a/common/errors/code.go
+++ b/common/errors/code.go
@@ -25,4 +25,10 @@ const (
 	Throttled
 	UnexpectedError
 	FailedTagging
+	DeployDoesNotExist
+	EnvironmentDoesNotExist
+	JobDoesNotExist
+	LoadBalancerDoesNotExist
+	ServiceDoesNotExist
+	TaskDoesNotExist
 )

--- a/plugins/terraform/resource_layer0_environment.go
+++ b/plugins/terraform/resource_layer0_environment.go
@@ -2,9 +2,9 @@ package main
 
 import (
 	"log"
-	"strings"
 
 	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/quintilesims/layer0/common/errors"
 )
 
 func resourceLayer0Environment() *schema.Resource {
@@ -86,7 +86,7 @@ func resourceLayer0EnvironmentRead(d *schema.ResourceData, meta interface{}) err
 
 	environment, err := client.API.GetEnvironment(environmentID)
 	if err != nil {
-		if strings.Contains(err.Error(), "No environment found") {
+		if err, ok := err.(*errors.ServerError); ok && err.Code == errors.EnvironmentDoesNotExist {
 			d.SetId("")
 			log.Printf("[WARN] Error Reading Environment (%s), environment does not exist", environmentID)
 			return nil
@@ -126,7 +126,7 @@ func resourceLayer0EnvironmentDelete(d *schema.ResourceData, meta interface{}) e
 
 	jobID, err := client.API.DeleteEnvironment(environmentID)
 	if err != nil {
-		if strings.Contains(err.Error(), "No environment found") {
+		if err, ok := err.(*errors.ServerError); ok && err.Code == errors.EnvironmentDoesNotExist {
 			return nil
 		}
 

--- a/plugins/terraform/resource_layer0_load_balancer.go
+++ b/plugins/terraform/resource_layer0_load_balancer.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/hashicorp/terraform/helper/hashcode"
 	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/quintilesims/layer0/common/errors"
 	"github.com/quintilesims/layer0/common/models"
 )
 
@@ -138,7 +139,7 @@ func resourceLayer0LoadBalancerRead(d *schema.ResourceData, meta interface{}) er
 
 	loadBalancer, err := client.API.GetLoadBalancer(loadBalancerID)
 	if err != nil {
-		if strings.Contains(err.Error(), "No load_balancer found") {
+		if err, ok := err.(*errors.ServerError); ok && err.Code == errors.LoadBalancerDoesNotExist {
 			d.SetId("")
 			log.Printf("[WARN] Error Reading Load Balancer (%s), load balancer does not exist", loadBalancerID)
 			return nil
@@ -186,7 +187,7 @@ func resourceLayer0LoadBalancerDelete(d *schema.ResourceData, meta interface{}) 
 
 	jobID, err := client.API.DeleteLoadBalancer(loadBalancerID)
 	if err != nil {
-		if strings.Contains(err.Error(), "No load_balancer found") {
+		if err, ok := err.(*errors.ServerError); ok && err.Code == errors.LoadBalancerDoesNotExist {
 			return nil
 		}
 

--- a/plugins/terraform/resource_layer0_service.go
+++ b/plugins/terraform/resource_layer0_service.go
@@ -2,9 +2,9 @@ package main
 
 import (
 	"log"
-	"strings"
 
 	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/quintilesims/layer0/common/errors"
 )
 
 func resourceLayer0Service() *schema.Resource {
@@ -81,7 +81,7 @@ func resourceLayer0ServiceRead(d *schema.ResourceData, meta interface{}) error {
 
 	service, err := client.API.GetService(serviceID)
 	if err != nil {
-		if strings.Contains(err.Error(), "No service found") {
+		if err, ok := err.(*errors.ServerError); ok && err.Code == errors.ServiceDoesNotExist {
 			d.SetId("")
 			log.Printf("[WARN] Error Reading Service (%s), service does not exist", serviceID)
 			return nil
@@ -137,7 +137,7 @@ func resourceLayer0ServiceDelete(d *schema.ResourceData, meta interface{}) error
 
 	jobID, err := client.API.DeleteService(serviceID)
 	if err != nil {
-		if strings.Contains(err.Error(), "No service found") {
+		if err, ok := err.(*errors.ServerError); ok && err.Code == errors.ServiceDoesNotExist {
 			return nil
 		}
 


### PR DESCRIPTION
**What does this pull request do?**
API returns `<Entity>DoesNotExist` error code when GET requests are made on an entity that does not exist. This is captured more explicitly in the Terraform plugin, allowing Terraform to gracefully handle when entities don't exist. 

**How should this be tested?**
1. Create entities using Terraform
2. Delete the entities outside of Terraform (e.g. the CLI)
3. Run `terraform plan`; it should show that the deleted entities are marked for re-creation.   

closes #113 
