### PR TITLE
Allow empty os field in environment create

### DIFF
--- a/api/controllers/tag_test.go
+++ b/api/controllers/tag_test.go
@@ -86,28 +86,28 @@ func TestListTags(t *testing.T) {
 				}))
 			},
 		},
-		  {
-                        Name: "fuzz='*name*'",
-                        Query: url.Values{
-                                client.TagQueryParamName: []string{"*name*"},
-                        },
-                        CheckResult: func(t *testing.T, result models.Tags) {
-                                assert.False(t, result.Any(func(tag models.Tag) bool {
-                                        return !glob.Glob("*name*", tag.EntityID) || tag.Key == "name" && !glob.Glob("*name*", tag.Value)
-                                }))
-                        },
-                },
-		    {
-                        Name: "fuzz='*s'",
-                        Query: url.Values{
-                                client.TagQueryParamName: []string{"*s*"},
-                        },
-                        CheckResult: func(t *testing.T, result models.Tags) {
-                                assert.False(t, result.Any(func(tag models.Tag) bool {
-                                        return !glob.Glob("*s", tag.EntityID) || tag.Key == "name" && !glob.Glob("*s", tag.Value)
-                                }))
-                        },
-                },
+		{
+			Name: "fuzz='*name*'",
+			Query: url.Values{
+				client.TagQueryParamName: []string{"*name*"},
+			},
+			CheckResult: func(t *testing.T, result models.Tags) {
+				assert.False(t, result.Any(func(tag models.Tag) bool {
+					return !glob.Glob("*name*", tag.EntityID) || tag.Key == "name" && !glob.Glob("*name*", tag.Value)
+				}))
+			},
+		},
+		{
+			Name: "fuzz='*s'",
+			Query: url.Values{
+				client.TagQueryParamName: []string{"*s*"},
+			},
+			CheckResult: func(t *testing.T, result models.Tags) {
+				assert.False(t, result.Any(func(tag models.Tag) bool {
+					return !glob.Glob("*s", tag.EntityID) || tag.Key == "name" && !glob.Glob("*s", tag.Value)
+				}))
+			},
+		},
 		{
 			Name: "version=1",
 			Query: url.Values{

--- a/api/provider/aws/defaults.go
+++ b/api/provider/aws/defaults.go
@@ -1,8 +1,8 @@
 package aws
 
 const (
-	DEFAULT_INSTANCE_SIZE = "m3.medium"
-  DEFAULT_ENVIRONMENT_OS = "linux"
+	DEFAULT_INSTANCE_SIZE  = "m3.medium"
+	DEFAULT_ENVIRONMENT_OS = "linux"
 )
 
 const DEFAULT_LINUX_USERDATA_TEMPLATE = `

--- a/api/provider/aws/defaults.go
+++ b/api/provider/aws/defaults.go
@@ -2,6 +2,7 @@ package aws
 
 const (
 	DEFAULT_INSTANCE_SIZE = "m3.medium"
+  DEFAULT_ENVIRONMENT_OS = "linux"
 )
 
 const DEFAULT_LINUX_USERDATA_TEMPLATE = `

--- a/api/provider/aws/environment_create.go
+++ b/api/provider/aws/environment_create.go
@@ -33,6 +33,10 @@ func (e *EnvironmentProvider) Create(req models.CreateEnvironmentRequest) (strin
 	var userDataTemplate []byte
 	var amiID string
 
+	if req.OperatingSystem == "" {
+		req.OperatingSystem = DEFAULT_ENVIRONMENT_OS
+	}
+
 	switch strings.ToLower(req.OperatingSystem) {
 	case "linux":
 		userDataTemplate = []byte(DEFAULT_LINUX_USERDATA_TEMPLATE)

--- a/common/models/create_environment_request.go
+++ b/common/models/create_environment_request.go
@@ -24,10 +24,6 @@ func (r CreateEnvironmentRequest) Validate() error {
 		return fmt.Errorf("MinClusterCount must be a positive integer")
 	}
 
-	if r.OperatingSystem == "" {
-		return fmt.Errorf("OperatingSystem is required")
-	}
-
 	return nil
 }
 


### PR DESCRIPTION
**What does this pull request do?**
Allows clients to specify an empty os field for environment create. The 'linux' option will be used by default. 

**How should this be tested?**
manually


**Checklist**
- [ ] Unit tests
- [ ] Smoke tests (if applicable)
- [ ] System tests (if applicable)
- [ ] Documentation (if applicable)


