### PR TITLE
Make Deploy Read() use new Model constructor pattern

### DIFF
--- a/api/provider/aws/deploy_read_test.go
+++ b/api/provider/aws/deploy_read_test.go
@@ -51,11 +51,12 @@ func TestDeploy_populateModelTags(t *testing.T) {
 		}
 	}
 
-	result := &models.Deploy{}
-	if err := deploy.populateModelTags("deploy_id_1", result); err != nil {
+	deployID := "deploy_id_1"
+	deployModel, err := deploy.newDeployModel(deployID)
+	if err != nil {
 		t.Fatal(err)
 	}
 
-	assert.Equal(t, "deploy_name_1", result.DeployName)
-	assert.Equal(t, "deploy_version_1", result.Version)
+	assert.Equal(t, "deploy_name_1", deployModel.DeployName)
+	assert.Equal(t, "deploy_version_1", deployModel.Version)
 }


### PR DESCRIPTION
**What does this pull request do?**
The newDeployModel() constructor will take the deployID passed to Read() and then populate
the model with as much information as can be provided by the tags db before making the API call
to AWS

Note that Deploy List() has a different workflow that won't use the stated SummaryModel constructor pattern because AWS gives back TaskDefinition ARNs. So the helper function will take the ARNs given by AWS to populate the Summary.

**How should this be tested?**
Unit test


**Checklist**
- [x] Unit tests
~- [ ] Smoke tests (if applicable)~
~- [ ] System tests (if applicable)~
~- [ ] Documentation (if applicable)~
