### PR TITLE
Return 'req.EntityID' strings from 'updateEntity' funcs

### DIFF
--- a/api/provider/aws/job_runner.go
+++ b/api/provider/aws/job_runner.go
@@ -233,7 +233,7 @@ func (r *JobRunner) updateEnvironment(jobID, request string) (string, error) {
 		return "", errors.New(errors.InvalidRequest, err)
 	}
 
-	return "", r.environmentProvider.Update(req)
+	return req.EnvironmentID, r.environmentProvider.Update(req)
 }
 
 func (r *JobRunner) updateLoadBalancer(jobID, request string) (string, error) {
@@ -242,7 +242,7 @@ func (r *JobRunner) updateLoadBalancer(jobID, request string) (string, error) {
 		return "", errors.New(errors.InvalidRequest, err)
 	}
 
-	return "", r.loadBalancerProvider.Update(req)
+	return req.LoadBalancerID, r.loadBalancerProvider.Update(req)
 }
 
 func (r *JobRunner) updateService(jobID, request string) (string, error) {
@@ -251,7 +251,7 @@ func (r *JobRunner) updateService(jobID, request string) (string, error) {
 		return "", errors.New(errors.InvalidRequest, err)
 	}
 
-	return "", r.serviceProvider.Update(req)
+	return req.ServiceID, r.serviceProvider.Update(req)
 }
 
 func catchAndRetry(timeout time.Duration, fn func() (result string, err error, shouldRetry bool)) (string, error) {


### PR DESCRIPTION
**What does this pull request do?**
Returns Entity ID strings from updateEntity functions. This fixes a bug where update operations in the `command` package receive an empty string for `job.Result`, resulting in a marshalling error when trying to read an entity after the update operation (successfully) finishes.


**How should this be tested?**
Confirm that update operations no longer fail for environments, loadbalancers, and services.