### PR TITLE
Tag API Client fix to target /tag of the API

### DIFF
--- a/client/mock_client/mock_client.go
+++ b/client/mock_client/mock_client.go
@@ -5,11 +5,10 @@
 package mock_client
 
 import (
-	url "net/url"
-	reflect "reflect"
-
 	gomock "github.com/golang/mock/gomock"
 	models "github.com/quintilesims/layer0/common/models"
+	url "net/url"
+	reflect "reflect"
 )
 
 // MockClient is a mock of Client interface
@@ -360,9 +359,9 @@ func (mr *MockClientMockRecorder) ReadServiceLogs(arg0, arg1 interface{}) *gomoc
 }
 
 // ReadTask mocks base method
-func (m *MockClient) ReadTask(arg0 string) (*models.Service, error) {
+func (m *MockClient) ReadTask(arg0 string) (*models.Task, error) {
 	ret := m.ctrl.Call(m, "ReadTask", arg0)
-	ret0, _ := ret[0].(*models.Service)
+	ret0, _ := ret[0].(*models.Task)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }

--- a/client/tag.go
+++ b/client/tag.go
@@ -9,7 +9,7 @@ import (
 
 func (c *APIClient) ListTags(query url.Values) (models.Tags, error) {
 	var tags models.Tags
-	if err := c.client.Get("/tags", &tags, rclient.Query(query)); err != nil {
+	if err := c.client.Get("/tag", &tags, rclient.Query(query)); err != nil {
 		return nil, err
 	}
 

--- a/client/tag_test.go
+++ b/client/tag_test.go
@@ -21,7 +21,7 @@ func TestListTags(t *testing.T) {
 
 	handler := func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, r.Method, "GET")
-		assert.Equal(t, r.URL.Path, "/tags")
+		assert.Equal(t, r.URL.Path, "/tag")
 		assert.Equal(t, query, r.URL.Query())
 
 		MarshalAndWrite(t, w, expected, 200)


### PR DESCRIPTION
**What does this pull request do?**
Change the target of the GET call for Tags to /tag.

**How should this be tested?**
Manually test entity operations that use the resolveSingleEntityIDHelper function and ensure that the API properly processes the call.


**Checklist**
- [x] Unit tests
~- [ ] Smoke tests (if applicable)~
~- [ ] System tests (if applicable)~
~- [ ] Documentation (if applicable)~

closes #392 
