### PR TITLE
274: Service Provider: Read: Bugfix

### DIFF
--- a/api/provider/aws/service_read.go
+++ b/api/provider/aws/service_read.go
@@ -16,7 +16,10 @@ func (s *ServiceProvider) Read(serviceID string) (*models.Service, error) {
 
 	fqEnvironmentID := addLayer0Prefix(s.Config.Instance(), environmentID)
 	clusterName := fqEnvironmentID
-	ecsService, err := s.readService(clusterName, serviceID)
+
+	fqServiceID := addLayer0Prefix(s.Config.Instance(), serviceID)
+
+	ecsService, err := s.readService(clusterName, fqServiceID)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
**What does this pull request do?**
Fixes a bug where `readService()` was called using a not-fully-qualified `serviceID`.


**How should this be tested?**
This is tricky to do with things in flight, since at this point in time the creation of a `deploy` doesn't create an `arn` tag in the tag database given the work currently in `api-refactor` (this work _does_ exist in the `deploy` work that Brandon and Josh have been working on, but at the time of this writing, those changes haven't been merged into `api-refactor` yet).

My current workaround is hacky af and as follows:

1. Get the ID of an existing service with `l0 service list` using Layer0 v0.10.3 or similar
2. Find the Task Definition's ARN
    - In `service_read.go:Read()` around line 29, look for where `taskDefinitionARN` gets defined and `fmt.Println(taskDefinitionARN)`. Write the file and make sure that the imports are updated.
    - `go run main.go` from `layer0/api/` and use swagger (http://localhost:9090/api/?url=/swagger.json -- you'll probably need to add "http" to the `Schemes` field in `api/controllers/swagger.go`) to run a `GET /service/{id}` with the service ID you got in step 1.
    - Check the `go run` console output for the ARN.
3. Use the Read() call to create and insert the `arn` tag
    - At the top of the `Read()` function in `service_read.go()` add the following code:
```
if err := s.TagStore.Insert(models.Tag{
    EntityID: "<service ID from earlier>",
    EntityType: "deploy",
    Key: "arn",
    Value: "<service ARN from earlier>",
}); err != nil {
    return nil, err
}
```
    - You can remove the `fmt.Println()` section from earlier, make sure the imports are correct, and write the file.
    - Restart the api console and run the same `GET /service/{id}` swagger call. This should return a correct response, and you could go and remove the block of code that adds the `arn` tag and make the call again to confirm that it works without writing the tag every time.


**Checklist**
- ~Unit tests~
- ~Smoke tests (if applicable)~
- ~System tests (if applicable)~
- ~Documentation (if applicable)~


closes #
(reference the issue(s) this pull request closes)
