### PR TITLE
Repair 'task_list.go'

### DIFF
--- a/api/provider/aws/task_list.go
+++ b/api/provider/aws/task_list.go
@@ -31,7 +31,7 @@ func (t *TaskProvider) List() ([]models.TaskSummary, error) {
 		taskARNs = append(taskARNs, clusterTaskARNsRunning...)
 	}
 
-	summaries, err := t.populateSummariesFromTaskARNs(taskARNs)
+	summaries, err := t.makeTaskSummaryModels(taskARNs)
 	if err != nil {
 		return nil, err
 	}
@@ -39,7 +39,7 @@ func (t *TaskProvider) List() ([]models.TaskSummary, error) {
 	return summaries, nil
 }
 
-func (t *TaskProvider) populateSummariesFromTaskARNs(taskARNs []string) ([]models.TaskSummary, error) {
+func (t *TaskProvider) makeTaskSummaryModels(taskARNs []string) ([]models.TaskSummary, error) {
 	environmentTags, err := t.TagStore.SelectByType("environment")
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
**What does this pull request do?**
It seems that part of `task_list.go` got messed up in a merge somewhere; most apparent, `makeTaskSummaryModels()` had been overwritten with an outdated `populateSummariesFromTaskARNs()`. This is an attempt to fix it. WARNING: I'm not particularly familiar with this part of the codebase, so it's very possible that I've overlooked something; but the tests pass now, which they don't currently do in `api-refactor`.


**How should this be tested?**
- `cd layer0/api && go test ./...`
- Confirm if desired behavior is intact
- Make sure that everything looks right

**Checklist**
- ~[ ] Unit tests~
- ~[ ] Smoke tests (if applicable)~
- ~[ ] System tests (if applicable)~
- ~[ ] Documentation (if applicable)~


closes #
(reference the issue(s) this pull request closes)
