### PR TITLE
[l0-setup] update linux AMI

### DIFF
--- a/setup/module/api/variables.tf
+++ b/setup/module/api/variables.tf
@@ -21,13 +21,13 @@ variable "tags" {
   default     = {}
 }
 
-# Current AMI: 	amzn-ami-2016.09.g-amazon-ecs-optimized
+# Current AMI: 	amzn-ami-2017.09.b-amazon-ecs-optimized
 variable "linux_region_amis" {
   default = {
-    us-west-1 = "ami-689bc208"
-    us-west-2 = "ami-62d35c02"
-    us-east-1 = "ami-62745007"
-    eu-west-1 = "ami-95f8d2f3"
+    us-west-1 = "ami-e5cdf385"
+    us-west-2 = "ami-4f8d912b"
+    us-east-1 = "ami-71ef560b"
+    eu-west-1 = "ami-014ae578"
   }
 }
 


### PR DESCRIPTION
**What does this pull request do?**
Updates the default Linux AMI used for Layer0.


**How should this be tested?**
Cannot be properly tested until l0-setup has been refactored. Merging is a "risk" as-is.
