### PR TITLE
Deploy Provider: List only Active Task Definitions

### DIFF
--- a/api/controllers/deploy_test.go
+++ b/api/controllers/deploy_test.go
@@ -113,6 +113,11 @@ func TestListDeploys(t *testing.T) {
 			Version:    "1",
 		},
 		{
+			DeployID:   "d1",
+			DeployName: "deploy1",
+			Version:    "2",
+		},
+		{
 			DeployID:   "d2",
 			DeployName: "deploy2",
 			Version:    "1",

--- a/api/provider/mock_provider/mock_deploy.go
+++ b/api/provider/mock_provider/mock_deploy.go
@@ -5,10 +5,9 @@
 package mock_provider
 
 import (
-	reflect "reflect"
-
 	gomock "github.com/golang/mock/gomock"
 	models "github.com/quintilesims/layer0/common/models"
+	reflect "reflect"
 )
 
 // MockDeployProvider is a mock of DeployProvider interface

--- a/api/provider/mock_provider/mock_environment.go
+++ b/api/provider/mock_provider/mock_environment.go
@@ -5,10 +5,9 @@
 package mock_provider
 
 import (
-	reflect "reflect"
-
 	gomock "github.com/golang/mock/gomock"
 	models "github.com/quintilesims/layer0/common/models"
+	reflect "reflect"
 )
 
 // MockEnvironmentProvider is a mock of EnvironmentProvider interface

--- a/api/provider/mock_provider/mock_loadbalancer.go
+++ b/api/provider/mock_provider/mock_loadbalancer.go
@@ -5,10 +5,9 @@
 package mock_provider
 
 import (
-	reflect "reflect"
-
 	gomock "github.com/golang/mock/gomock"
 	models "github.com/quintilesims/layer0/common/models"
+	reflect "reflect"
 )
 
 // MockLoadBalancerProvider is a mock of LoadBalancerProvider interface

--- a/api/provider/mock_provider/mock_service.go
+++ b/api/provider/mock_provider/mock_service.go
@@ -5,10 +5,10 @@
 package mock_provider
 
 import (
-	reflect "reflect"
-
 	gomock "github.com/golang/mock/gomock"
 	models "github.com/quintilesims/layer0/common/models"
+	reflect "reflect"
+	time "time"
 )
 
 // MockServiceProvider is a mock of ServiceProvider interface
@@ -70,6 +70,19 @@ func (m *MockServiceProvider) List() ([]models.ServiceSummary, error) {
 // List indicates an expected call of List
 func (mr *MockServiceProviderMockRecorder) List() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "List", reflect.TypeOf((*MockServiceProvider)(nil).List))
+}
+
+// Logs mocks base method
+func (m *MockServiceProvider) Logs(arg0 string, arg1 int, arg2, arg3 time.Time) ([]models.LogFile, error) {
+	ret := m.ctrl.Call(m, "Logs", arg0, arg1, arg2, arg3)
+	ret0, _ := ret[0].([]models.LogFile)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// Logs indicates an expected call of Logs
+func (mr *MockServiceProviderMockRecorder) Logs(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Logs", reflect.TypeOf((*MockServiceProvider)(nil).Logs), arg0, arg1, arg2, arg3)
 }
 
 // Read mocks base method

--- a/api/provider/mock_provider/mock_service.go
+++ b/api/provider/mock_provider/mock_service.go
@@ -6,7 +6,6 @@ package mock_provider
 
 import (
 	reflect "reflect"
-	time "time"
 
 	gomock "github.com/golang/mock/gomock"
 	models "github.com/quintilesims/layer0/common/models"
@@ -71,19 +70,6 @@ func (m *MockServiceProvider) List() ([]models.ServiceSummary, error) {
 // List indicates an expected call of List
 func (mr *MockServiceProviderMockRecorder) List() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "List", reflect.TypeOf((*MockServiceProvider)(nil).List))
-}
-
-// Logs mocks base method
-func (m *MockServiceProvider) Logs(arg0 string, arg1 int, arg2, arg3 time.Time) ([]models.LogFile, error) {
-	ret := m.ctrl.Call(m, "Logs", arg0, arg1, arg2, arg3)
-	ret0, _ := ret[0].([]models.LogFile)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// Logs indicates an expected call of Logs
-func (mr *MockServiceProviderMockRecorder) Logs(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Logs", reflect.TypeOf((*MockServiceProvider)(nil).Logs), arg0, arg1, arg2, arg3)
 }
 
 // Read mocks base method

--- a/api/provider/mock_provider/mock_task.go
+++ b/api/provider/mock_provider/mock_task.go
@@ -6,7 +6,6 @@ package mock_provider
 
 import (
 	reflect "reflect"
-	time "time"
 
 	gomock "github.com/golang/mock/gomock"
 	models "github.com/quintilesims/layer0/common/models"
@@ -71,19 +70,6 @@ func (m *MockTaskProvider) List() ([]models.TaskSummary, error) {
 // List indicates an expected call of List
 func (mr *MockTaskProviderMockRecorder) List() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "List", reflect.TypeOf((*MockTaskProvider)(nil).List))
-}
-
-// Logs mocks base method
-func (m *MockTaskProvider) Logs(arg0 string, arg1 int, arg2, arg3 time.Time) ([]models.LogFile, error) {
-	ret := m.ctrl.Call(m, "Logs", arg0, arg1, arg2, arg3)
-	ret0, _ := ret[0].([]models.LogFile)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// Logs indicates an expected call of Logs
-func (mr *MockTaskProviderMockRecorder) Logs(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Logs", reflect.TypeOf((*MockTaskProvider)(nil).Logs), arg0, arg1, arg2, arg3)
 }
 
 // Read mocks base method

--- a/api/provider/mock_provider/mock_task.go
+++ b/api/provider/mock_provider/mock_task.go
@@ -5,10 +5,10 @@
 package mock_provider
 
 import (
-	reflect "reflect"
-
 	gomock "github.com/golang/mock/gomock"
 	models "github.com/quintilesims/layer0/common/models"
+	reflect "reflect"
+	time "time"
 )
 
 // MockTaskProvider is a mock of TaskProvider interface
@@ -70,6 +70,19 @@ func (m *MockTaskProvider) List() ([]models.TaskSummary, error) {
 // List indicates an expected call of List
 func (mr *MockTaskProviderMockRecorder) List() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "List", reflect.TypeOf((*MockTaskProvider)(nil).List))
+}
+
+// Logs mocks base method
+func (m *MockTaskProvider) Logs(arg0 string, arg1 int, arg2, arg3 time.Time) ([]models.LogFile, error) {
+	ret := m.ctrl.Call(m, "Logs", arg0, arg1, arg2, arg3)
+	ret0, _ := ret[0].([]models.LogFile)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// Logs indicates an expected call of Logs
+func (mr *MockTaskProviderMockRecorder) Logs(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Logs", reflect.TypeOf((*MockTaskProvider)(nil).Logs), arg0, arg1, arg2, arg3)
 }
 
 // Read mocks base method


### PR DESCRIPTION
**What does this pull request do?**
Deploy List() will now explicitly only return active Task Definitions and Task Definition Families.


**How should this be tested?**
Manually test Deploy methods with Swagger
Unit tests


**Checklist**
- [x] Unit tests
~- [ ] Smoke tests (if applicable)~
~- [ ] System tests (if applicable)~
~- [ ] Documentation (if applicable)~

