### PR TITLE
274: Task List provider/aws implementation

### DIFF
--- a/api/main.go
+++ b/api/main.go
@@ -65,7 +65,7 @@ func main() {
 		environmentProvider := aws.NewEnvironmentProvider(client, tagStore, cfg)
 		loadBalancerProvider := aws.NewLoadBalancerProvider(client, tagStore, cfg)
 		serviceProvider := aws.NewServiceProvider(client, tagStore)
-		taskProvider := aws.NewTaskProvider(client, tagStore)
+		taskProvider := aws.NewTaskProvider(client, tagStore, cfg)
 		jobRunner := aws.NewJobRunner(
 			deployProvider,
 			environmentProvider,

--- a/api/provider/aws/common.go
+++ b/api/provider/aws/common.go
@@ -2,10 +2,13 @@ package aws
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/aws/aws-sdk-go/service/ec2/ec2iface"
+	"github.com/aws/aws-sdk-go/service/ecs"
+	"github.com/aws/aws-sdk-go/service/ecs/ecsiface"
 	"github.com/quintilesims/layer0/api/tag"
 )
 
@@ -85,4 +88,26 @@ func deleteEntityTags(tagStore tag.Store, entityType, entityID string) error {
 	}
 
 	return nil
+}
+
+func listClusterNames(ecsapi ecsiface.ECSAPI, instance string) ([]string, error) {
+	clusterNames := []string{}
+	fn := func(output *ecs.ListClustersOutput, lastPage bool) bool {
+		for _, arn := range output.ClusterArns {
+			// cluster arn format: arn:aws:ecs:region:012345678910:cluster/name
+			clusterName := strings.Split(aws.StringValue(arn), "/")[1]
+
+			if hasLayer0Prefix(instance, clusterName) {
+				clusterNames = append(clusterNames, clusterName)
+			}
+		}
+
+		return !lastPage
+	}
+
+	if err := ecsapi.ListClustersPages(&ecs.ListClustersInput{}, fn); err != nil {
+		return nil, err
+	}
+
+	return clusterNames, nil
 }

