### PR TITLE
Removed warning message when no auths property exists

### DIFF
--- a/setup/instance/init.go
+++ b/setup/instance/init.go
@@ -124,17 +124,7 @@ func (l *LocalInstance) createOrWriteDockerCFG(dockerInputPath string) error {
 		return err
 	}
 
-	if len(config.Auths) == 0 {
-		fmt.Println("[WARNING] Even though you have specified a path to a docker config file, " +
-			"it does not contain any auth information. If you need to add auth information " +
-			"to the docker config file, you can do so and re-run the l0-setup init command to " +
-			"include private registry authentication.\n")
-
-		fmt.Println("Press 'enter' to continue without private registry authentication: ")
-
-		var input string
-		fmt.Scanln(&input)
-	} else if config.CredsStore != "" {
+	if config.CredsStore != "" {
 		fmt.Printf("[WARNING] You are using a credential store '%s'. "+
 			"Layer0 does not support credential store authentication.\n\n",
 			config.CredsStore)


### PR DESCRIPTION
**What does this pull request do?**
Removes the warning message when an `auths` property doesn't exists in a docker config file being used for private repo authentication.


**How should this be tested?**
Run `l0-setup init <name>` with a docker config file like:
```
{
  "https://index.docker.io/v1/": {
    "auth": "zq212MzEXAMPLE7o6T25Dk0i",
    "email": "email@example.com"
  }
}
```

Even though the above format is valid, l0-setup generates a warning.

**Checklist**
- ~[ ] Unit tests~
- ~[ ] Smoke tests (if applicable)~
- ~[ ] System tests (if applicable)~
- ~[ ] Documentation (if applicable)~


closes #344 