### PR TITLE
WIP: l0-setup upgrade: Breadcrumb message when current version is not SemV

### DIFF
--- a/setup/instance/upgrade.go
+++ b/setup/instance/upgrade.go
@@ -76,7 +76,9 @@ func assertPatchUpgrade(currentVersion, desiredVersion string) error {
 
 	current, err := semver.Make(currentVersion)
 	if err != nil {
-		return fmt.Errorf("Current version not semver compatible: %v\nUse --force to override this behavior", currentVersion)
+		text := fmt.Sprintf("Failed to parse current version ('%s'): %v\n", currentVersion, err)
+		text += "Use --force to disable semantic version checking"
+		return fmt.Errorf(text)
 	}
 
 	desired, err := semver.Make(desiredVersion)

--- a/setup/instance/upgrade.go
+++ b/setup/instance/upgrade.go
@@ -76,7 +76,7 @@ func assertPatchUpgrade(currentVersion, desiredVersion string) error {
 
 	current, err := semver.Make(currentVersion)
 	if err != nil {
-		return fmt.Errorf("Failed to parse current version: %v", err)
+		return fmt.Errorf("Current version not semver compatible: %v\nUse --force to override this behavior", currentVersion)
 	}
 
 	desired, err := semver.Make(desiredVersion)


### PR DESCRIPTION
…er compliant (#310)

If the current version of a user's layer0 (as defined in ~/.layer0/<instance>/main.tf.json)
is not semver compatible, this change will notify the user that they can use the --force
flag to override the message.

**What does this pull request do?**
Include a short summary of what this PR intends to fix and/or a reference to an existing issue.

Issue #310 
Changes console output when `l0-setup upgrade <instance_name> <version>` is run if the layer0 instance's version is not semver compatible. User will be directed to use `--force` to override the behavior.

**How should this be tested?**
Include steps to test intended functionality.

Use a non-standard version for your layer0, e.g. in ~/.layer0/<instance>/main.tf.json, set the version field to something like latest, e.g.

```
{
    "module": {
        "layer0": {
            ...
            "version": "latest",
            ...
        }
    }
}
```
Then try to run `l0-setup upgrade <instance_name> v0.10.3`

The user should be directed to use the `--force` flag. 

**Checklist**
- [ ] Unit tests
~- [ ] Smoke tests (if applicable)~
~- [ ] System tests (if applicable)~
~- [ ] Documentation (if applicable)~


closes #310 
(reference the issue(s) this pull request closes)