--- a/api/provider/aws/environment_list.go
+++ b/api/provider/aws/environment_list.go
@@ -1,15 +1,11 @@
 package aws
 
 import (
-	"strings"
-
-	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/service/ecs"
 	"github.com/quintilesims/layer0/common/models"
 )
 
 func (e *EnvironmentProvider) List() ([]models.EnvironmentSummary, error) {
-	clusterNames, err := e.listClusterNames()
+	clusterNames, err := listClusterNames(e.AWS.ECS, e.Config.Instance())
 	if err != nil {
 		return nil, err
 	}
@@ -29,25 +25,6 @@ func (e *EnvironmentProvider) List() ([]models.EnvironmentSummary, error) {
 	}
 
 	return summaries, nil
-}
-
-func (e *EnvironmentProvider) listClusterNames() ([]string, error) {
-	output, err := e.AWS.ECS.ListClusters(&ecs.ListClustersInput{})
-	if err != nil {
-		return nil, err
-	}
-
-	clusterNames := []string{}
-	for _, arn := range output.ClusterArns {
-		// cluster arn format: arn:aws:ecs:region:012345678910:cluster/name
-		clusterName := strings.Split(aws.StringValue(arn), "/")[1]
-
-		if hasLayer0Prefix(e.Config.Instance(), clusterName) {
-			clusterNames = append(clusterNames, clusterName)
-		}
-	}
-
-	return clusterNames, nil
 }
 
 func (e *EnvironmentProvider) populateSummariesTags(summaries []models.EnvironmentSummary) error {

--- a/api/provider/aws/load_balancer_update.go
+++ b/api/provider/aws/load_balancer_update.go
@@ -1,9 +1,6 @@
 package aws
 
 import (
-	"strings"
-
-	"github.com/aws/aws-sdk-go/aws"
 	"github.com/quintilesims/layer0/common/models"
 )
 

--- a/api/provider/aws/task.go
+++ b/api/provider/aws/task.go
@@ -3,33 +3,19 @@ package aws
 import (
 	"github.com/quintilesims/layer0/api/tag"
 	awsc "github.com/quintilesims/layer0/common/aws"
-	"github.com/quintilesims/layer0/common/models"
+	"github.com/quintilesims/layer0/common/config"
 )
 
 type TaskProvider struct {
 	AWS      *awsc.Client
 	TagStore tag.Store
+	Config   config.APIConfig
 }
 
-func NewTaskProvider(a *awsc.Client, t tag.Store) *TaskProvider {
+func NewTaskProvider(a *awsc.Client, t tag.Store, c config.APIConfig) *TaskProvider {
 	return &TaskProvider{
 		AWS:      a,
 		TagStore: t,
+		Config:   c,
 	}
-}
-
-func (t *TaskProvider) Create(req models.CreateTaskRequest) (*models.Task, error) {
-	return nil, nil
-}
-
-func (t *TaskProvider) Read(TaskID string) (*models.Task, error) {
-	return nil, nil
-}
-
-func (t *TaskProvider) List() ([]models.TaskSummary, error) {
-	return nil, nil
-}
-
-func (t *TaskProvider) Delete(TaskID string) error {
-	return nil
 }

--- a/api/provider/aws/task_create.go
+++ b/api/provider/aws/task_create.go
@@ -1,0 +1,7 @@
+package aws
+
+import "github.com/quintilesims/layer0/common/models"
+
+func (t *TaskProvider) Create(req models.CreateTaskRequest) (*models.Task, error) {
+	return nil, nil
+}

--- a/api/provider/aws/task_delete.go
+++ b/api/provider/aws/task_delete.go
@@ -1,0 +1,5 @@
+package aws
+
+func (t *TaskProvider) Delete(TaskID string) error {
+	return nil
+}

--- a/api/provider/aws/task_list.go
+++ b/api/provider/aws/task_list.go
@@ -1,0 +1,93 @@
+package aws
+
+import (
+	"strings"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/ecs"
+	"github.com/quintilesims/layer0/common/models"
+)
+
+func (t *TaskProvider) List() ([]models.TaskSummary, error) {
+	clusterNames, err := listClusterNames(t.AWS.ECS, t.Config.Instance())
+	if err != nil {
+		return nil, err
+	}
+
+	summaries := []models.TaskSummary{}
+	for _, clusterName := range clusterNames {
+		runningTaskIDs, err := t.listTaskIDs(clusterName, ecs.DesiredStatusRunning)
+		if err != nil {
+			return nil, err
+		}
+
+		stoppedTaskIDs, err := t.listTaskIDs(clusterName, ecs.DesiredStatusStopped)
+		if err != nil {
+			return nil, err
+		}
+
+		for _, taskID := range append(runningTaskIDs, stoppedTaskIDs...) {
+			summary := models.TaskSummary{
+				TaskID: taskID,
+			}
+			summaries = append(summaries, summary)
+		}
+
+	}
+
+	if err := t.populateTaskSummaries(summaries); err != nil {
+		return nil, err
+	}
+
+	return summaries, nil
+}
+
+func (t *TaskProvider) listTaskIDs(clusterName, status string) ([]string, error) {
+	taskIDs := []string{}
+	fn := func(output *ecs.ListTasksOutput, lastPage bool) bool {
+		for _, arn := range output.TaskArns {
+			// task arn format: arn:aws:ecs:region:012345678910:task/taskID
+			taskID := strings.Split(aws.StringValue(arn), "/")[1]
+			taskIDs = append(taskIDs, taskID)
+		}
+		return !lastPage
+	}
+
+	input := &ecs.ListTasksInput{}
+	input.SetCluster(clusterName)
+	input.SetDesiredStatus(status)
+
+	if err := t.AWS.ECS.ListTasksPages(input, fn); err != nil {
+		return nil, err
+	}
+
+	return taskIDs, nil
+}
+
+func (t *TaskProvider) populateTaskSummaries(summaries []models.TaskSummary) error {
+	environmentTags, err := t.TagStore.SelectByType("environment")
+	if err != nil {
+		return err
+	}
+
+	taskTags, err := t.TagStore.SelectByType("task")
+	if err != nil {
+		return err
+	}
+
+	for i, summary := range summaries {
+		if tag, ok := taskTags.WithID(summary.TaskID).WithKey("name").First(); ok {
+			summaries[i].TaskName = tag.Value
+		}
+
+		if tag, ok := taskTags.WithID(summary.TaskID).WithKey("environment_id").First(); ok {
+			summaries[i].EnvironmentID = tag.Value
+
+			if t, ok := environmentTags.WithID(tag.Value).WithKey("name").First(); ok {
+				summaries[i].EnvironmentName = t.Value
+			}
+		}
+	}
+
+	return nil
+}

--- a/api/provider/aws/task_list_test.go
+++ b/api/provider/aws/task_list_test.go
@@ -1,0 +1,94 @@
+package aws
+
+import (
+	"testing"
+
+	"github.com/quintilesims/layer0/api/tag"
+	"github.com/quintilesims/layer0/common/models"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestTask_populateTaskSummaries(t *testing.T) {
+	tagStore := tag.NewMemoryStore()
+	task := NewTaskProvider(nil, tagStore, nil)
+
+	tags := models.Tags{
+		{
+			EntityID:   "t1",
+			EntityType: "task",
+			Key:        "name",
+			Value:      "tsk1",
+		},
+		{
+			EntityID:   "t1",
+			EntityType: "task",
+			Key:        "environment_id",
+			Value:      "e1",
+		},
+		{
+			EntityID:   "e1",
+			EntityType: "environment",
+			Key:        "name",
+			Value:      "ename1",
+		},
+		{
+			EntityID:   "t2",
+			EntityType: "task",
+			Key:        "name",
+			Value:      "tsk2",
+		},
+		{
+			EntityID:   "t2",
+			EntityType: "task",
+			Key:        "environment_id",
+			Value:      "e2",
+		},
+		{
+			EntityID:   "e2",
+			EntityType: "environment",
+			Key:        "name",
+			Value:      "ename2",
+		},
+		{
+			EntityID:   "someid",
+			EntityType: "task",
+			Key:        "name",
+			Value:      "badname",
+		},
+		{
+			EntityID:   "someid",
+			EntityType: "task",
+			Key:        "bad_env_key",
+			Value:      "env1",
+		},
+		{
+			EntityID:   "env1",
+			EntityType: "service",
+			Key:        "name",
+			Value:      "servicename",
+		},
+	}
+
+	for _, tag := range tags {
+		if err := tagStore.Insert(tag); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	results := []models.TaskSummary{
+		{TaskID: "t1"},
+		{TaskID: "t2"},
+	}
+
+	if err := task.populateTaskSummaries(results); err != nil {
+		t.Fatal(err)
+	}
+
+	assert.Len(t, results, 2)
+	assert.Equal(t, "tsk1", results[0].TaskName)
+	assert.Equal(t, "e1", results[0].EnvironmentID)
+	assert.Equal(t, "ename1", results[0].EnvironmentName)
+	assert.Equal(t, "tsk2", results[1].TaskName)
+	assert.Equal(t, "e2", results[1].EnvironmentID)
+	assert.Equal(t, "ename2", results[1].EnvironmentName)
+}

--- a/api/provider/aws/task_read.go
+++ b/api/provider/aws/task_read.go
@@ -1,0 +1,9 @@
+package aws
+
+import (
+	"github.com/quintilesims/layer0/common/models"
+)
+
+func (t *TaskProvider) Read(taskID string) (*models.Task, error) {
+	return nil, nil
+}

--- a/api/provider/mock_provider/mock_deploy.go
+++ b/api/provider/mock_provider/mock_deploy.go
@@ -5,9 +5,10 @@
 package mock_provider
 
 import (
+	reflect "reflect"
+
 	gomock "github.com/golang/mock/gomock"
 	models "github.com/quintilesims/layer0/common/models"
-	reflect "reflect"
 )
 
 // MockDeployProvider is a mock of DeployProvider interface


### PR DESCRIPTION
**What does this pull request do?**
List() returns a slice of models.TaskSummary objects which describe the Task and the Environment it is contained in
Task entity CRUD methods will be split into separate files rather than one big file
listClusterNames() now in common.go since it is also used by Environment List
List Provider now includes the config.APIConfig object in the constructor
Unit test for populating Task Summaries

**How should this be tested?**
Include steps to test intended functionality.

**Checklist**
- [x] Unit tests
~- [ ] Smoke tests (if applicable)~
~- [ ] System tests (if applicable)~
~- [ ] Documentation (if applicable)~

Work is going toward #274 
