### PR TITLE
Add leftover tags janitor and handle resolving leftover tags in CLI.

### DIFF
--- a/api/logic/tag_janitor.go
+++ b/api/logic/tag_janitor.go
@@ -1,7 +1,6 @@
 package logic
 
 import (
-	"fmt"
 	"time"
 
 	"github.com/quintilesims/layer0/common/db/tag_store"
@@ -65,14 +64,13 @@ func (t *TagJanitor) pulse() error {
 
 	errs := []error{}
 	for _, tag := range tags {
-		fmt.Printf("tag: %s, %s, %s, %s \n", tag.EntityID, tag.EntityType, tag.Key, tag.Value)
 		if !taskExists(tag.EntityID) {
 			if err := t.TagStore.Delete(tag.EntityType, tag.EntityID, tag.Key); err != nil {
-				tagLogger.Errorf("Could not delete tag (id: %s, type: %s, key: %s) -  %s\n",
-					tag.EntityID, tag.EntityType, tag.Key, err.Error())
-			} else {
-				tagLogger.Infof("Tag for task (%s) has been deleted\n", tag.EntityID)
+				tagLogger.Errorf("Could not delete tag (%#v) -  %s\n", tag, err.Error())
+				continue
 			}
+
+			tagLogger.Infof("Tag for task (%s) has been deleted\n", tag.EntityID)
 		}
 	}
 

--- a/api/logic/tag_janitor.go
+++ b/api/logic/tag_janitor.go
@@ -1,0 +1,80 @@
+package logic
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/quintilesims/layer0/common/db/tag_store"
+	"github.com/quintilesims/layer0/common/errors"
+	"github.com/quintilesims/layer0/common/logutils"
+	"github.com/quintilesims/layer0/common/waitutils"
+)
+
+const (
+	taskJanitorSleepDuration = time.Minute * 10
+)
+
+var tagLogger = logutils.NewStackTraceLogger("Tags Janitor")
+
+type TagJanitor struct {
+	TaskLogic TaskLogic
+	TagStore  tag_store.TagStore
+	Clock     waitutils.Clock
+}
+
+func NewTagJanitor(taskLogic TaskLogic, tagStore tag_store.TagStore) *TagJanitor {
+	return &TagJanitor{
+		TaskLogic: taskLogic,
+		TagStore:  tagStore,
+		Clock:     waitutils.RealClock{},
+	}
+}
+
+func (t *TagJanitor) Run() {
+	go func() {
+		for {
+			tagLogger.Info("Starting cleanup")
+			t.pulse()
+			tagLogger.Infof("Finished cleanup")
+			t.Clock.Sleep(taskJanitorSleepDuration)
+		}
+	}()
+}
+
+func (t *TagJanitor) pulse() error {
+	tasks, err := t.TaskLogic.ListTasks()
+	if err != nil {
+		tagLogger.Errorf("Failed to list tasks: %v", err)
+		return err
+	}
+
+	taskExists := func(id string) bool {
+		for _, t := range tasks {
+			if t.TaskID == id {
+				return true
+			}
+		}
+
+		return false
+	}
+
+	tags, err := t.TagStore.SelectByType("task")
+	if err != nil {
+		tagLogger.Errorln("Could not query for tag store for task entity type - ", err.Error())
+	}
+
+	errs := []error{}
+	for _, tag := range tags {
+		fmt.Printf("tag: %s, %s, %s, %s \n", tag.EntityID, tag.EntityType, tag.Key, tag.Value)
+		if !taskExists(tag.EntityID) {
+			if err := t.TagStore.Delete(tag.EntityType, tag.EntityID, tag.Key); err != nil {
+				tagLogger.Errorf("Could not delete tag (id: %s, type: %s, key: %s) -  %s\n",
+					tag.EntityID, tag.EntityType, tag.Key, err.Error())
+			} else {
+				tagLogger.Infof("Tag for task (%s) has been deleted\n", tag.EntityID)
+			}
+		}
+	}
+
+	return errors.MultiError(errs)
+}

--- a/api/logic/tag_janitor_test.go
+++ b/api/logic/tag_janitor_test.go
@@ -1,0 +1,71 @@
+package logic
+
+import (
+	"testing"
+
+	"github.com/golang/mock/gomock"
+	"github.com/quintilesims/layer0/api/logic/mock_logic"
+	"github.com/quintilesims/layer0/common/db/tag_store"
+	"github.com/quintilesims/layer0/common/models"
+	"github.com/quintilesims/layer0/common/testutils"
+)
+
+func TestTagJanitorPulse(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	taskLogicMock := mock_logic.NewMockTaskLogic(ctrl)
+	tagStore, tagsAdded := getTagStore()
+
+	tasks := []*models.TaskSummary{
+		{
+			TaskID: "task2",
+		},
+	}
+
+	taskLogicMock.EXPECT().
+		ListTasks().
+		Return(tasks, nil)
+
+	janitor := NewTagJanitor(taskLogicMock, tagStore)
+	if err := janitor.pulse(); err != nil {
+		t.Fatal(err)
+	}
+
+	tags, err := tagStore.SelectByType("task")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	//expecting 3 tags for task1 to be deleted from the tagstore
+	testutils.AssertEqual(t, tagsAdded-3, len(tags))
+	testutils.AssertEqual(t, "task2", tags[0].EntityID)
+}
+
+func getTagStore() (tag_store.TagStore, int) {
+	store := tag_store.NewMemoryTagStore()
+	tagsAdded := 0
+
+	generateTag := func(entityType, entityID, key, value string) models.Tag {
+		tagsAdded++
+
+		return models.Tag{
+			EntityType: entityType,
+			EntityID:   entityID,
+			Key:        key,
+			Value:      value,
+		}
+	}
+
+	//task 1
+	store.Insert(generateTag("task", "task1", "deploy_id", "efgh-task.1"))
+	store.Insert(generateTag("task", "task1", "environment_id", "env1"))
+	store.Insert(generateTag("task", "task1", "name", "random-task"))
+
+	//task 2
+	store.Insert(generateTag("task", "task2", "deploy_id", "abcd-task.2"))
+	store.Insert(generateTag("task", "task2", "environment_id", "env1"))
+	store.Insert(generateTag("task", "task2", "name", "not-so-random-task"))
+
+	return store, tagsAdded
+}

--- a/api/main.go
+++ b/api/main.go
@@ -149,10 +149,14 @@ func main() {
 	}
 
 	jobJanitor := logic.NewJobJanitor(jobLogic)
+	tagJanitor := logic.NewTagJanitor(taskLogic, lgc.TagStore)
 	go runEnvironmentScaler(environmentLogic)
 
 	logrus.Infof("Starting Job Janitor")
 	jobJanitor.Run()
+
+	logrus.Infof("Starting Tag Janitor")
+	tagJanitor.Run()
 
 	logrus.Print("Service on localhost" + port)
 	logrus.Fatal(http.ListenAndServe(port, nil))

--- a/cli/command/task_command.go
+++ b/cli/command/task_command.go
@@ -179,7 +179,7 @@ func (t *TaskCommand) Get(c *cli.Context) error {
 	tasks := []*models.Task{}
 	getTaskf := func(id string) error {
 		if !taskExists(id) {
-			log.Debugln("No corresponding Task found for TaskID:", id)
+			log.Debugf("No corresponding Task found for TaskID: %s\n", id)
 			return nil
 		}
 

--- a/cli/command/task_command.go
+++ b/cli/command/task_command.go
@@ -3,6 +3,7 @@ package command
 import (
 	"strings"
 
+	log "github.com/Sirupsen/logrus"
 	"github.com/quintilesims/layer0/common/models"
 	"github.com/urfave/cli"
 )
@@ -160,8 +161,28 @@ func (t *TaskCommand) Delete(c *cli.Context) error {
 }
 
 func (t *TaskCommand) Get(c *cli.Context) error {
+	taskSummaries, err := t.Client.ListTasks()
+	if err != nil {
+		return err
+	}
+
+	taskExists := func(id string) bool {
+		for _, t := range taskSummaries {
+			if t.TaskID == id {
+				return true
+			}
+		}
+
+		return false
+	}
+
 	tasks := []*models.Task{}
 	getTaskf := func(id string) error {
+		if !taskExists(id) {
+			log.Debugln("No corresponding Task found for TaskID:", id)
+			return nil
+		}
+
 		task, err := t.Client.GetTask(id)
 		if err != nil {
 			return err

--- a/cli/command/task_command_test.go
+++ b/cli/command/task_command_test.go
@@ -242,10 +242,10 @@ func TestGetTask_expiredTasks(t *testing.T) {
 		ListTasks().
 		Return(result, nil)
 
+	//only task 'id3' should result in a GetTask call
 	tc.Client.EXPECT().
-		GetTask(gomock.Any()).
-		Return(&models.Task{}, nil).
-		Times(1) //only task 'id3' should result in a gettask call
+		GetTask("id3").
+		Return(&models.Task{}, nil)
 
 	c := testutils.GetCLIContext(t, []string{"name"}, nil)
 	if err := command.Get(c); err != nil {

--- a/cli/command/task_command_test.go
+++ b/cli/command/task_command_test.go
@@ -190,6 +190,12 @@ func TestGetTask(t *testing.T) {
 		Return([]string{"id"}, nil)
 
 	tc.Client.EXPECT().
+		ListTasks().
+		Return([]*models.TaskSummary{
+			{TaskID: "id"},
+		}, nil)
+
+	tc.Client.EXPECT().
 		GetTask("id").
 		Return(&models.Task{}, nil)
 
@@ -207,6 +213,10 @@ func TestGetTask_userInputErrors(t *testing.T) {
 	contexts := map[string]*cli.Context{
 		"Missing NAME arg": testutils.GetCLIContext(t, nil, nil),
 	}
+
+	tc.Client.EXPECT().
+		ListTasks().
+		Return(nil, nil)
 
 	for name, c := range contexts {
 		if err := command.Get(c); err == nil {


### PR DESCRIPTION
**What does this pull request do?**
Addresses the situation where the dynamodb task ends up with leftover tags which don't correspond to a ecs task. This causes the l0 cli to return errors when when executing commands like `l0 task get \*`. This PR addresses the CLI and the leftover Tags in 2 parts:

**CLI:**
Return a debug message when iterating over tasks and a task is not found.

**API:**
Add a new Tags Janitor that searches for and deletes leftover tags as result of ECS Tasks being removed, every 10 minutes.

---

**How should this be tested?**
Unit Test: `go test`

You can also simulate the left over task tag with the following steps:

1. Create a one off task in layer0
2. Ensure a corresponding tag exists in the dynamo db table l0_<l0_prefix>_tags table
3. Duplicate the corresponding tag item and update the `EntityID` with random suffix
4. Run the api locally `go run api/main.go`
5. Execute `l0 -d task get \*` to confirm:
  a. cli doesn't crash
  b. debug flag correctly mentions tag without a corresponding task
5. Check that the duplicated tag has been deleted from the random suffix in DynamoDB

---

**Checklist**
- [x] Unit tests
- [ ] ~Smoke tests (if applicable)~
- [ ] ~System tests (if applicable)~
- [ ] ~Documentation (if applicable)~


closes #140 
