### PR TITLE
Return '404 Not Found' errors when resource not found

### DIFF
--- a/api/backend/ecs/task_manager.go
+++ b/api/backend/ecs/task_manager.go
@@ -179,7 +179,7 @@ func (this *ECSTaskManager) GetTaskLogs(environmentID, taskID, start, end string
 // Assumes the tasks are all of the same type
 func modelFromTasks(tasks []*ecs.Task) (*models.Task, error) {
 	if len(tasks) == 0 {
-		return nil, errors.Newf(errors.InvalidTaskID, "The specified task does not exist")
+		return nil, errors.Newf(errors.TaskDoesNotExist, "The specified task does not exist")
 	}
 
 	var pendingCount, runningCount int64

--- a/api/handlers/errors.go
+++ b/api/handlers/errors.go
@@ -21,6 +21,9 @@ func ToHttpError(code errors.ErrorCode) int {
 		ret = http.StatusBadRequest
 	case errors.Throttled:
 		ret = http.StatusServiceUnavailable
+	case errors.DeployDoesNotExist, errors.EnvironmentDoesNotExist, errors.JobDoesNotExist,
+		errors.LoadBalancerDoesNotExist, errors.ServiceDoesNotExist, errors.TaskDoesNotExist:
+		ret = http.StatusNotFound
 	default:
 		ret = http.StatusInternalServerError
 	}

--- a/api/logic/task_logic.go
+++ b/api/logic/task_logic.go
@@ -164,7 +164,7 @@ func (this *L0TaskLogic) getEnvironmentID(taskID string) (string, error) {
 		}
 	}
 
-	return "", errors.Newf(errors.InvalidTaskID, "Task %s does not exist", taskID)
+	return "", errors.Newf(errors.TaskDoesNotExist, "Task %s does not exist", taskID)
 }
 
 func (this *L0TaskLogic) populateModel(model *models.Task) error {

--- a/common/db/job_store/dynamo.go
+++ b/common/db/job_store/dynamo.go
@@ -3,6 +3,7 @@ package job_store
 import (
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/guregu/dynamo"
+	"github.com/quintilesims/layer0/common/errors"
 	"github.com/quintilesims/layer0/common/models"
 	"github.com/quintilesims/layer0/common/types"
 )
@@ -75,9 +76,15 @@ func (d *DynamoJobStore) SelectAll() ([]*models.Job, error) {
 
 func (d *DynamoJobStore) SelectByID(jobID string) (*models.Job, error) {
 	var job *models.Job
+
 	if err := d.table.Get("JobID", jobID).
 		Consistent(true).
 		One(&job); err != nil {
+
+		if err.Error() == "dynamo: no item found" {
+			return nil, errors.Newf(errors.JobDoesNotExist, "Job %s does not exist", jobID)
+		}
+
 		return nil, err
 	}
 


### PR DESCRIPTION
**What does this pull request do?**
Return 404 Http response when a resource is not found:

- Deploy
- Service
- Environment
- Job
- Load Balancer
- Task


**How should this be tested?**
Run API locally. Test the below endpoints with a random id value that doesn't exist. Confirm you receive a 404 rather than a 500.

1. GET, DELETE entity/{id} for deploy, service, environment, job, load balancer & task
2. PUT service/{id}/scale & service/{id}/deploy
3. GET service/{id}/logs & task/{id}/logs 


**Checklist**
- [ ] ~Unit tests~
- [ ] ~Smoke tests (if applicable)~
- [ ] ~System tests (if applicable)~
- [ ] ~Documentation (if applicable)~


closes #304 