### PR TITLE
274: Service provider: Read

### DIFF
--- a/api/controllers/swagger.go
+++ b/api/controllers/swagger.go
@@ -68,6 +68,10 @@ func (s *SwaggerController) ServeSwaggerSpec(c *fireball.Context) (fireball.Resp
 				Description: "Methods related to load balancers",
 			},
 			{
+				Name:        "Service",
+				Description: "Methods related to services",
+			},
+			{
 				Name:        "Task",
 				Description: "Methods related to tasks",
 			},
@@ -230,7 +234,7 @@ func (s *SwaggerController) ServeSwaggerSpec(c *fireball.Context) (fireball.Resp
 					},
 				},
 			},
-			"service": {
+			"/service": {
 				"put": {
 					Summary: "Update a Service",
 					Tags:    []string{"Service"},
@@ -240,6 +244,21 @@ func (s *SwaggerController) ServeSwaggerSpec(c *fireball.Context) (fireball.Resp
 					Responses: map[string]swagger.Response{
 						"200": {
 							Description: "The updated Service",
+							Schema:      swagger.NewObjectSchema("Service"),
+						},
+					},
+				},
+			},
+			"/service/{id}": {
+				"get": {
+					Summary: "Describe a Service",
+					Tags:    []string{"Service"},
+					Parameters: []swagger.Parameter{
+						swagger.NewStringPathParam("id", "ID of the service to describe", true),
+					},
+					Responses: map[string]swagger.Response{
+						"200": {
+							Description: "The desired service",
 							Schema:      swagger.NewObjectSchema("Service"),
 						},
 					},

--- a/api/provider/aws/README.md
+++ b/api/provider/aws/README.md
@@ -248,8 +248,16 @@ func (e *EntityProvider) readResourceB(args) (*aws.ResourceB, error) {
     // assuming `Describe()` returns `(ECSOutput, err)`
     // and `ECSOutput.ResourceBs` is `[]*ResourceB`
 	output, err := e.AWS.ECS.Describe(input)
-	if err != nil || len(output.ResourceBs) == 0 {
-        return nil, errors.Newf(errors.<Entity>DoesNotExist, "<Entity> '%s' does not exist")
+	if err != nil {
+        if err, ok := err.(awserr.Error); ok && err.Code() == "<Entity>NotFoundException" {
+            return nil, errors.Newf(errors.<Entity>DoesNotExist, "<Entity> '%s' does not exist", <entity>ID)
+        }
+
+        return nil, err
+    }
+
+    if len(output.ResourceBs) == 0 {
+        return nil, errors.Newf(errors.<Entity>DoesNotExist, "<Entity> '%s' does not exist", <entity>ID)
     }
 
 	return output.ResourceBs[0], nil

--- a/api/provider/aws/README.md
+++ b/api/provider/aws/README.md
@@ -248,12 +248,8 @@ func (e *EntityProvider) readResourceB(args) (*aws.ResourceB, error) {
     // assuming `Describe()` returns `(ECSOutput, err)`
     // and `ECSOutput.ResourceBs` is `[]*ResourceB`
 	output, err := e.AWS.ECS.Describe(input)
-	if err != nil {
-		return nil, err
-	}
-
-    if len(output.ResourceBs) == 0 {
-        return nil, fmt.Errorf("ResourceB not found")
+	if err != nil || len(output.ResourceBs) == 0 {
+        return nil, errors.Newf(errors.<Entity>DoesNotExist, "<Entity> '%s' does not exist")
     }
 
 	return output.ResourceBs[0], nil

--- a/api/provider/aws/README.md
+++ b/api/provider/aws/README.md
@@ -234,6 +234,9 @@ func (e *EntityProvider) readResourceA(args) (*aws.ResourceA, error) {
 	return output.ResourceA, nil
 }
 
+// if the helper function's AWS call returns a slice of objects,
+// and we expect `len(slice) == 0` or `len(slice) == 1`, standardize
+// on a pattern like this:
 func (e *EntityProvider) readResourceB(args) (*aws.ResourceB, error) {
 	input := &aws.Input{}
 	input.FieldA(args)
@@ -242,12 +245,18 @@ func (e *EntityProvider) readResourceB(args) (*aws.ResourceB, error) {
 		return nil, err
 	}
 
+    // assuming `Describe()` returns `(ECSOutput, err)`
+    // and `ECSOutput.ResourceBs` is `[]*ResourceB`
 	output, err := e.AWS.ECS.Describe(input)
 	if err != nil {
 		return nil, err
 	}
 
-	return output.ResourceB, nil
+    if len(output.ResourceBs) == 0 {
+        return nil, fmt.Errorf("ResourceB not found")
+    }
+
+	return output.ResourceBs[0], nil
 }
 
 func (e *EntityProvider) populateModelTags(entityID string, model *models.Entity) error {

--- a/api/provider/aws/common.go
+++ b/api/provider/aws/common.go
@@ -13,8 +13,8 @@ import (
 	"github.com/quintilesims/layer0/common/errors"
 )
 
-func (s *ServiceProvider) lookupDeployIDFromTaskDefinitionARN(taskDefinitionARN string) (string, error) {
-	tags, err := s.TagStore.SelectByType("deploy")
+func lookupDeployIDFromTaskDefinitionARN(store tag.Store, taskDefinitionARN string) (string, error) {
+	tags, err := store.SelectByType("deploy")
 	if err != nil {
 		return "", err
 	}

--- a/api/provider/aws/common.go
+++ b/api/provider/aws/common.go
@@ -13,6 +13,19 @@ import (
 	"github.com/quintilesims/layer0/common/errors"
 )
 
+func (s *ServiceProvider) lookupDeployIDFromTaskDefinitionARN(taskDefinitionARN string) (string, error) {
+	tags, err := s.TagStore.SelectByType("deploy")
+	if err != nil {
+		return "", err
+	}
+
+	if tag, ok := tags.WithKey("arn").WithValue(taskDefinitionARN).First(); ok {
+		return tag.EntityID, nil
+	}
+
+	return "", errors.Newf(errors.DeployDoesNotExist, "Failed to find deploy with ARN '%s'", taskDefinitionARN)
+}
+
 func lookupEntityEnvironmentID(store tag.Store, entityType, entityID string) (string, error) {
 	tags, err := store.SelectByTypeAndID(entityType, entityID)
 	if err != nil {

--- a/api/provider/aws/common_test.go
+++ b/api/provider/aws/common_test.go
@@ -10,7 +10,6 @@ import (
 
 func Test_lookupDeployIDFromTaskDefinitionARN(t *testing.T) {
 	tagStore := tag.NewMemoryStore()
-	service := NewServiceProvider(nil, tagStore, nil)
 
 	tags := models.Tags{
 		{
@@ -27,7 +26,7 @@ func Test_lookupDeployIDFromTaskDefinitionARN(t *testing.T) {
 		}
 	}
 
-	result, err := service.lookupDeployIDFromTaskDefinitionARN("task_definition_arn")
+	result, err := lookupDeployIDFromTaskDefinitionARN(tagStore, "task_definition_arn")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/api/provider/aws/common_test.go
+++ b/api/provider/aws/common_test.go
@@ -1,0 +1,36 @@
+package aws
+
+import (
+	"testing"
+
+	"github.com/quintilesims/layer0/api/tag"
+	"github.com/quintilesims/layer0/common/models"
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_lookupDeployIDFromTaskDefinitionARN(t *testing.T) {
+	tagStore := tag.NewMemoryStore()
+	service := NewServiceProvider(nil, tagStore, nil)
+
+	tags := models.Tags{
+		{
+			EntityID:   "dpl_id",
+			EntityType: "deploy",
+			Key:        "arn",
+			Value:      "task_definition_arn",
+		},
+	}
+
+	for _, tag := range tags {
+		if err := tagStore.Insert(tag); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	result, err := service.lookupDeployIDFromTaskDefinitionARN("task_definition_arn")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	assert.Equal(t, "dpl_id", result)
+}

--- a/api/provider/aws/service_read.go
+++ b/api/provider/aws/service_read.go
@@ -1,10 +1,9 @@
 package aws
 
 import (
-	"fmt"
-
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/ecs"
+	"github.com/quintilesims/layer0/common/errors"
 	"github.com/quintilesims/layer0/common/models"
 )
 
@@ -16,36 +15,54 @@ func (s *ServiceProvider) Read(serviceID string) (*models.Service, error) {
 
 	fqEnvironmentID := addLayer0Prefix(s.Config.Instance(), environmentID)
 	clusterName := fqEnvironmentID
-	service, err := s.readService(clusterName, serviceID)
+	ecsService, err := s.readService(clusterName, serviceID)
 	if err != nil {
 		return nil, err
 	}
 
-	model := &models.Service{
-		DesiredCount: aws.Int64Value(service.DesiredCount),
-		RunningCount: aws.Int64Value(service.RunningCount),
-		PendingCount: aws.Int64Value(service.PendingCount),
-	}
-
-	for _, deploy := range service.Deployments {
+	var deployments []models.Deployment
+	for _, deploy := range ecsService.Deployments {
 		deployID := aws.StringValue(deploy.TaskDefinition)
+
 		//todo: convert deployid to layer0 deploy id
 
-		deploy := models.Deployment{
-			DeploymentID: aws.StringValue(deploy.Id),
-			Created:      aws.TimeValue(deploy.CreatedAt),
-			Updated:      aws.TimeValue(deploy.UpdatedAt),
-			Status:       aws.StringValue(deploy.Status),
-			PendingCount: aws.Int64Value(deploy.PendingCount),
-			RunningCount: aws.Int64Value(deploy.RunningCount),
-			DesiredCount: aws.Int64Value(deploy.DesiredCount),
-			DeployID:     deployID,
+		d := models.Deployment{
+			Created:       aws.TimeValue(deploy.CreatedAt),
+			DeployID:      deployID,
+			DeployName:    "", // tag
+			DeployVersion: "", // tag
+			DesiredCount:  int(aws.Int64Value(deploy.DesiredCount)),
+			PendingCount:  int(aws.Int64Value(deploy.PendingCount)),
+			RunningCount:  int(aws.Int64Value(deploy.RunningCount)),
+			Status:        aws.StringValue(deploy.Status),
+			Updated:       aws.TimeValue(deploy.UpdatedAt),
 		}
 
-		model.Deployments = append(model.Deployments, deploy)
+		deployments = append(deployments, d)
 	}
 
-	if err := s.updateWithTagInfo(model, serviceID); err != nil {
+	var loadBalancerID string
+	if len(ecsService.LoadBalancers) != 0 {
+		loadBalancer := ecsService.LoadBalancers[0]
+		loadBalancerName := aws.StringValue(loadBalancer.LoadBalancerName)
+		fqLoadBalancerID := loadBalancerName
+		loadBalancerID = delLayer0Prefix(s.Config.Instance(), fqLoadBalancerID)
+	}
+
+	model := &models.Service{
+		Deployments:      deployments,
+		DesiredCount:     int(aws.Int64Value(ecsService.DesiredCount)),
+		EnvironmentID:    environmentID,
+		EnvironmentName:  "", // tag
+		LoadBalancerID:   loadBalancerID,
+		LoadBalancerName: "", // tag
+		PendingCount:     int(aws.Int64Value(ecsService.PendingCount)),
+		RunningCount:     int(aws.Int64Value(ecsService.RunningCount)),
+		ServiceID:        serviceID,
+		ServiceName:      "", // tag
+	}
+
+	if err := s.populateModelTags(serviceID, model); err != nil {
 		return nil, err
 	}
 
@@ -60,13 +77,72 @@ func (s *ServiceProvider) readService(clusterName, serviceID string) (*ecs.Servi
 	})
 
 	output, err := s.AWS.ECS.DescribeServices(input)
-	if err != nil {
-		return nil, err
-	}
-
-	if len(output.Services) == 0 {
-		return nil, fmt.Errorf("ECS service '%s' in cluster '%s' does not exist", serviceID, clusterName)
+	if err != nil || len(output.Services) == 0 {
+		return nil, errors.Newf(errors.ServiceDoesNotExist, "Service '%s' does not exist")
 	}
 
 	return output.Services[0], nil
+}
+
+func (s *ServiceProvider) populateModelTags(serviceID string, model *models.Service) error {
+	tags, err := s.TagStore.SelectByTypeAndID("service", serviceID)
+	if err != nil {
+		return err
+	}
+
+	if tag, ok := tags.WithKey("environment_id").First(); ok {
+		model.EnvironmentID = tag.Value
+	}
+
+	if tag, ok := tags.WithKey("load_balancer_id").First(); ok {
+		model.LoadBalancerID = tag.Value
+	}
+
+	if tag, ok := tags.WithKey("name").First(); ok {
+		model.ServiceName = tag.Value
+	}
+
+	if model.EnvironmentID != "" {
+		tags, err := s.TagStore.SelectByTypeAndID("environment", model.EnvironmentID)
+		if err != nil {
+			return err
+		}
+
+		if tag, ok := tags.WithKey("name").First(); ok {
+			model.EnvironmentName = tag.Value
+		}
+	}
+
+	if model.LoadBalancerID != "" {
+		tags, err := s.TagStore.SelectByTypeAndID("load_balancer", model.LoadBalancerID)
+		if err != nil {
+			return err
+		}
+
+		if tag, ok := tags.WithKey("name").First(); ok {
+			model.LoadBalancerName = tag.Value
+		}
+	}
+
+	deployments := []models.Deployment{}
+	for _, deploy := range model.Deployments {
+		tags, err := s.TagStore.SelectByTypeAndID("deploy", deploy.DeployID)
+		if err != nil {
+			return err
+		}
+
+		if tag, ok := tags.WithKey("name").First(); ok {
+			deploy.DeployName = tag.Value
+		}
+
+		if tag, ok := tags.WithKey("version").First(); ok {
+			deploy.DeployVersion = tag.Value
+		}
+
+		deployments = append(deployments, deploy)
+	}
+
+	model.Deployments = deployments
+
+	return nil
 }

--- a/api/provider/aws/service_read.go
+++ b/api/provider/aws/service_read.go
@@ -24,7 +24,7 @@ func (s *ServiceProvider) Read(serviceID string) (*models.Service, error) {
 	var deployments []models.Deployment
 	for _, d := range ecsService.Deployments {
 		taskDefinitionARN := aws.StringValue(d.TaskDefinition)
-		deployID, err := s.lookupDeployIDFromTaskDefinitionARN(taskDefinitionARN)
+		deployID, err := lookupDeployIDFromTaskDefinitionARN(s.TagStore, taskDefinitionARN)
 		if err != nil {
 			return nil, err
 		}

--- a/api/provider/aws/service_read.go
+++ b/api/provider/aws/service_read.go
@@ -125,15 +125,13 @@ func (s *ServiceProvider) makeServiceModel(environmentID, loadBalancerID, servic
 		model.ServiceName = tag.Value
 	}
 
-	if environmentID != "" {
-		tags, err := s.TagStore.SelectByTypeAndID("environment", environmentID)
-		if err != nil {
-			return nil, err
-		}
+	tags, err = s.TagStore.SelectByTypeAndID("environment", environmentID)
+	if err != nil {
+		return nil, err
+	}
 
-		if tag, ok := tags.WithKey("name").First(); ok {
-			model.EnvironmentName = tag.Value
-		}
+	if tag, ok := tags.WithKey("name").First(); ok {
+		model.EnvironmentName = tag.Value
 	}
 
 	if loadBalancerID != "" {

--- a/api/provider/aws/service_read.go
+++ b/api/provider/aws/service_read.go
@@ -88,19 +88,6 @@ func (s *ServiceProvider) readService(clusterName, serviceID string) (*ecs.Servi
 	return output.Services[0], nil
 }
 
-func (s *ServiceProvider) lookupDeployIDFromTaskDefinitionARN(taskDefinitionARN string) (string, error) {
-	tags, err := s.TagStore.SelectByType("deploy")
-	if err != nil {
-		return "", err
-	}
-
-	if tag, ok := tags.WithKey("arn").WithValue(taskDefinitionARN).First(); ok {
-		return tag.EntityID, nil
-	}
-
-	return "", errors.Newf(errors.DeployDoesNotExist, "Failed to find deploy with ARN '%s'", taskDefinitionARN)
-}
-
 func (s *ServiceProvider) makeDeploymentModel(deployID string) (*models.Deployment, error) {
 	model := &models.Deployment{
 		DeployID: deployID,

--- a/api/provider/aws/service_read.go
+++ b/api/provider/aws/service_read.go
@@ -101,11 +101,7 @@ func (s *ServiceProvider) lookupDeployIDFromTaskDefinitionARN(taskDefinitionARN 
 		return "", err
 	}
 
-	if len(tags) == 0 {
-		return "", errors.Newf(errors.DeployDoesNotExist, "No deploys exist")
-	}
-
-	if tag, ok := tags.WithValue(taskDefinitionARN).First(); ok {
+	if tag, ok := tags.WithKey("arn").WithValue(taskDefinitionARN).First(); ok {
 		return tag.EntityID, nil
 	}
 
@@ -118,16 +114,12 @@ func (s *ServiceProvider) populateModelTags(serviceID string, model *models.Serv
 		return err
 	}
 
-	if tag, ok := tags.WithKey("environment_id").First(); ok {
-		model.EnvironmentID = tag.Value
-	}
-
-	if tag, ok := tags.WithKey("load_balancer_id").First(); ok {
-		model.LoadBalancerID = tag.Value
-	}
-
 	if tag, ok := tags.WithKey("name").First(); ok {
 		model.ServiceName = tag.Value
+	}
+
+	if tag, ok := tags.WithKey("environment_id").First(); ok {
+		model.EnvironmentID = tag.Value
 	}
 
 	if model.EnvironmentID != "" {
@@ -139,6 +131,10 @@ func (s *ServiceProvider) populateModelTags(serviceID string, model *models.Serv
 		if tag, ok := tags.WithKey("name").First(); ok {
 			model.EnvironmentName = tag.Value
 		}
+	}
+
+	if tag, ok := tags.WithKey("load_balancer_id").First(); ok {
+		model.LoadBalancerID = tag.Value
 	}
 
 	if model.LoadBalancerID != "" {
@@ -158,7 +154,7 @@ func (s *ServiceProvider) populateModelTags(serviceID string, model *models.Serv
 			return err
 		}
 
-		if tag, ok := tags.WithKey("deploy_name").First(); ok {
+		if tag, ok := tags.WithKey("name").First(); ok {
 			d.DeployName = tag.Value
 		}
 

--- a/api/provider/aws/service_read.go
+++ b/api/provider/aws/service_read.go
@@ -29,7 +29,7 @@ func (s *ServiceProvider) Read(serviceID string) (*models.Service, error) {
 			return nil, err
 		}
 
-		deployment, err := s.newDeploymentModel(deployID)
+		deployment, err := s.makeDeploymentModel(deployID)
 		if err != nil {
 			return nil, err
 		}
@@ -52,7 +52,7 @@ func (s *ServiceProvider) Read(serviceID string) (*models.Service, error) {
 		loadBalancerID = delLayer0Prefix(s.Config.Instance(), fqLoadBalancerID)
 	}
 
-	model, err := s.newServiceModel(environmentID, loadBalancerID, serviceID)
+	model, err := s.makeServiceModel(environmentID, loadBalancerID, serviceID)
 	if err != nil {
 		return nil, err
 	}
@@ -101,7 +101,7 @@ func (s *ServiceProvider) lookupDeployIDFromTaskDefinitionARN(taskDefinitionARN 
 	return "", errors.Newf(errors.DeployDoesNotExist, "Failed to find deploy with ARN '%s'", taskDefinitionARN)
 }
 
-func (s *ServiceProvider) newDeploymentModel(deployID string) (*models.Deployment, error) {
+func (s *ServiceProvider) makeDeploymentModel(deployID string) (*models.Deployment, error) {
 	model := &models.Deployment{
 		DeployID: deployID,
 	}
@@ -122,7 +122,7 @@ func (s *ServiceProvider) newDeploymentModel(deployID string) (*models.Deploymen
 	return model, nil
 }
 
-func (s *ServiceProvider) newServiceModel(environmentID, loadBalancerID, serviceID string) (*models.Service, error) {
+func (s *ServiceProvider) makeServiceModel(environmentID, loadBalancerID, serviceID string) (*models.Service, error) {
 	model := &models.Service{
 		EnvironmentID:  environmentID,
 		LoadBalancerID: loadBalancerID,

--- a/api/provider/aws/service_read_test.go
+++ b/api/provider/aws/service_read_test.go
@@ -1,0 +1,90 @@
+package aws
+
+import (
+	"testing"
+
+	"github.com/quintilesims/layer0/api/tag"
+	"github.com/quintilesims/layer0/common/models"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestService_lookupDeployIDFromTaskDefinition(t *testing.T) {}
+
+func TestService_newDeploymentModel(t *testing.T) {
+	tagStore := tag.NewMemoryStore()
+	service := NewServiceProvider(nil, tagStore, nil)
+
+	tags := models.Tags{
+		{
+			EntityID:   "dpl_id",
+			EntityType: "deploy",
+			Key:        "name",
+			Value:      "dpl_name",
+		},
+		{
+			EntityID:   "dpl_id",
+			EntityType: "deploy",
+			Key:        "version",
+			Value:      "0",
+		},
+	}
+
+	for _, tag := range tags {
+		if err := tagStore.Insert(tag); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	result, err := service.newDeploymentModel("dpl_id")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	assert.Equal(t, "dpl_id", result.DeployID)
+	assert.Equal(t, "dpl_name", result.DeployName)
+	assert.Equal(t, "0", result.DeployVersion)
+}
+
+func TestService_newServiceModel(t *testing.T) {
+	tagStore := tag.NewMemoryStore()
+	service := NewServiceProvider(nil, tagStore, nil)
+
+	tags := models.Tags{
+		{
+			EntityID:   "env_id",
+			EntityType: "environment",
+			Key:        "name",
+			Value:      "env_name",
+		},
+		{
+			EntityID:   "lb_id",
+			EntityType: "load_balancer",
+			Key:        "name",
+			Value:      "lb_name",
+		},
+		{
+			EntityID:   "svc_id",
+			EntityType: "service",
+			Key:        "name",
+			Value:      "svc_name",
+		},
+	}
+
+	for _, tag := range tags {
+		if err := tagStore.Insert(tag); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	result, err := service.newServiceModel("env_id", "lb_id", "svc_id")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	assert.Equal(t, "env_id", result.EnvironmentID)
+	assert.Equal(t, "env_name", result.EnvironmentName)
+	assert.Equal(t, "lb_id", result.LoadBalancerID)
+	assert.Equal(t, "lb_name", result.LoadBalancerName)
+	assert.Equal(t, "svc_id", result.ServiceID)
+	assert.Equal(t, "svc_name", result.ServiceName)
+}

--- a/api/provider/aws/service_read_test.go
+++ b/api/provider/aws/service_read_test.go
@@ -8,33 +8,6 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestService_lookupDeployIDFromTaskDefinitionARN(t *testing.T) {
-	tagStore := tag.NewMemoryStore()
-	service := NewServiceProvider(nil, tagStore, nil)
-
-	tags := models.Tags{
-		{
-			EntityID:   "dpl_id",
-			EntityType: "deploy",
-			Key:        "arn",
-			Value:      "task_definition_arn",
-		},
-	}
-
-	for _, tag := range tags {
-		if err := tagStore.Insert(tag); err != nil {
-			t.Fatal(err)
-		}
-	}
-
-	result, err := service.lookupDeployIDFromTaskDefinitionARN("task_definition_arn")
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	assert.Equal(t, "dpl_id", result)
-}
-
 func TestService_makeDeploymentModel(t *testing.T) {
 	tagStore := tag.NewMemoryStore()
 	service := NewServiceProvider(nil, tagStore, nil)

--- a/api/provider/aws/service_read_test.go
+++ b/api/provider/aws/service_read_test.go
@@ -8,7 +8,32 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestService_lookupDeployIDFromTaskDefinition(t *testing.T) {}
+func TestService_lookupDeployIDFromTaskDefinitionARN(t *testing.T) {
+	tagStore := tag.NewMemoryStore()
+	service := NewServiceProvider(nil, tagStore, nil)
+
+	tags := models.Tags{
+		{
+			EntityID:   "dpl_id",
+			EntityType: "deploy",
+			Key:        "arn",
+			Value:      "task_definition_arn",
+		},
+	}
+
+	for _, tag := range tags {
+		if err := tagStore.Insert(tag); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	result, err := service.lookupDeployIDFromTaskDefinitionARN("task_definition_arn")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	assert.Equal(t, "dpl_id", result)
+}
 
 func TestService_makeDeploymentModel(t *testing.T) {
 	tagStore := tag.NewMemoryStore()

--- a/api/provider/aws/service_read_test.go
+++ b/api/provider/aws/service_read_test.go
@@ -10,7 +10,7 @@ import (
 
 func TestService_lookupDeployIDFromTaskDefinition(t *testing.T) {}
 
-func TestService_newDeploymentModel(t *testing.T) {
+func TestService_makeDeploymentModel(t *testing.T) {
 	tagStore := tag.NewMemoryStore()
 	service := NewServiceProvider(nil, tagStore, nil)
 
@@ -35,7 +35,7 @@ func TestService_newDeploymentModel(t *testing.T) {
 		}
 	}
 
-	result, err := service.newDeploymentModel("dpl_id")
+	result, err := service.makeDeploymentModel("dpl_id")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -45,7 +45,7 @@ func TestService_newDeploymentModel(t *testing.T) {
 	assert.Equal(t, "0", result.DeployVersion)
 }
 
-func TestService_newServiceModel(t *testing.T) {
+func TestService_makeServiceModel(t *testing.T) {
 	tagStore := tag.NewMemoryStore()
 	service := NewServiceProvider(nil, tagStore, nil)
 
@@ -76,7 +76,7 @@ func TestService_newServiceModel(t *testing.T) {
 		}
 	}
 
-	result, err := service.newServiceModel("env_id", "lb_id", "svc_id")
+	result, err := service.makeServiceModel("env_id", "lb_id", "svc_id")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/common/models/deployment.go
+++ b/common/models/deployment.go
@@ -11,12 +11,11 @@ type Deployment struct {
 	DeployID      string    `json:"deploy_id"`
 	DeployName    string    `json:"deploy_name"`
 	DeployVersion string    `json:"deploy_version"`
-	DesiredCount  int64     `json:"desired_count"`
-	PendingCount  int64     `json:"pending_count"`
-	RunningCount  int64     `json:"running_count"`
+	DesiredCount  int       `json:"desired_count"`
+	PendingCount  int       `json:"pending_count"`
+	RunningCount  int       `json:"running_count"`
 	Status        string    `json:"status"`
 	Updated       time.Time `json:"updated"`
-	DeploymentID  string    `json:"deployment_id"`
 }
 
 func (u Deployment) Definition() swagger.Definition {
@@ -32,7 +31,6 @@ func (u Deployment) Definition() swagger.Definition {
 			"running_count":  swagger.NewIntProperty(),
 			"status":         swagger.NewStringProperty(),
 			"updated":        swagger.NewStringProperty(),
-			"deployment_id":  swagger.NewStringProperty(),
 		},
 	}
 }

--- a/common/models/service.go
+++ b/common/models/service.go
@@ -4,13 +4,13 @@ import swagger "github.com/zpatrick/go-plugin-swagger"
 
 type Service struct {
 	Deployments      []Deployment `json:"deployments"`
-	DesiredCount     int64        `json:"desired_count"`
+	DesiredCount     int          `json:"desired_count"`
 	EnvironmentID    string       `json:"environment_id"`
 	EnvironmentName  string       `json:"environment_name"`
 	LoadBalancerID   string       `json:"load_balancer_id"`
 	LoadBalancerName string       `json:"load_balancer_name"`
-	PendingCount     int64        `json:"pending_count"`
-	RunningCount     int64        `json:"running_count"`
+	PendingCount     int          `json:"pending_count"`
+	RunningCount     int          `json:"running_count"`
 	ServiceID        string       `json:"service_id"`
 	ServiceName      string       `json:"service_name"`
 }


### PR DESCRIPTION
**What does this pull request do?**
Adds the `Read` operation to the Service Provider.


**How should this be tested?**
- Unit tests
- Run API locally
    - confirm compilation
    - hit http://localhost:9090/api/?url=/swagger.json with a browser to confirm Swagger functionality


**Checklist**
- [x] Unit tests
- ~Smoke tests (if applicable)~
- ~System tests (if applicable)~
- ~Documentation (if applicable)~

-----

Apologies for the difficulty in reviewing this PR; the subject matter is both the current changes as well as a post-merge review of Seshi's work. You might not need to look at all of them, but in an attempt to ease this headache, the files immediately relevant to `Service Provider: Read()` are these:


```
common/models/
    - deployment.go
    - service.go

api/controllers/
    - service.go
    - service_test.go
    - swagger.go

api/job/
    - types.go

api/provider/
    - service.go

api/provider/aws/
    - common.go
    - service.go
    - service_read.go
```

If you have comments on parts of the code that aren't in the diff, I guess just make them here in the PR's conversation like so?


`api/provider/aws/service_read.go:Read()`:
 - `model` should be `&models.Service{}`, not `&models.SillyGoose{}`