### PR TITLE
Add telemetry role to default IAM/ECS policy

### DIFF
--- a/setup/module/api/policies/ecs_role_policy.json
+++ b/setup/module/api/policies/ecs_role_policy.json
@@ -12,6 +12,7 @@
                 "ecs:DiscoverPollEndpoint",
                 "ecs:Submit*",
                 "ecs:Poll",
+                "ecs:StartTelemetrySession",
                 "logs:CreateLogStream",
                 "logs:PutLogEvents",
                 "logs:CreateLogGroup",


### PR DESCRIPTION
**What does this pull request do?**
Adds an ECS role to our default Layer0 policy that enables CloudWatch Metrics for ECS Clusters.


**How should this be tested?**
Tested on v0.10.3, confirmed that metrics appeared for Consul and HelloWorld apps. 

closes #
https://github.com/quintilesims/layer0/issues/431
