### PR TITLE
add GetCLIContext func

### DIFF
--- a/cli/command/test_helpers.go
+++ b/cli/command/test_helpers.go
@@ -1,0 +1,37 @@
+package command
+
+import (
+	"flag"
+	"testing"
+	"time"
+
+	"github.com/urfave/cli"
+)
+
+var TEST_TIMEOUT = time.Minute * 15
+
+func GetCLIContext(t *testing.T, args []string, flags map[string]interface{}) *cli.Context {
+	flagSet := &flag.FlagSet{}
+
+	for key, val := range flags {
+		switch v := val.(type) {
+		case bool:
+			flagSet.Bool(key, v, "")
+		case string:
+			flagSet.String(key, v, "")
+		case []string:
+			slice := cli.StringSlice(v)
+			flagSet.Var(&slice, key, "")
+		case int:
+			flagSet.Int(key, v, "")
+		default:
+			t.Errorf("Cannot generate CLI context: unknown flag type for '%s'", key)
+		}
+	}
+
+	// add default global flags
+	flagSet.String("output", "text", "")
+	flagSet.String("timeout", TEST_TIMEOUT.String(), "")
+	flagSet.Parse(args)
+	return cli.NewContext(nil, flagSet, nil)
+}

--- a/cli/command/test_helpers.go
+++ b/cli/command/test_helpers.go
@@ -3,13 +3,12 @@ package command
 import (
 	"flag"
 	"testing"
-	"time"
 
 	"github.com/quintilesims/layer0/common/config"
 	"github.com/urfave/cli"
 )
 
-func GetCLIContext(t *testing.T, args []string, flags map[string]interface{}) *cli.Context {
+func getCLIContext(t *testing.T, args []string, flags map[string]interface{}) *cli.Context {
 	flagSet := &flag.FlagSet{}
 
 	for key, val := range flags {
@@ -29,7 +28,7 @@ func GetCLIContext(t *testing.T, args []string, flags map[string]interface{}) *c
 	}
 
 	// add default global flags
-	flagSet.String("output", "text", "")
+	flagSet.String(config.FLAG_OUTPUT, "text", "")
 	flagSet.String(config.FLAG_TIMEOUT, "15m", "")
 	flagSet.Parse(args)
 	return cli.NewContext(nil, flagSet, nil)

--- a/cli/command/test_helpers.go
+++ b/cli/command/test_helpers.go
@@ -5,10 +5,9 @@ import (
 	"testing"
 	"time"
 
+	"github.com/quintilesims/layer0/common/config"
 	"github.com/urfave/cli"
 )
-
-var TEST_TIMEOUT = time.Minute * 15
 
 func GetCLIContext(t *testing.T, args []string, flags map[string]interface{}) *cli.Context {
 	flagSet := &flag.FlagSet{}
@@ -31,7 +30,7 @@ func GetCLIContext(t *testing.T, args []string, flags map[string]interface{}) *c
 
 	// add default global flags
 	flagSet.String("output", "text", "")
-	flagSet.String("timeout", TEST_TIMEOUT.String(), "")
+	flagSet.String(config.FLAG_TIMEOUT, "15m", "")
 	flagSet.Parse(args)
 	return cli.NewContext(nil, flagSet, nil)
 }


### PR DESCRIPTION
**What does this pull request do?**
Includes the former `testutils` function `getCLIContext`, which is used for unit testing `command`  

