### PR TITLE
Return entityID on entity.Create

### DIFF
--- a/api/provider/aws/deploy_create_test.go
+++ b/api/provider/aws/deploy_create_test.go
@@ -20,7 +20,7 @@ func TestDeploy_createTags(t *testing.T) {
 	version := "deploy_version"
 	arn := "deploy_arn"
 
-	if err := deploy.createTags(name, id, version, arn); err != nil {
+	if err := deploy.createTags(id, name, version, arn); err != nil {
 		t.Fatal(err)
 	}
 

--- a/api/provider/aws/job_runner.go
+++ b/api/provider/aws/job_runner.go
@@ -79,12 +79,12 @@ func (r *JobRunner) createDeploy(jobID, request string) (string, error) {
 		return "", errors.New(errors.InvalidRequest, err)
 	}
 
-	deploy, err := r.deployProvider.Create(req)
+	deployID, err := r.deployProvider.Create(req)
 	if err != nil {
 		return "", err
 	}
 
-	return deploy.DeployID, nil
+	return deployID, nil
 }
 
 func (r *JobRunner) createEnvironment(jobID, request string) (string, error) {
@@ -93,12 +93,12 @@ func (r *JobRunner) createEnvironment(jobID, request string) (string, error) {
 		return "", errors.New(errors.InvalidRequest, err)
 	}
 
-	environment, err := r.environmentProvider.Create(req)
+	environmentID, err := r.environmentProvider.Create(req)
 	if err != nil {
 		return "", err
 	}
 
-	return environment.EnvironmentID, nil
+	return environmentID, nil
 }
 
 func (r *JobRunner) createLoadBalancer(jobID, request string) (string, error) {
@@ -107,12 +107,12 @@ func (r *JobRunner) createLoadBalancer(jobID, request string) (string, error) {
 		return "", errors.New(errors.InvalidRequest, err)
 	}
 
-	loadBalancer, err := r.loadBalancerProvider.Create(req)
+	loadBalancerID, err := r.loadBalancerProvider.Create(req)
 	if err != nil {
 		return "", err
 	}
 
-	return loadBalancer.LoadBalancerID, nil
+	return loadBalancerID, nil
 }
 
 func (r *JobRunner) createService(jobID, request string) (string, error) {
@@ -121,14 +121,14 @@ func (r *JobRunner) createService(jobID, request string) (string, error) {
 		return "", errors.New(errors.InvalidRequest, err)
 	}
 
-	service, err := r.serviceProvider.Create(req)
+	serviceID, err := r.serviceProvider.Create(req)
 	if err != nil {
 		return "", err
 	}
 
 	// scale up after the service has been added into the ecs service scheduler
 	r.scaler.ScheduleRun(req.EnvironmentID)
-	return service.ServiceID, nil
+	return serviceID, nil
 }
 
 func (r *JobRunner) createTask(jobID, request string) (string, error) {

--- a/api/provider/aws/service_create.go
+++ b/api/provider/aws/service_create.go
@@ -2,7 +2,6 @@ package aws
 
 import "github.com/quintilesims/layer0/common/models"
 
-func (s *ServiceProvider) Create(req models.CreateServiceRequest) (*models.Service, error) {
-
-	return nil, nil
+func (s *ServiceProvider) Create(req models.CreateServiceRequest) (string, error) {
+	return "", nil
 }

--- a/api/provider/deploy.go
+++ b/api/provider/deploy.go
@@ -3,7 +3,7 @@ package provider
 import "github.com/quintilesims/layer0/common/models"
 
 type DeployProvider interface {
-	Create(req models.CreateDeployRequest) (*models.Deploy, error)
+	Create(req models.CreateDeployRequest) (string, error)
 	Delete(deployID string) error
 	List() ([]models.DeploySummary, error)
 	Read(deployID string) (*models.Deploy, error)

--- a/api/provider/environment.go
+++ b/api/provider/environment.go
@@ -3,7 +3,7 @@ package provider
 import "github.com/quintilesims/layer0/common/models"
 
 type EnvironmentProvider interface {
-	Create(req models.CreateEnvironmentRequest) (*models.Environment, error)
+	Create(req models.CreateEnvironmentRequest) (string, error)
 	Delete(environmentID string) error
 	List() ([]models.EnvironmentSummary, error)
 	Read(environmentID string) (*models.Environment, error)

--- a/api/provider/load_balancer.go
+++ b/api/provider/load_balancer.go
@@ -3,7 +3,7 @@ package provider
 import "github.com/quintilesims/layer0/common/models"
 
 type LoadBalancerProvider interface {
-	Create(req models.CreateLoadBalancerRequest) (*models.LoadBalancer, error)
+	Create(req models.CreateLoadBalancerRequest) (string, error)
 	Delete(loadBalancerID string) error
 	List() ([]models.LoadBalancerSummary, error)
 	Read(loadBalancerID string) (*models.LoadBalancer, error)

--- a/api/provider/mock_provider/mock_deploy.go
+++ b/api/provider/mock_provider/mock_deploy.go
@@ -5,9 +5,10 @@
 package mock_provider
 
 import (
+	reflect "reflect"
+
 	gomock "github.com/golang/mock/gomock"
 	models "github.com/quintilesims/layer0/common/models"
-	reflect "reflect"
 )
 
 // MockDeployProvider is a mock of DeployProvider interface
@@ -34,9 +35,9 @@ func (m *MockDeployProvider) EXPECT() *MockDeployProviderMockRecorder {
 }
 
 // Create mocks base method
-func (m *MockDeployProvider) Create(arg0 models.CreateDeployRequest) (*models.Deploy, error) {
+func (m *MockDeployProvider) Create(arg0 models.CreateDeployRequest) (string, error) {
 	ret := m.ctrl.Call(m, "Create", arg0)
-	ret0, _ := ret[0].(*models.Deploy)
+	ret0, _ := ret[0].(string)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }

--- a/api/provider/mock_provider/mock_environment.go
+++ b/api/provider/mock_provider/mock_environment.go
@@ -5,9 +5,10 @@
 package mock_provider
 
 import (
+	reflect "reflect"
+
 	gomock "github.com/golang/mock/gomock"
 	models "github.com/quintilesims/layer0/common/models"
-	reflect "reflect"
 )
 
 // MockEnvironmentProvider is a mock of EnvironmentProvider interface
@@ -34,9 +35,9 @@ func (m *MockEnvironmentProvider) EXPECT() *MockEnvironmentProviderMockRecorder 
 }
 
 // Create mocks base method
-func (m *MockEnvironmentProvider) Create(arg0 models.CreateEnvironmentRequest) (*models.Environment, error) {
+func (m *MockEnvironmentProvider) Create(arg0 models.CreateEnvironmentRequest) (string, error) {
 	ret := m.ctrl.Call(m, "Create", arg0)
-	ret0, _ := ret[0].(*models.Environment)
+	ret0, _ := ret[0].(string)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }

--- a/api/provider/mock_provider/mock_loadbalancer.go
+++ b/api/provider/mock_provider/mock_loadbalancer.go
@@ -5,9 +5,10 @@
 package mock_provider
 
 import (
+	reflect "reflect"
+
 	gomock "github.com/golang/mock/gomock"
 	models "github.com/quintilesims/layer0/common/models"
-	reflect "reflect"
 )
 
 // MockLoadBalancerProvider is a mock of LoadBalancerProvider interface
@@ -34,9 +35,9 @@ func (m *MockLoadBalancerProvider) EXPECT() *MockLoadBalancerProviderMockRecorde
 }
 
 // Create mocks base method
-func (m *MockLoadBalancerProvider) Create(arg0 models.CreateLoadBalancerRequest) (*models.LoadBalancer, error) {
+func (m *MockLoadBalancerProvider) Create(arg0 models.CreateLoadBalancerRequest) (string, error) {
 	ret := m.ctrl.Call(m, "Create", arg0)
-	ret0, _ := ret[0].(*models.LoadBalancer)
+	ret0, _ := ret[0].(string)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }

--- a/api/provider/mock_provider/mock_service.go
+++ b/api/provider/mock_provider/mock_service.go
@@ -5,10 +5,11 @@
 package mock_provider
 
 import (
-	gomock "github.com/golang/mock/gomock"
-	models "github.com/quintilesims/layer0/common/models"
 	reflect "reflect"
 	time "time"
+
+	gomock "github.com/golang/mock/gomock"
+	models "github.com/quintilesims/layer0/common/models"
 )
 
 // MockServiceProvider is a mock of ServiceProvider interface
@@ -35,9 +36,9 @@ func (m *MockServiceProvider) EXPECT() *MockServiceProviderMockRecorder {
 }
 
 // Create mocks base method
-func (m *MockServiceProvider) Create(arg0 models.CreateServiceRequest) (*models.Service, error) {
+func (m *MockServiceProvider) Create(arg0 models.CreateServiceRequest) (string, error) {
 	ret := m.ctrl.Call(m, "Create", arg0)
-	ret0, _ := ret[0].(*models.Service)
+	ret0, _ := ret[0].(string)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }

--- a/api/provider/mock_provider/mock_task.go
+++ b/api/provider/mock_provider/mock_task.go
@@ -5,10 +5,11 @@
 package mock_provider
 
 import (
-	gomock "github.com/golang/mock/gomock"
-	models "github.com/quintilesims/layer0/common/models"
 	reflect "reflect"
 	time "time"
+
+	gomock "github.com/golang/mock/gomock"
+	models "github.com/quintilesims/layer0/common/models"
 )
 
 // MockTaskProvider is a mock of TaskProvider interface

--- a/api/provider/service.go
+++ b/api/provider/service.go
@@ -7,7 +7,7 @@ import (
 )
 
 type ServiceProvider interface {
-	Create(req models.CreateServiceRequest) (*models.Service, error)
+	Create(req models.CreateServiceRequest) (string, error)
 	Delete(serviceID string) error
 	List() ([]models.ServiceSummary, error)
 	Logs(taskID string, tail int, start, end time.Time) ([]models.LogFile, error)

--- a/api/provider/task.go
+++ b/api/provider/task.go
@@ -6,7 +6,6 @@ import (
 	"github.com/quintilesims/layer0/common/models"
 )
 
-// todo: all create methods should return a string
 type TaskProvider interface {
 	Create(req models.CreateTaskRequest) (string, error)
 	Delete(taskID string) error


### PR DESCRIPTION
**What does this pull request do?**
This removes the `entity.Read` calls at the end of `entity.Create` functions.
I encountered a bug where `entity.Create` would complete fine, but `entity.Read` would return an error. This would cause the retry logic in the job runner to execute unnecessarily. 

I also did some cleanup for `deploy.Create`


**How should this be tested?**
Unit tests

**Checklist**
- [x] Unit tests
