### PR TITLE
Added terraform init to l0-setup init

### DIFF
--- a/setup/instance/init.go
+++ b/setup/instance/init.go
@@ -45,6 +45,11 @@ func (l *LocalInstance) Init(dockerInputPath string, inputOverrides map[string]i
 		return err
 	}
 
+	// run `terraform init` to initialize terraform
+	if err := l.Terraform.Init(l.Dir); err != nil {
+		return err
+	}
+
 	// validate the terraform configuration
 	if err := l.Terraform.Validate(l.Dir); err != nil {
 		return err

--- a/setup/terraform/terraform.go
+++ b/setup/terraform/terraform.go
@@ -39,6 +39,10 @@ func (t *Terraform) Get(dir string) error {
 	return t.run(dir, "get", "-update")
 }
 
+func (t *Terraform) Init(dir string) error {
+	return t.run(dir, "init", "-no-color")
+}
+
 func (t *Terraform) Output(dir, key string) (string, error) {
 	if err := t.validateTerraformVersion(); err != nil {
 		return "", err


### PR DESCRIPTION
**What does this pull request do?**
This adds the "terraform init" to the l0-setup.

**How should this be tested?**
Clone branch, cd to layer0/setup and run `go run main.go init <instance name>`
You should see the terraform success message then

**Checklist**
- [ ] Unit tests
- [ ] Smoke tests (if applicable)
- [ ] System tests (if applicable)
- [ ] Documentation (if applicable)

**Concerns**
<img width="807" alt="screen shot 2017-09-25 at 3 32 45 pm" src="https://user-images.githubusercontent.com/6733030/30830580-0c290468-a20a-11e7-82be-4d73ba4e69d9.png">
- I've removed the color in the output, but I'm wondering if this should be muted too since it's confusing that it tells the user they can run terraform plan.
- No download indicator when running the `terraform get` command

closes #
#338 