### PR TITLE
Fix aws provider unit test on RenderLoadBalancerRolPolicy helper function

### DIFF
--- a/api/provider/aws/load_balancer_create_test.go
+++ b/api/provider/aws/load_balancer_create_test.go
@@ -39,7 +39,7 @@ func TestLoadBalancer_createTags(t *testing.T) {
 func TestLoadBalancer_renderLoadBalancerRolePolicy(t *testing.T) {
 	template := "{{ .Region }} {{ .AccountID }} {{ .LoadBalancerID }}"
 
-	policy, err := renderLoadBalancerRolePolicy("region", "account_id", "lbid", template)
+	policy, err := RenderLoadBalancerRolePolicy("region", "account_id", "lbid", template)
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
**What does this pull request do?**
Because RenderLoadBalancerRolePolicy was recently changed as an
exportable function, the capitalization change causes the LB Create
test to fail.


**How should this be tested?**
`go test` in the `api/provider/aws` directory. This is currently failing in the current state of the `api-refactor` branch.

**Checklist**
- [x] Unit tests
~- [ ] Smoke tests (if applicable)~
~- [ ] System tests (if applicable)~
~- [ ] Documentation (if applicable)~
