### PR TITLE
Environment Max Scale

### DIFF
--- a/api/controllers/environment_test.go
+++ b/api/controllers/environment_test.go
@@ -22,8 +22,9 @@ func TestCreateEnvironment(t *testing.T) {
 
 	req := models.CreateEnvironmentRequest{
 		EnvironmentName: "env",
-		InstanceSize:    "m3.medium",
-		MinClusterCount: 1,
+		InstanceType:    "m3.medium",
+		MinScale:        1,
+		MaxScale:        3,
 		OperatingSystem: "linux",
 		AMIID:           "ami123",
 	}
@@ -83,8 +84,10 @@ func TestGetEnvironment(t *testing.T) {
 	environmentModel := models.Environment{
 		EnvironmentID:   "e1",
 		EnvironmentName: "env",
-		InstanceSize:    "m3.medium",
-		ClusterCount:    1,
+		InstanceType:    "m3.medium",
+		MinScale:        1,
+		CurrentScale:    2,
+		MaxScale:        3,
 		SecurityGroupID: "sg1",
 		OperatingSystem: "linux",
 		AMIID:           "ami123",
@@ -156,12 +159,14 @@ func TestUpdateEnvironment(t *testing.T) {
 	tagStore := tag.NewMemoryStore()
 	controller := NewEnvironmentController(mockEnvironmentProvider, mockJobStore, tagStore)
 
-	minClusterCount := 2
+	minScale := 2
+	maxScale := 5
 	links := []string{"e2"}
 
 	req := models.UpdateEnvironmentRequest{
-		MinClusterCount: &minClusterCount,
-		Links:           &links,
+		MinScale: &minScale,
+		MaxScale: &maxScale,
+		Links:    &links,
 	}
 
 	mockJobStore.EXPECT().

--- a/api/controllers/environment_test.go
+++ b/api/controllers/environment_test.go
@@ -22,7 +22,7 @@ func TestCreateEnvironment(t *testing.T) {
 
 	req := models.CreateEnvironmentRequest{
 		EnvironmentName: "env",
-		InstanceType:    "m3.medium",
+		InstanceType:    "t2.small",
 		MinScale:        1,
 		MaxScale:        3,
 		OperatingSystem: "linux",
@@ -84,7 +84,7 @@ func TestGetEnvironment(t *testing.T) {
 	environmentModel := models.Environment{
 		EnvironmentID:   "e1",
 		EnvironmentName: "env",
-		InstanceType:    "m3.medium",
+		InstanceType:    "t2.small",
 		MinScale:        1,
 		CurrentScale:    2,
 		MaxScale:        3,

--- a/api/provider/aws/defaults.go
+++ b/api/provider/aws/defaults.go
@@ -118,17 +118,3 @@ const DefaultLBRolePolicyTemplate = `{
         }
     ]
 }`
-
-var DefaultLoadBalancerPort = models.Port{
-	ContainerPort: 80,
-	HostPort:      80,
-	Protocol:      "tcp",
-}
-
-var DefaultHealthCheck = models.HealthCheck{
-	Target:             "TCP:80",
-	Interval:           30,
-	Timeout:            5,
-	HealthyThreshold:   2,
-	UnhealthyThreshold: 2,
-}

--- a/api/provider/aws/defaults.go
+++ b/api/provider/aws/defaults.go
@@ -1,7 +1,5 @@
 package aws
 
-import "github.com/quintilesims/layer0/common/models"
-
 const DefaultLinuxUserdataTemplate = `
 #!/bin/bash
 echo ECS_CLUSTER={{ .ECSEnvironmentID }} >> /etc/ecs/ecs.config

--- a/api/provider/aws/defaults.go
+++ b/api/provider/aws/defaults.go
@@ -2,12 +2,6 @@ package aws
 
 import "github.com/quintilesims/layer0/common/models"
 
-const (
-	DefaultInstanceSize  = "m3.medium"
-	DefaultEnvironmentOS = "linux"
-	DefaultServiceScale  = 1
-)
-
 const DefaultLinuxUserdataTemplate = `
 #!/bin/bash
 echo ECS_CLUSTER={{ .ECSEnvironmentID }} >> /etc/ecs/ecs.config

--- a/api/provider/aws/environment_read.go
+++ b/api/provider/aws/environment_read.go
@@ -41,8 +41,10 @@ func (e *EnvironmentProvider) Read(environmentID string) (*models.Environment, e
 		return nil, err
 	}
 
-	model.ClusterCount = len(autoScalingGroup.Instances)
-	model.InstanceSize = aws.StringValue(launchConfig.InstanceType)
+	model.MinScale = int(aws.Int64Value(autoScalingGroup.MinSize))
+	model.CurrentScale = int(aws.Int64Value(autoScalingGroup.DesiredCapacity))
+	model.MaxScale = int(aws.Int64Value(autoScalingGroup.MaxSize))
+	model.InstanceType = aws.StringValue(launchConfig.InstanceType)
 	model.SecurityGroupID = aws.StringValue(securityGroup.GroupId)
 	model.AMIID = aws.StringValue(launchConfig.ImageId)
 

--- a/api/provider/aws/load_balancer_create.go
+++ b/api/provider/aws/load_balancer_create.go
@@ -10,6 +10,7 @@ import (
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/aws/aws-sdk-go/service/elb"
 	"github.com/aws/aws-sdk-go/service/iam"
+	"github.com/quintilesims/layer0/common/config"
 	"github.com/quintilesims/layer0/common/models"
 )
 
@@ -59,7 +60,7 @@ func (l *LoadBalancerProvider) Create(req models.CreateLoadBalancerRequest) (str
 
 	loadBalancerSGID := aws.StringValue(loadBalancerSG.GroupId)
 	if len(req.Ports) == 0 {
-		req.Ports = []models.Port{DefaultLoadBalancerPort}
+		req.Ports = []models.Port{config.DefaultLoadBalancerPort}
 	}
 
 	for _, port := range req.Ports {
@@ -104,7 +105,7 @@ func (l *LoadBalancerProvider) Create(req models.CreateLoadBalancerRequest) (str
 	}
 
 	if req.HealthCheck == (models.HealthCheck{}) {
-		req.HealthCheck = DefaultHealthCheck
+		req.HealthCheck = config.DefaultLoadBalancerHealthCheck
 	}
 
 	healthCheck := &elb.HealthCheck{

--- a/api/provider/aws/test_aws/environment_create_test.go
+++ b/api/provider/aws/test_aws/environment_create_test.go
@@ -12,6 +12,7 @@ import (
 	provider "github.com/quintilesims/layer0/api/provider/aws"
 	"github.com/quintilesims/layer0/api/tag"
 	awsc "github.com/quintilesims/layer0/common/aws"
+	"github.com/quintilesims/layer0/common/config"
 	"github.com/quintilesims/layer0/common/config/mock_config"
 	"github.com/quintilesims/layer0/common/models"
 	"github.com/stretchr/testify/assert"
@@ -39,10 +40,11 @@ func TestEnvironmentCreate(t *testing.T) {
 
 	req := models.CreateEnvironmentRequest{
 		EnvironmentName:  "env_name",
-		InstanceSize:     "m3.small",
+		InstanceType:     "m3.small",
 		UserDataTemplate: []byte("some user data"),
 		AMIID:            "some ami",
-		MinClusterCount:  2,
+		MinScale:         2,
+		MaxScale:         5,
 		OperatingSystem:  "windows",
 	}
 
@@ -91,7 +93,7 @@ func TestEnvironmentCreate(t *testing.T) {
 	createASGInput.SetLaunchConfigurationName("l0-test-env_id")
 	createASGInput.SetVPCZoneIdentifier("priv1,priv2")
 	createASGInput.SetMinSize(2)
-	createASGInput.SetMaxSize(2)
+	createASGInput.SetMaxSize(5)
 	createASGInput.SetTags([]*autoscaling.Tag{tag})
 
 	mockAWS.AutoScaling.EXPECT().
@@ -176,7 +178,7 @@ func TestEnvironmentCreateDefaults(t *testing.T) {
 	}
 
 	validateCreateLCInput := func(input *autoscaling.CreateLaunchConfigurationInput) {
-		assert.Equal(t, provider.DefaultInstanceSize, aws.StringValue(input.InstanceType))
+		assert.Equal(t, config.DefaultEnvironmentInstanceType, aws.StringValue(input.InstanceType))
 		assert.Equal(t, "lx_ami", aws.StringValue(input.ImageId))
 		assert.Equal(t, renderedUserData, aws.StringValue(input.UserData))
 	}

--- a/api/provider/aws/test_aws/environment_create_test.go
+++ b/api/provider/aws/test_aws/environment_create_test.go
@@ -40,7 +40,7 @@ func TestEnvironmentCreate(t *testing.T) {
 
 	req := models.CreateEnvironmentRequest{
 		EnvironmentName:  "env_name",
-		InstanceType:     "m3.small",
+		InstanceType:     "t2.small",
 		UserDataTemplate: []byte("some user data"),
 		AMIID:            "some ami",
 		MinScale:         2,
@@ -71,7 +71,7 @@ func TestEnvironmentCreate(t *testing.T) {
 	createLCInput := &autoscaling.CreateLaunchConfigurationInput{}
 	createLCInput.SetLaunchConfigurationName("l0-test-env_id")
 	createLCInput.SetSecurityGroups([]*string{aws.String("sg_id")})
-	createLCInput.SetInstanceType("m3.small")
+	createLCInput.SetInstanceType("t2.small")
 	createLCInput.SetIamInstanceProfile("profile")
 	createLCInput.SetImageId("some ami")
 	createLCInput.SetKeyName("keypair")

--- a/api/provider/aws/test_aws/environment_read_test.go
+++ b/api/provider/aws/test_aws/environment_read_test.go
@@ -58,7 +58,9 @@ func TestEnvironmentRead(t *testing.T) {
 	asg := &autoscaling.Group{}
 	asg.SetAutoScalingGroupName("l0-test-env_id")
 	asg.SetLaunchConfigurationName("lc_name")
-	asg.SetInstances(make([]*autoscaling.Instance, 2))
+	asg.SetMinSize(1)
+	asg.SetDesiredCapacity(2)
+	asg.SetMaxSize(5)
 
 	describeASGOutput := &autoscaling.DescribeAutoScalingGroupsOutput{}
 	describeASGOutput.SetAutoScalingGroups([]*autoscaling.Group{asg})
@@ -93,9 +95,11 @@ func TestEnvironmentRead(t *testing.T) {
 		EnvironmentID:   "env_id",
 		EnvironmentName: "env_name",
 		OperatingSystem: "linux",
-		InstanceSize:    "m3.small",
+		InstanceType:    "m3.small",
 		SecurityGroupID: "sg_id",
-		ClusterCount:    2,
+		MinScale:        1,
+		CurrentScale:    2,
+		MaxScale:        5,
 		AMIID:           "ami_id",
 		Links:           []string{},
 	}

--- a/api/provider/aws/test_aws/environment_read_test.go
+++ b/api/provider/aws/test_aws/environment_read_test.go
@@ -74,7 +74,7 @@ func TestEnvironmentRead(t *testing.T) {
 
 	lc := &autoscaling.LaunchConfiguration{}
 	lc.SetLaunchConfigurationName("lc_name")
-	lc.SetInstanceType("m3.small")
+	lc.SetInstanceType("t2.small")
 	lc.SetImageId("ami_id")
 
 	describeLCOutput := &autoscaling.DescribeLaunchConfigurationsOutput{}
@@ -95,7 +95,7 @@ func TestEnvironmentRead(t *testing.T) {
 		EnvironmentID:   "env_id",
 		EnvironmentName: "env_name",
 		OperatingSystem: "linux",
-		InstanceType:    "m3.small",
+		InstanceType:    "t2.small",
 		SecurityGroupID: "sg_id",
 		MinScale:        1,
 		CurrentScale:    2,

--- a/api/provider/aws/test_aws/environment_update_test.go
+++ b/api/provider/aws/test_aws/environment_update_test.go
@@ -25,17 +25,16 @@ func TestEnvironmentUpdate(t *testing.T) {
 	mockConfig.EXPECT().Instance().Return("test").AnyTimes()
 
 	req := models.UpdateEnvironmentRequest{
-		MinClusterCount: aws.Int(2),
+		MinScale: aws.Int(2),
+		MaxScale: aws.Int(5),
 	}
 
 	// an environment's asg name is the same as the fq environment id
 	describeASGInput := &autoscaling.DescribeAutoScalingGroupsInput{}
 	describeASGInput.SetAutoScalingGroupNames([]*string{aws.String("l0-test-env_id")})
 
-	// show that the asg's current max size is 1
 	asg := &autoscaling.Group{}
 	asg.SetAutoScalingGroupName("l0-test-env_id")
-	asg.SetMaxSize(1)
 
 	describeASGOutput := &autoscaling.DescribeAutoScalingGroupsOutput{}
 	describeASGOutput.SetAutoScalingGroups([]*autoscaling.Group{asg})
@@ -48,7 +47,7 @@ func TestEnvironmentUpdate(t *testing.T) {
 	updateASGInput := &autoscaling.UpdateAutoScalingGroupInput{}
 	updateASGInput.SetAutoScalingGroupName("l0-test-env_id")
 	updateASGInput.SetMinSize(2)
-	updateASGInput.SetMaxSize(2)
+	updateASGInput.SetMaxSize(5)
 
 	mockAWS.AutoScaling.EXPECT().
 		UpdateAutoScalingGroup(updateASGInput).

--- a/api/provider/aws/test_aws/load_balancer_create_test.go
+++ b/api/provider/aws/test_aws/load_balancer_create_test.go
@@ -11,6 +11,7 @@ import (
 	provider "github.com/quintilesims/layer0/api/provider/aws"
 	"github.com/quintilesims/layer0/api/tag"
 	awsc "github.com/quintilesims/layer0/common/aws"
+	"github.com/quintilesims/layer0/common/config"
 	"github.com/quintilesims/layer0/common/config/mock_config"
 	"github.com/quintilesims/layer0/common/models"
 	"github.com/stretchr/testify/assert"
@@ -211,7 +212,7 @@ func TestLoadBalancerCreateDefaults(t *testing.T) {
 		PutRolePolicy(gomock.Any()).
 		Return(&iam.PutRolePolicyOutput{}, nil)
 
-	listeners := []*elb.Listener{listenerHelper(provider.DefaultLoadBalancerPort)}
+	listeners := []*elb.Listener{listenerHelper(config.DefaultLoadBalancerPort)}
 	createLoadBalancerInput := &elb.CreateLoadBalancerInput{}
 	createLoadBalancerInput.SetLoadBalancerName("l0-test-lb_id")
 	createLoadBalancerInput.SetScheme("internal")
@@ -223,7 +224,7 @@ func TestLoadBalancerCreateDefaults(t *testing.T) {
 		CreateLoadBalancer(createLoadBalancerInput).
 		Return(&elb.CreateLoadBalancerOutput{}, nil)
 
-	healthCheck := healthCheckHelper(&provider.DefaultHealthCheck)
+	healthCheck := healthCheckHelper(&config.DefaultLoadBalancerHealthCheck)
 	configureHealthCheckInput := &elb.ConfigureHealthCheckInput{}
 	configureHealthCheckInput.SetLoadBalancerName("l0-test-lb_id")
 	configureHealthCheckInput.SetHealthCheck(healthCheck)

--- a/api/provider/aws/test_aws/load_balancer_update_test.go
+++ b/api/provider/aws/test_aws/load_balancer_update_test.go
@@ -11,6 +11,7 @@ import (
 	provider "github.com/quintilesims/layer0/api/provider/aws"
 	"github.com/quintilesims/layer0/api/tag"
 	awsc "github.com/quintilesims/layer0/common/aws"
+	"github.com/quintilesims/layer0/common/config"
 	"github.com/quintilesims/layer0/common/config/mock_config"
 	"github.com/quintilesims/layer0/common/models"
 )
@@ -80,11 +81,11 @@ func TestLoadBalancerUpdate(t *testing.T) {
 
 	readSGHelper(mockAWS, "l0-test-lb_name-lb", "lb_sg")
 	listenerDescription := &elb.ListenerDescription{}
-	listenerDescription.SetListener(listenerHelper(provider.DefaultLoadBalancerPort))
+	listenerDescription.SetListener(listenerHelper(config.DefaultLoadBalancerPort))
 
 	lb := &elb.LoadBalancerDescription{}
 	lb.SetLoadBalancerName("l0-test-lb_name")
-	lb.SetHealthCheck(healthCheckHelper(&provider.DefaultHealthCheck))
+	lb.SetHealthCheck(healthCheckHelper(&config.DefaultLoadBalancerHealthCheck))
 	lb.SetListenerDescriptions([]*elb.ListenerDescription{listenerDescription})
 
 	describeLoadBalancersInput := &elb.DescribeLoadBalancersInput{}
@@ -98,14 +99,14 @@ func TestLoadBalancerUpdate(t *testing.T) {
 		DescribeLoadBalancers(describeLoadBalancersInput).
 		Return(describeLoadBalancersOutput, nil)
 
-	revokeIngressInput := revokeSGIngressHelper(provider.DefaultLoadBalancerPort)
+	revokeIngressInput := revokeSGIngressHelper(config.DefaultLoadBalancerPort)
 	revokeIngressInput.SetGroupId("lb_sg")
 
 	mockAWS.EC2.EXPECT().
 		RevokeSecurityGroupIngress(revokeIngressInput).
 		Return(&ec2.RevokeSecurityGroupIngressOutput{}, nil)
 
-	port := int64(provider.DefaultLoadBalancerPort.HostPort)
+	port := int64(config.DefaultLoadBalancerPort.HostPort)
 	deleteLoadBalancerListenersInput := &elb.DeleteLoadBalancerListenersInput{}
 	deleteLoadBalancerListenersInput.SetLoadBalancerName("l0-test-lb_name")
 	deleteLoadBalancerListenersInput.SetLoadBalancerPorts([]*int64{&port})

--- a/api/provider/aws/test_aws/service_create_test.go
+++ b/api/provider/aws/test_aws/service_create_test.go
@@ -10,6 +10,7 @@ import (
 	provider "github.com/quintilesims/layer0/api/provider/aws"
 	"github.com/quintilesims/layer0/api/tag"
 	awsc "github.com/quintilesims/layer0/common/aws"
+	"github.com/quintilesims/layer0/common/config"
 	"github.com/quintilesims/layer0/common/config/mock_config"
 	"github.com/quintilesims/layer0/common/models"
 	"github.com/stretchr/testify/assert"
@@ -47,7 +48,7 @@ func TestServiceCreate(t *testing.T) {
 	loadBalancerInput.SetPageSize(1)
 
 	listener := &elb.Listener{}
-	listener.SetInstancePort(provider.DefaultLoadBalancerPort.HostPort)
+	listener.SetInstancePort(config.DefaultLoadBalancerPort.HostPort)
 
 	listenerDescription := &elb.ListenerDescription{}
 	listenerDescription.SetListener(listener)

--- a/cli/command/context_test.go
+++ b/cli/command/context_test.go
@@ -32,8 +32,6 @@ func NewContext(t *testing.T, args Args, flags Flags, options ...Option) *cli.Co
 		case []string:
 			slice := cli.StringSlice(v)
 			flagSet.Var(&slice, key, "")
-
-			// todo: figure hwo to set
 		default:
 			t.Fatalf("Unexpected flag type for '%s'", key)
 		}

--- a/cli/command/context_test.go
+++ b/cli/command/context_test.go
@@ -22,13 +22,18 @@ func NewContext(t *testing.T, args Args, flags Flags, options ...Option) *cli.Co
 		switch v := val.(type) {
 		case bool:
 			flagSet.Bool(key, v, "")
+			c.Set(key, strconv.FormatBool(v))
+		case int:
+			flagSet.Int(key, v, "")
+			c.Set(key, strconv.Itoa(v))
 		case string:
 			flagSet.String(key, v, "")
+			c.Set(key, v)
 		case []string:
 			slice := cli.StringSlice(v)
 			flagSet.Var(&slice, key, "")
-		case int:
-			flagSet.Int(key, v, "")
+
+			// todo: figure hwo to set
 		default:
 			t.Fatalf("Unexpected flag type for '%s'", key)
 		}

--- a/cli/command/deploy.go
+++ b/cli/command/deploy.go
@@ -74,6 +74,10 @@ func (d *DeployCommand) create(c *cli.Context) error {
 		DeployFile: content,
 	}
 
+	if err := req.Validate(); err != nil {
+		return err
+	}
+
 	jobID, err := d.client.CreateDeploy(req)
 	if err != nil {
 		return err

--- a/cli/command/environment.go
+++ b/cli/command/environment.go
@@ -100,7 +100,7 @@ func (e *EnvironmentCommand) Command() cli.Command {
 				Flags: []cli.Flag{
 					cli.BoolTFlag{
 						Name:  "bi-directional",
-						Usage: "specifies whether the link should be direcional",
+						Usage: "specifies whether the link should be bi-directional",
 					},
 				},
 			},

--- a/cli/command/environment_test.go
+++ b/cli/command/environment_test.go
@@ -263,18 +263,18 @@ func TestEnvironmentSetScale(t *testing.T) {
 			Resolve("environment", "env_name").
 			Return([]string{"env_id"}, nil)
 
-		 minScale := 2
-                maxScale := 5
+		minScale := 2
+		maxScale := 5
 		req := models.UpdateEnvironmentRequest{
 			MinScale: &minScale,
 			MaxScale: &maxScale,
 		}
 
 		job := &models.Job{
-                        JobID:  "job_id",
-                        Status: models.CompletedJobStatus,
-                        Result: "entity_id",
-                }
+			JobID:  "job_id",
+			Status: models.CompletedJobStatus,
+			Result: "entity_id",
+		}
 
 		base.Client.EXPECT().
 			UpdateEnvironment("env_id", req).
@@ -315,6 +315,7 @@ func TestEnvironmentLinkBiDirectional(t *testing.T) {
 			EnvironmentID: "env_id1",
 			Links:         []string{},
 		}
+
 		env2 := &models.Environment{
 			EnvironmentID: "env_id2",
 			Links:         []string{"env_id3"},
@@ -373,6 +374,7 @@ func TestEnvironmentLinkBiDirectional(t *testing.T) {
 		f := Flags{
 			"bi-directional": true,
 		}
+
 		c := NewContext(t, []string{"env_name1", "env_name2"}, f, SetNoWait(!wait))
 		if err := command.link(c); err != nil {
 			t.Fatal(err)

--- a/cli/command/environment_test.go
+++ b/cli/command/environment_test.go
@@ -133,7 +133,7 @@ func TestCreateEnvironment(t *testing.T) {
 
 		req := models.CreateEnvironmentRequest{
 			EnvironmentName:  "env_name",
-			InstanceType:     "m3.large",
+			InstanceType:     "t2.small",
 			MinScale:         2,
 			MaxScale:         5,
 			UserDataTemplate: []byte(userData),

--- a/cli/command/job.go
+++ b/cli/command/job.go
@@ -25,7 +25,7 @@ func (j *JobCommand) Command() cli.Command {
 				ArgsUsage: "NAME",
 			},
 			{
-				Name:      "read",
+				Name:      "get",
 				Usage:     "describe a job",
 				Action:    j.read,
 				ArgsUsage: "NAME",

--- a/cli/command/load_balancer.go
+++ b/cli/command/load_balancer.go
@@ -222,6 +222,10 @@ func (l *LoadBalancerCommand) create(c *cli.Context) error {
 		HealthCheck:      healthCheck,
 	}
 
+	if err := req.Validate(); err != nil {
+		return err
+	}
+
 	jobID, err := l.client.CreateLoadBalancer(req)
 	if err != nil {
 		return err

--- a/cli/command/load_balancer_test.go
+++ b/cli/command/load_balancer_test.go
@@ -3,6 +3,7 @@ package command
 import (
 	"testing"
 
+	"github.com/quintilesims/layer0/common/config"
 	"github.com/quintilesims/layer0/common/models"
 	"github.com/stretchr/testify/assert"
 	"github.com/urfave/cli"
@@ -106,7 +107,7 @@ func TestCreateLoadBalancer(t *testing.T) {
 			},
 		}
 
-		healthCheck := models.HealthCheck{Target: "TCP:80"}
+		healthCheck := config.DefaultLoadBalancerHealthCheck
 
 		req := models.CreateLoadBalancerRequest{
 			LoadBalancerName: "lb_name",
@@ -137,8 +138,12 @@ func TestCreateLoadBalancer(t *testing.T) {
 
 		args := Args{"ename", "lb_name"}
 		flags := Flags{
-			"healthcheck-target": "TCP:80",
-			"port":               []string{"80:80/tcp"},
+			"healthcheck-target":              healthCheck.Target,
+			"healthcheck-interval":            healthCheck.Interval,
+			"healthcheck-timeout":             healthCheck.Timeout,
+			"healthcheck-healthy-threshold":   healthCheck.HealthyThreshold,
+			"healthcheck-unhealthy-threshold": healthCheck.UnhealthyThreshold,
+			"port": []string{"80:80/tcp"},
 		}
 
 		c := NewContext(t, args, flags, SetNoWait(!wait))

--- a/cli/command/service.go
+++ b/cli/command/service.go
@@ -35,7 +35,7 @@ func (s *ServiceCommand) Command() cli.Command {
 					},
 					cli.IntFlag{
 						Name:  "scale",
-						Value: 1,
+						Value: config.DefaultServiceScale,
 						Usage: "The desired scale of the service",
 					},
 				},
@@ -125,6 +125,10 @@ func (s *ServiceCommand) create(c *cli.Context) error {
 		LoadBalancerID: loadBalancerID,
 		ServiceName:    args["SERVICE_NAME"],
 		Scale:          c.Int("scale"),
+	}
+
+	if err := req.Validate(); err != nil {
+		return err
 	}
 
 	jobID, err := s.client.CreateService(req)

--- a/cli/command/task.go
+++ b/cli/command/task.go
@@ -104,6 +104,10 @@ func (t *TaskCommand) create(c *cli.Context) error {
 		ContainerOverrides: overrides,
 	}
 
+	if err := req.Validate(); err != nil {
+		return err
+	}
+
 	jobID, err := t.client.CreateTask(req)
 	if err != nil {
 		return err

--- a/cli/command/task_test.go
+++ b/cli/command/task_test.go
@@ -282,7 +282,8 @@ func TestParseOverrides(t *testing.T) {
 	input := []string{
 		"container1:key1=val1",
 		"container1:key2=val2",
-		"container2:k1=v1"}
+		"container2:k1=v1",
+	}
 
 	expected := []models.ContainerOverride{
 		{
@@ -300,9 +301,10 @@ func TestParseOverrides(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	assert.Equal(t, expected, output)
-	assert.Equal(t, expected[0], output[0])
-	assert.Equal(t, expected[1], output[1])
+	assert.Len(t, output, 2)
+	for _, e := range expected {
+		assert.Contains(t, output, e)
+	}
 }
 
 func TestParseOverridesErrors(t *testing.T) {

--- a/cli/printer/text.go
+++ b/cli/printer/text.go
@@ -73,6 +73,10 @@ func (t *TextPrinter) PrintDeploySummaries(deploys ...*models.DeploySummary) err
 }
 
 func (t *TextPrinter) PrintEnvironments(environments ...*models.Environment) error {
+	getScale := func(e *models.Environment) string {
+		return fmt.Sprintf("%d:%d:%d", e.MinScale, e.CurrentScale, e.MaxScale)
+	}
+
 	getLink := func(e *models.Environment, i int) string {
 		if i > len(e.Links)-1 {
 			return ""
@@ -81,14 +85,14 @@ func (t *TextPrinter) PrintEnvironments(environments ...*models.Environment) err
 		return e.Links[i]
 	}
 
-	rows := []string{"ENVIRONMENT ID | ENVIRONMENT NAME | OS | CLUSTER COUNT | INSTANCE SIZE | LINKS"}
+	rows := []string{"ENVIRONMENT ID | ENVIRONMENT NAME | OS | SCALE | INSTANCE TYPE | LINKS"}
 	for _, e := range environments {
-		row := fmt.Sprintf("%s | %s | %s | %d | %s | %s",
+		row := fmt.Sprintf("%s | %s | %s | %s | %s | %s",
 			e.EnvironmentID,
 			e.EnvironmentName,
 			e.OperatingSystem,
-			e.ClusterCount,
-			e.InstanceSize,
+			getScale(e),
+			e.InstanceType,
 			getLink(e, 0))
 
 		rows = append(rows, row)

--- a/cli/printer/text_test.go
+++ b/cli/printer/text_test.go
@@ -43,26 +43,30 @@ func ExampleTextPrintEnvironments() {
 			EnvironmentID:   "id1",
 			EnvironmentName: "name1",
 			OperatingSystem: "linux",
-			ClusterCount:    1,
-			InstanceSize:    "m3.medium",
+			MinScale:        1,
+			CurrentScale:    2,
+			MaxScale:        3,
+			InstanceType:    "m3.medium",
 			Links:           []string{"id2"},
 		},
 		{
 			EnvironmentID:   "id2",
 			EnvironmentName: "name2",
 			OperatingSystem: "windows",
-			ClusterCount:    2,
-			InstanceSize:    "m3.xlarge",
+			MinScale:        2,
+			CurrentScale:    5,
+			MaxScale:        50,
+			InstanceType:    "m3.xlarge",
 			Links:           []string{"id1", "api"},
 		},
 	}
 
 	printer.PrintEnvironments(environments...)
 	// Output:
-	// ENVIRONMENT ID  ENVIRONMENT NAME  OS       CLUSTER COUNT  INSTANCE SIZE  LINKS
-	// id1             name1             linux    1              m3.medium      id2
-	// id2             name2             windows  2              m3.xlarge      id1
-	//                                                                          api
+	// ENVIRONMENT ID  ENVIRONMENT NAME  OS       SCALE   INSTANCE TYPE  LINKS
+	// id1             name1             linux    1:2:3   m3.medium      id2
+	// id2             name2             windows  2:5:50  m3.xlarge      id1
+	//                                                                   api
 }
 
 func ExampleTextPrintEnvironmentSummaries() {

--- a/cli/printer/text_test.go
+++ b/cli/printer/text_test.go
@@ -46,7 +46,7 @@ func ExampleTextPrintEnvironments() {
 			MinScale:        1,
 			CurrentScale:    2,
 			MaxScale:        3,
-			InstanceType:    "m3.medium",
+			InstanceType:    "t2.small",
 			Links:           []string{"id2"},
 		},
 		{
@@ -56,7 +56,7 @@ func ExampleTextPrintEnvironments() {
 			MinScale:        2,
 			CurrentScale:    5,
 			MaxScale:        50,
-			InstanceType:    "m3.xlarge",
+			InstanceType:    "t2.small",
 			Links:           []string{"id1", "api"},
 		},
 	}
@@ -64,8 +64,8 @@ func ExampleTextPrintEnvironments() {
 	printer.PrintEnvironments(environments...)
 	// Output:
 	// ENVIRONMENT ID  ENVIRONMENT NAME  OS       SCALE   INSTANCE TYPE  LINKS
-	// id1             name1             linux    1:2:3   m3.medium      id2
-	// id2             name2             windows  2:5:50  m3.xlarge      id1
+	// id1             name1             linux    1:2:3   t2.small       id2
+	// id2             name2             windows  2:5:50  t2.small       id1
 	//                                                                   api
 }
 

--- a/cli/resolver/mock_resolver/mock_resolver.go
+++ b/cli/resolver/mock_resolver/mock_resolver.go
@@ -5,8 +5,9 @@
 package mock_resolver
 
 import (
-	gomock "github.com/golang/mock/gomock"
 	reflect "reflect"
+
+	gomock "github.com/golang/mock/gomock"
 )
 
 // MockResolver is a mock of Resolver interface

--- a/client/environment_test.go
+++ b/client/environment_test.go
@@ -11,7 +11,7 @@ import (
 func TestCreateEnvironment(t *testing.T) {
 	req := models.CreateEnvironmentRequest{
 		EnvironmentName:  "name",
-		InstanceType:     "m3.medium",
+		InstanceType:     "t2.small",
 		MinScale:         1,
 		MaxScale:         5,
 		UserDataTemplate: []byte("user_data"),

--- a/client/environment_test.go
+++ b/client/environment_test.go
@@ -11,8 +11,9 @@ import (
 func TestCreateEnvironment(t *testing.T) {
 	req := models.CreateEnvironmentRequest{
 		EnvironmentName:  "name",
-		InstanceSize:     "size",
-		MinClusterCount:  1,
+		InstanceType:     "m3.medium",
+		MinScale:         1,
+		MaxScale:         5,
 		UserDataTemplate: []byte("user_data"),
 		OperatingSystem:  "os",
 		AMIID:            "ami",
@@ -108,10 +109,15 @@ func TestReadEnvironment(t *testing.T) {
 }
 
 func TestUpdateEnvironment(t *testing.T) {
-	count := 1
-	links := []string{}
-	req := models.UpdateEnvironmentRequest{MinClusterCount: &count}
-	req.Links = &links
+	minScale := 1
+	maxScale := 5
+	links := []string{"env_id2"}
+
+	req := models.UpdateEnvironmentRequest{
+		MinScale: &minScale,
+		MaxScale: &maxScale,
+		Links:    &links,
+	}
 
 	handler := func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, r.Method, "PATCH")

--- a/client/mock_client/mock_client.go
+++ b/client/mock_client/mock_client.go
@@ -5,10 +5,11 @@
 package mock_client
 
 import (
-	gomock "github.com/golang/mock/gomock"
-	models "github.com/quintilesims/layer0/common/models"
 	url "net/url"
 	reflect "reflect"
+
+	gomock "github.com/golang/mock/gomock"
+	models "github.com/quintilesims/layer0/common/models"
 )
 
 // MockClient is a mock of Client interface

--- a/common/config/common.go
+++ b/common/config/common.go
@@ -1,7 +1,5 @@
 package config
 
-import "time"
-
 const (
 	FLAG_PORT                      = "port"
 	FLAG_JOB_EXPIRY                = "job-expiry"
@@ -66,12 +64,4 @@ const (
 	ENVVAR_AWS_LOG_GROUP_NAME        = "LAYER0_AWS_LOG_GROUP_NAME"
 	ENVVAR_AWS_TIME_BETWEEN_REQUESTS = "LAYER0_AWS_TIME_BETWEEN_REQUESTS"
 	ENVVAR_AWS_MAX_RETRIES           = "LAYER0_AWS_MAX_RETRIES"
-)
-
-const (
-	DefaultAWSRegion           = "us-west-2"
-	DefaultTimeBetweenRequests = time.Millisecond * 10
-	DefaultJobExpiry           = time.Hour * 1
-	DefaultLockExpiry          = time.Hour * 1
-	DefaultPort                = 9090
 )

--- a/common/config/defaults.go
+++ b/common/config/defaults.go
@@ -1,15 +1,33 @@
 package config
 
-import "time"
+import (
+	"time"
+
+	"github.com/quintilesims/layer0/common/models"
+)
 
 const (
-	DefaultAWSRegion           = "us-west-2"
-	DefaultTimeBetweenRequests = time.Millisecond * 10
-	DefaultJobExpiry           = time.Hour * 1
-	DefaultLockExpiry          = time.Hour * 1
-	DefaultPort                = 9090
-	DefaultEnvironmentInstanceType     = "t2.small"
-	DefaultEnvironmentMaxScale = 100
-	  DefaultEnvironmentOS = "linux"
-        DefaultServiceScale  = 1
+	DefaultAWSRegion               = "us-west-2"
+	DefaultTimeBetweenRequests     = time.Millisecond * 10
+	DefaultJobExpiry               = time.Hour * 1
+	DefaultLockExpiry              = time.Hour * 1
+	DefaultPort                    = 9090
+	DefaultEnvironmentInstanceType = "t2.small"
+	DefaultEnvironmentMaxScale     = 100
+	DefaultEnvironmentOS           = "linux"
+	DefaultServiceScale            = 1
 )
+
+var DefaultLoadBalancerHealthCheck = models.HealthCheck{
+	Target:             "TCP:80",
+	Interval:           30,
+	Timeout:            5,
+	HealthyThreshold:   2,
+	UnhealthyThreshold: 2,
+}
+
+var DefaultLoadBalancerPort = models.Port{
+	ContainerPort: 80,
+	HostPort:      80,
+	Protocol:      "TCP",
+}

--- a/common/config/defaults.go
+++ b/common/config/defaults.go
@@ -1,0 +1,15 @@
+package config
+
+import "time"
+
+const (
+	DefaultAWSRegion           = "us-west-2"
+	DefaultTimeBetweenRequests = time.Millisecond * 10
+	DefaultJobExpiry           = time.Hour * 1
+	DefaultLockExpiry          = time.Hour * 1
+	DefaultPort                = 9090
+	DefaultEnvironmentInstanceType     = "t2.small"
+	DefaultEnvironmentMaxScale = 100
+	  DefaultEnvironmentOS = "linux"
+        DefaultServiceScale  = 1
+)

--- a/common/config/mock_config/mock_api.go
+++ b/common/config/mock_config/mock_api.go
@@ -5,9 +5,10 @@
 package mock_config
 
 import (
-	gomock "github.com/golang/mock/gomock"
 	reflect "reflect"
 	time "time"
+
+	gomock "github.com/golang/mock/gomock"
 )
 
 // MockAPIConfig is a mock of APIConfig interface

--- a/common/models/create_environment_request.go
+++ b/common/models/create_environment_request.go
@@ -8,9 +8,10 @@ import (
 
 type CreateEnvironmentRequest struct {
 	EnvironmentName  string `json:"environment_name"`
-	InstanceSize     string `json:"instance_size"`
+	InstanceType     string `json:"instance_type"`
 	UserDataTemplate []byte `json:"user_data_template"`
-	MinClusterCount  int    `json:"min_cluster_count"`
+	MinScale         int    `json:"min_scale"`
+	MaxScale         int    `json:"max_scale"`
 	OperatingSystem  string `json:"operating_system"`
 	AMIID            string `json:"ami_id"`
 }
@@ -20,8 +21,16 @@ func (r CreateEnvironmentRequest) Validate() error {
 		return fmt.Errorf("EnvironmentName is required")
 	}
 
-	if r.MinClusterCount < 0 {
-		return fmt.Errorf("MinClusterCount must be a positive integer")
+	if r.MinScale < 0 {
+		return fmt.Errorf("MinScale must be a positive integer")
+	}
+
+	if r.MaxScale < 0 {
+		return fmt.Errorf("MaxScale must be a positive integer")
+	}
+
+	if r.MaxScale < r.MinScale {
+		return fmt.Errorf("MaxScale must be greater than or equal to MinScale")
 	}
 
 	return nil
@@ -32,9 +41,10 @@ func (e CreateEnvironmentRequest) Definition() swagger.Definition {
 		Type: "object",
 		Properties: map[string]swagger.Property{
 			"environment_name":   swagger.NewStringProperty(),
-			"instance_size":      swagger.NewStringProperty(),
+			"instance_type":      swagger.NewStringProperty(),
 			"user_data_template": swagger.NewStringProperty(),
-			"min_cluster_count":  swagger.NewIntProperty(),
+			"min_scale":          swagger.NewIntProperty(),
+			"max_scale":          swagger.NewIntProperty(),
 			"operating_system":   swagger.NewStringProperty(),
 			"ami_id":             swagger.NewStringProperty(),
 		},

--- a/common/models/environment.go
+++ b/common/models/environment.go
@@ -5,8 +5,10 @@ import swagger "github.com/zpatrick/go-plugin-swagger"
 type Environment struct {
 	EnvironmentID   string   `json:"environment_id"`
 	EnvironmentName string   `json:"environment_name"`
-	ClusterCount    int      `json:"cluster_count"`
-	InstanceSize    string   `json:"instance_size"`
+	MinScale        int      `json:"min_scale"`
+	CurrentScale    int      `json:"current_scale"`
+	MaxScale        int      `json:"max_scale"`
+	InstanceType    string   `json:"instance_type"`
 	SecurityGroupID string   `json:"security_group_id"`
 	OperatingSystem string   `json:"operating_system"`
 	AMIID           string   `json:"ami_id"`
@@ -19,8 +21,10 @@ func (e Environment) Definition() swagger.Definition {
 		Properties: map[string]swagger.Property{
 			"environment_id":    swagger.NewStringProperty(),
 			"environment_name":  swagger.NewStringProperty(),
-			"cluster_count":     swagger.NewIntProperty(),
-			"instance_size":     swagger.NewStringProperty(),
+			"min_scale":         swagger.NewIntProperty(),
+			"current_scale":     swagger.NewIntProperty(),
+			"max_scale":         swagger.NewIntProperty(),
+			"instance_type":     swagger.NewStringProperty(),
 			"security_group_id": swagger.NewStringProperty(),
 			"operating_system":  swagger.NewStringProperty(),
 			"ami_id":            swagger.NewStringProperty(),

--- a/common/models/update_environment_request.go
+++ b/common/models/update_environment_request.go
@@ -27,8 +27,8 @@ func (u UpdateEnvironmentRequest) Validate() error {
 	}
 
 	if u.MaxScale != nil && u.MinScale != nil && *u.MaxScale < *u.MinScale {
-                return fmt.Errorf("MaxScale must be greater than or equal to MinScale")
-        }
+		return fmt.Errorf("MaxScale must be greater than or equal to MinScale")
+	}
 
 	return nil
 }

--- a/common/models/update_environment_request.go
+++ b/common/models/update_environment_request.go
@@ -26,6 +26,10 @@ func (u UpdateEnvironmentRequest) Validate() error {
 		return fmt.Errorf("MaxScale must be a positive integer")
 	}
 
+	if u.MaxScale != nil && u.MinScale != nil && *u.MaxScale < *u.MinScale {
+                return fmt.Errorf("MaxScale must be greater than or equal to MinScale")
+        }
+
 	return nil
 }
 

--- a/common/models/update_environment_request.go
+++ b/common/models/update_environment_request.go
@@ -12,15 +12,18 @@ type UpdateEnvironmentRequestJob struct {
 }
 
 type UpdateEnvironmentRequest struct {
-	MinClusterCount *int      `json:"min_cluster_count"`
-	Links           *[]string `json:"links"`
+	MinScale *int      `json:"min_scale"`
+	MaxScale *int      `json:"max_scale"`
+	Links    *[]string `json:"links"`
 }
 
 func (u UpdateEnvironmentRequest) Validate() error {
-	if u.MinClusterCount != nil {
-		if *u.MinClusterCount < 0 {
-			return fmt.Errorf("MinClusterCount must be a positive integer")
-		}
+	if u.MinScale != nil && *u.MinScale < 0 {
+		return fmt.Errorf("MinScale must be a positive integer")
+	}
+
+	if u.MaxScale != nil && *u.MaxScale < 0 {
+		return fmt.Errorf("MaxScale must be a positive integer")
 	}
 
 	return nil
@@ -30,8 +33,9 @@ func (u UpdateEnvironmentRequest) Definition() swagger.Definition {
 	return swagger.Definition{
 		Type: "object",
 		Properties: map[string]swagger.Property{
-			"min_cluster_count": swagger.NewIntProperty(),
-			"links":             swagger.NewStringSliceProperty(),
+			"min_scale": swagger.NewIntProperty(),
+			"max_scale": swagger.NewIntProperty(),
+			"links":     swagger.NewStringSliceProperty(),
 		},
 	}
 }

--- a/plugins/terraform/layer0/data_source_layer0_environment.go
+++ b/plugins/terraform/layer0/data_source_layer0_environment.go
@@ -20,11 +20,19 @@ func dataSourceLayer0Environment() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
-			"size": {
+			"instance_type": {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
-			"cluster_count": {
+			"min_scale": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+			"current_scale": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+			"max_scale": {
 				Type:     schema.TypeInt,
 				Computed: true,
 			},
@@ -68,8 +76,10 @@ func dataSourceLayer0EnvironmentRead(d *schema.ResourceData, meta interface{}) e
 
 	d.SetId(environment.EnvironmentID)
 	d.Set("name", environment.EnvironmentName)
-	d.Set("size", environment.InstanceSize)
-	d.Set("cluster_count", environment.ClusterCount)
+	d.Set("instance_type", environment.InstanceType)
+	d.Set("min_scale", environment.MinScale)
+	d.Set("current_scale", environment.CurrentScale)
+	d.Set("max_scale", environment.MaxScale)
 	d.Set("security_group_id", environment.SecurityGroupID)
 	d.Set("os", environment.OperatingSystem)
 	d.Set("ami", environment.AMIID)

--- a/plugins/terraform/layer0/data_source_layer0_environment_test.go
+++ b/plugins/terraform/layer0/data_source_layer0_environment_test.go
@@ -32,7 +32,7 @@ func TestDataSourceLayer0EnvironmentRead(t *testing.T) {
 		MinScale:        1,
 		CurrentScale:    2,
 		MaxScale:        3,
-		InstanceType:    "m3.small",
+		InstanceType:    "t2.small",
 		SecurityGroupID: "some_sg",
 		OperatingSystem: "some_os",
 		AMIID:           "some_ami",
@@ -56,7 +56,7 @@ func TestDataSourceLayer0EnvironmentRead(t *testing.T) {
 	assert.Equal(t, 1, d.Get("min_scale"))
 	assert.Equal(t, 2, d.Get("current_scale"))
 	assert.Equal(t, 3, d.Get("max_scale"))
-	assert.Equal(t, "m3.small", d.Get("instance_type"))
+	assert.Equal(t, "t2.small", d.Get("instance_type"))
 	assert.Equal(t, "some_sg", d.Get("security_group_id"))
 	assert.Equal(t, "some_os", d.Get("os"))
 	assert.Equal(t, "some_ami", d.Get("ami"))

--- a/plugins/terraform/layer0/data_source_layer0_environment_test.go
+++ b/plugins/terraform/layer0/data_source_layer0_environment_test.go
@@ -29,8 +29,10 @@ func TestDataSourceLayer0EnvironmentRead(t *testing.T) {
 	environment := &models.Environment{
 		EnvironmentID:   "env_id",
 		EnvironmentName: "env_name",
-		ClusterCount:    2,
-		InstanceSize:    "m3.small",
+		MinScale:        1,
+		CurrentScale:    2,
+		MaxScale:        3,
+		InstanceType:    "m3.small",
 		SecurityGroupID: "some_sg",
 		OperatingSystem: "some_os",
 		AMIID:           "some_ami",
@@ -51,8 +53,10 @@ func TestDataSourceLayer0EnvironmentRead(t *testing.T) {
 
 	assert.Equal(t, "env_id", d.Id())
 	assert.Equal(t, "env_name", d.Get("name"))
-	assert.Equal(t, 2, d.Get("cluster_count"))
-	assert.Equal(t, "m3.small", d.Get("size"))
+	assert.Equal(t, 1, d.Get("min_scale"))
+	assert.Equal(t, 2, d.Get("current_scale"))
+	assert.Equal(t, 3, d.Get("max_scale"))
+	assert.Equal(t, "m3.small", d.Get("instance_type"))
 	assert.Equal(t, "some_sg", d.Get("security_group_id"))
 	assert.Equal(t, "some_os", d.Get("os"))
 	assert.Equal(t, "some_ami", d.Get("ami"))

--- a/plugins/terraform/layer0/resource_layer0_environment_test.go
+++ b/plugins/terraform/layer0/resource_layer0_environment_test.go
@@ -18,9 +18,10 @@ func TestResourceEnvironmentCreateRead(t *testing.T) {
 
 	req := models.CreateEnvironmentRequest{
 		EnvironmentName:  "env_name",
-		InstanceSize:     "m3.large",
+		InstanceType:     "m3.large",
 		UserDataTemplate: []byte("template"),
-		MinClusterCount:  1,
+		MinScale:         1,
+		MaxScale:         3,
 		OperatingSystem:  "linux",
 		AMIID:            "ami123",
 	}
@@ -41,8 +42,10 @@ func TestResourceEnvironmentCreateRead(t *testing.T) {
 	environment := &models.Environment{
 		EnvironmentID:   "env_id",
 		EnvironmentName: "env_name",
-		ClusterCount:    1,
-		InstanceSize:    "m3.large",
+		MinScale:        1,
+		CurrentScale:    2,
+		MaxScale:        3,
+		InstanceType:    "m3.large",
 		SecurityGroupID: "sgid",
 		OperatingSystem: "linux",
 		AMIID:           "ami123",
@@ -54,12 +57,13 @@ func TestResourceEnvironmentCreateRead(t *testing.T) {
 
 	environmentResource := Provider().(*schema.Provider).ResourcesMap["layer0_environment"]
 	d := schema.TestResourceDataRaw(t, environmentResource.Schema, map[string]interface{}{
-		"name":      "env_name",
-		"size":      "m3.large",
-		"user_data": "template",
-		"min_count": 1,
-		"os":        "linux",
-		"ami":       "ami123",
+		"name":          "env_name",
+		"instance_type": "m3.large",
+		"user_data":     "template",
+		"min_scale":     1,
+		"max_scale":     3,
+		"os":            "linux",
+		"ami":           "ami123",
 	})
 
 	if err := resourceLayer0EnvironmentCreate(d, mockClient); err != nil {
@@ -68,8 +72,10 @@ func TestResourceEnvironmentCreateRead(t *testing.T) {
 
 	assert.Equal(t, "env_id", d.Id())
 	assert.Equal(t, "env_name", d.Get("name").(string))
-	assert.Equal(t, "m3.large", d.Get("size").(string))
-	assert.Equal(t, 1, d.Get("cluster_count").(int))
+	assert.Equal(t, "m3.large", d.Get("instance_type").(string))
+	assert.Equal(t, 1, d.Get("min_scale").(int))
+	assert.Equal(t, 2, d.Get("current_scale").(int))
+	assert.Equal(t, 3, d.Get("max_scale").(int))
 	assert.Equal(t, "sgid", d.Get("security_group_id").(string))
 	assert.Equal(t, "linux", d.Get("os").(string))
 	assert.Equal(t, "ami123", d.Get("ami").(string))

--- a/plugins/terraform/layer0/resource_layer0_environment_test.go
+++ b/plugins/terraform/layer0/resource_layer0_environment_test.go
@@ -18,7 +18,7 @@ func TestResourceEnvironmentCreateRead(t *testing.T) {
 
 	req := models.CreateEnvironmentRequest{
 		EnvironmentName:  "env_name",
-		InstanceType:     "m3.large",
+		InstanceType:     "t2.small",
 		UserDataTemplate: []byte("template"),
 		MinScale:         1,
 		MaxScale:         3,
@@ -45,7 +45,7 @@ func TestResourceEnvironmentCreateRead(t *testing.T) {
 		MinScale:        1,
 		CurrentScale:    2,
 		MaxScale:        3,
-		InstanceType:    "m3.large",
+		InstanceType:    "t2.small",
 		SecurityGroupID: "sgid",
 		OperatingSystem: "linux",
 		AMIID:           "ami123",
@@ -58,7 +58,7 @@ func TestResourceEnvironmentCreateRead(t *testing.T) {
 	environmentResource := Provider().(*schema.Provider).ResourcesMap["layer0_environment"]
 	d := schema.TestResourceDataRaw(t, environmentResource.Schema, map[string]interface{}{
 		"name":          "env_name",
-		"instance_type": "m3.large",
+		"instance_type": "t2.small",
 		"user_data":     "template",
 		"min_scale":     1,
 		"max_scale":     3,
@@ -72,7 +72,7 @@ func TestResourceEnvironmentCreateRead(t *testing.T) {
 
 	assert.Equal(t, "env_id", d.Id())
 	assert.Equal(t, "env_name", d.Get("name").(string))
-	assert.Equal(t, "m3.large", d.Get("instance_type").(string))
+	assert.Equal(t, "t2.small", d.Get("instance_type").(string))
 	assert.Equal(t, 1, d.Get("min_scale").(int))
 	assert.Equal(t, 2, d.Get("current_scale").(int))
 	assert.Equal(t, 3, d.Get("max_scale").(int))

--- a/plugins/terraform/layer0/resource_layer0_load_balancer.go
+++ b/plugins/terraform/layer0/resource_layer0_load_balancer.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/hashicorp/terraform/helper/hashcode"
 	"github.com/hashicorp/terraform/helper/schema"
-	"github.com/quintilesims/layer0/api/provider/aws"
 	"github.com/quintilesims/layer0/client"
 	"github.com/quintilesims/layer0/common/config"
 	"github.com/quintilesims/layer0/common/errors"
@@ -79,27 +78,27 @@ func resourceLayer0LoadBalancer() *schema.Resource {
 						"target": {
 							Type:     schema.TypeString,
 							Optional: true,
-							Default:  aws.DefaultHealthCheck.Target,
+							Default:  config.DefaultLoadBalancerHealthCheck.Target,
 						},
 						"interval": {
 							Type:     schema.TypeInt,
 							Optional: true,
-							Default:  aws.DefaultHealthCheck.Interval,
+							Default:  config.DefaultLoadBalancerHealthCheck.Interval,
 						},
 						"timeout": {
 							Type:     schema.TypeInt,
 							Optional: true,
-							Default:  aws.DefaultHealthCheck.Timeout,
+							Default:  config.DefaultLoadBalancerHealthCheck.Timeout,
 						},
 						"healthy_threshold": {
 							Type:     schema.TypeInt,
 							Optional: true,
-							Default:  aws.DefaultHealthCheck.HealthyThreshold,
+							Default:  config.DefaultLoadBalancerHealthCheck.HealthyThreshold,
 						},
 						"unhealthy_threshold": {
 							Type:     schema.TypeInt,
 							Optional: true,
-							Default:  aws.DefaultHealthCheck.UnhealthyThreshold,
+							Default:  config.DefaultLoadBalancerHealthCheck.UnhealthyThreshold,
 						},
 					},
 				},
@@ -113,7 +112,7 @@ func resourceLayer0LoadBalancerCreate(d *schema.ResourceData, meta interface{}) 
 
 	ports := expandPorts(d.Get("port").(*schema.Set).List())
 	if len(ports) == 0 {
-		ports = []models.Port{aws.DefaultLoadBalancerPort}
+		ports = []models.Port{config.DefaultLoadBalancerPort}
 	}
 
 	req := models.CreateLoadBalancerRequest{
@@ -249,7 +248,7 @@ func expandHealthCheck(flattened interface{}) models.HealthCheck {
 		}
 	}
 
-	return aws.DefaultHealthCheck
+	return config.DefaultLoadBalancerHealthCheck
 }
 
 func flattenHealthCheck(healthCheck models.HealthCheck) []map[string]interface{} {

--- a/tests/smoke/admin.bats
+++ b/tests/smoke/admin.bats
@@ -1,17 +1,5 @@
 #!/usr/bin/env bats
 
-@test "admin sql" {
-    l0 admin sql
-}
-
-@test "admin version" {
-    l0 admin version
-}
-
 @test "admin debug" {
     l0 admin debug
-}
-
-@test "admin scale api" {
-    l0 admin scale api
 }

--- a/tests/smoke/environment.bats
+++ b/tests/smoke/environment.bats
@@ -53,17 +53,17 @@
 }
 
 @test "environment delete test1" {
-    l0 environment delete test1
+    l0 --no-wait environment delete test1
 }
 
 @test "environment delete test2" {
-    l0 environment delete test2
+    l0 --no-wait environment delete test2
 }
 
-@test "environment delete --wait test3" {
-    l0 environment delete test3
+@test "environment delete test3" {
+    l0 --no-wait environment delete test3
 }
 
-@test "environment delete --wait test4" {
-    l0 environment delete --wait test4
+@test "environment delete test4" {
+    l0 environment delete test4
 }

--- a/tests/smoke/environment.bats
+++ b/tests/smoke/environment.bats
@@ -20,12 +20,20 @@
     l0 environment create --user-data common/user_data.sh test2 
 }
 
-@test "environment create --min-count 2 test3" {
-    l0 environment create --min-count 2 test3
+@test "environment create --min-scale 2 --max-scale 5 test3" {
+    l0 environment create --min-scale 2 --max-scale 5  test3
 }
 
 @test "environment create --os windows test4" {
     l0 environment create --os windows test4
+}
+
+@test "environment link --bi-directional test1 test2" {
+    l0 environment link --bi-directional test1 test2
+}
+
+@test "environment unlink --bi-directional test1 test2" {
+    l0 environment unlink --bi-directional test1 test2
 }
 
 @test "environment link test3 test4" {
@@ -44,12 +52,8 @@
     l0 environment get test2
 }
 
-@test "environment setmincount test3 0" {
-    l0 environment setmincount test3 0
-}
-
-@test "environment setmincount test3 3" {
-    l0 environment setmincount test3 3
+@test "environment set-scale --min-scale 1 --max-scale 5 test3" {
+    l0 environment set-scale --min-scale 1 --max-scale 5 test3
 }
 
 @test "environment delete test1" {

--- a/tests/smoke/job.bats
+++ b/tests/smoke/job.bats
@@ -4,8 +4,8 @@
     l0 environment create test
 }
 
-@test "environment delete --wait test" {
-    l0 environment delete -wait test
+@test "environment delete test" {
+    l0 environment delete test
 }
 
 @test "job: list" {
@@ -17,18 +17,7 @@
     l0 job get $result
 }
 
-@test "job: logs (most recent)" {
+@test "job delete (most recent)" {
     result="$(l0 -o json job list | jq -r 'max_by(.time_created) | .job_id')"
-    l0 job logs $result
+    l0 job delete $result
 }
-
-@test "job: logs --tail 100 (most recent)" {
-    result="$(l0 -o json job list | jq -r 'max_by(.time_created) | .job_id')"
-    l0 job logs $result
-}
-
-@test "job logs --start 2001-01-01 01:01 --end 2012-12-12 12:12 (most recent)" {
-    result="$(l0 -o json job list | jq -r 'max_by(.time_created) | .job_id')"
-    l0 job logs --start '2001-01-01 01:01' --end '2012-12-12 12:12' $result
-}
-

--- a/tests/smoke/load_balancer.bats
+++ b/tests/smoke/load_balancer.bats
@@ -1,6 +1,6 @@
 #!/usr/bin/env bats
 
-certificate_name="l0-$LAYER0_PREFIX-api"
+certificate_name="l0-$LAYER0_INSTANCE-api"
 
 @test "create environment test" {
     l0 environment create test
@@ -26,8 +26,8 @@ certificate_name="l0-$LAYER0_PREFIX-api"
     l0 loadbalancer dropport loadbalancer1 8000
 }
 
-@test "loadbalancer delete --wait loadbalancer1" {
-    l0 loadbalancer delete --wait loadbalancer1
+@test "loadbalancer delete loadbalancer1" {
+    l0 loadbalancer delete loadbalancer1
 }
 
 @test "loadbalancer create --port 80:80/http --port 443:443/https --private --certificate $certificate_name loadbalancer2" {
@@ -46,8 +46,8 @@ certificate_name="l0-$LAYER0_PREFIX-api"
     l0 loadbalancer get l\*
 }
 
-@test "loadbalancer delete --wait loadbalancer2" {
-    l0 loadbalancer delete --wait loadbalancer2
+@test "loadbalancer delete loadbalancer2" {
+    l0 loadbalancer delete loadbalancer2
 }
 
 @test "loadbalancer create --healthcheck-target TCP:80 --healthcheck-interval 30 --healthcheck-timeout 5 --healthcheck-healthy-threshold 2 --healthcheck-unhealthy-threshold 2 loadbalancer3" {
@@ -62,8 +62,8 @@ certificate_name="l0-$LAYER0_PREFIX-api"
     l0 loadbalancer healthcheck --set-target TCP:88 --set-interval 45 --set-timeout 10 --set-healthy-threshold 5 --set-unhealthy-threshold 3 loadbalancer3
 }
 
-@test "loadbalancer delete --wait loadbalancer3" {
-    l0 loadbalancer delete --wait loadbalancer3
+@test "loadbalancer delete loadbalancer3" {
+    l0 loadbalancer delete loadbalancer3
 }
 
 @test "loadbalancer create --port 80:80/http test loadbalancer4" {
@@ -90,7 +90,7 @@ certificate_name="l0-$LAYER0_PREFIX-api"
     l0 deploy delete guestbook:latest
 }
 
-# this deletes the remaining service(s) and loadbalancer(s)
-@test "environment delete --wait test" {
-    l0 environment delete --wait test
+# this deletes the remaining service(s), load balancer(s), and task(s)
+@test "environment delete test" {
+    l0 environment delete test
 }

--- a/tests/smoke/load_balancer.bats
+++ b/tests/smoke/load_balancer.bats
@@ -58,8 +58,8 @@ certificate_name="l0-$LAYER0_INSTANCE-api"
     l0 loadbalancer healthcheck loadbalancer3
 }
 
-@test "loadbalancer healthcheck --set-target TCP:88 --set-interval 45 --set-timeout 10 --set-healthy-threshold 5 --set-unhealthy-threshold 3 loadbalancer3" {
-    l0 loadbalancer healthcheck --set-target TCP:88 --set-interval 45 --set-timeout 10 --set-healthy-threshold 5 --set-unhealthy-threshold 3 loadbalancer3
+@test "loadbalancer healthcheck --healthcheck-target TCP:88 --healthcheck-interval 45 --healthcheck-timeout 10 --healthy-threshold 5 --unhealthy-threshold 3 loadbalancer3" {
+    l0 loadbalancer healthcheck --healthcheck-target TCP:88 --healthcheck-interval 45 --healthcheck-timeout 10 --healthy-threshold 5 --unhealthy-threshold 3 loadbalancer3
 }
 
 @test "loadbalancer delete loadbalancer3" {

--- a/tests/smoke/service.bats
+++ b/tests/smoke/service.bats
@@ -16,8 +16,8 @@
     l0 service create --loadbalancer loadbalancer1 test service1 guestbook:latest
 }
 
-@test "service create --wait test service2 guestbook:latest" {
-    l0 service create --wait test service2 guestbook:latest
+@test "service create test service2 guestbook:latest" {
+    l0 service create test service2 guestbook:latest
 }
 
 @test "service create test service3 guestbook:latest" {
@@ -33,11 +33,11 @@
 }
 
 @test "service scale service1 2" {
-    l0 service scale service1 2
+    l0 --no-wait service scale service1 2
 }
 
-@test "service scale --wait service2 2" {
-    l0 service scale --wait service2 2
+@test "service scale service2 2" {
+    l0 service scale service2 2
 }
 
 @test "deploy create guestbook" {
@@ -45,11 +45,11 @@
 }
 
 @test "service update service1 guestbook:latest" {
-    l0 service update service1 guestbook:latest
+    l0 --no-wait service update service1 guestbook:latest
 }
 
-@test "service update --wait service2 guestbook:latest" {
-    l0 service update --wait service2 guestbook:latest
+@test "service update service2 guestbook:latest" {
+    l0 --no-wait service update service2 guestbook:latest
 }
 
 @test "service update service3 guestbook:latest" {
@@ -74,11 +74,11 @@
     l0 deploy delete guestbook:latest
 }
 
-@test "service delete --wait service1" {
-    l0 service delete --wait service1
+@test "service delete service1" {
+    l0 service delete service1
 }
 
-# this deletes the remaining service(s) and loadbalancer(s)
-@test "environment delete --wait test" {
-    l0 environment delete --wait test
+# this deletes the remaining service(s), load balancer(s), and task(s)
+@test "environment delete test" {
+    l0 environment delete test
 }

--- a/tests/smoke/task.bats
+++ b/tests/smoke/task.bats
@@ -8,20 +8,20 @@
     l0 deploy create ./common/Task.Dockerrun.aws.json alpine
 }
 
-@test "task create --wait test task1 alpine:latest" {
-    l0 task create --wait test task1 alpine:latest
+@test "task create test task1 alpine:latest" {
+    l0 task create test task1 alpine:latest
 }
 
-@test "task create --copies 2 --env alpine:key=val test task2 alpine:latest" {
-    l0 task create --copies 2 --env alpine:key=val test task2 alpine:latest
+@test "task create --env alpine:key=val test task2 alpine:latest" {
+    l0 task create --env alpine:key=val test task2 alpine:latest
 }
 
 @test "task list" {
     l0 task list
 }
 
-@test "task list --all" {
-    l0 task list --all
+@test "task list" {
+    l0 task list
 }
 
 @test "task get task1" {
@@ -52,7 +52,7 @@
     l0 deploy delete alpine:latest
 }
 
-# this deletes the remaining service(s), loadbalancer(s), and task(s)
-@test "environment delete --wait test" {
-    l0 environment delete --wait test
+# this deletes the remaining service(s), load balancer(s), and task(s)
+@test "environment delete test" {
+    l0 environment delete test
 }


### PR DESCRIPTION
**What does this pull request do?**
* Adds/Changes environment model to include `MinScale`, `CurrentScale, `MaxScale`, and `InstanceType`. 
* Puts reasonable defaults into `config` package. 
* Allows `MaxScale` for environment to be set on `l0 environment create`, `l0 environment scale`, and through the terraform provider
* Changes how environment scale is printed on the CLI: `<min>:<current>:<max>`
* Miscellaneous improvements, bug fixes, etc. 


**How should this be tested?**
Unit Tests
Create/Update read environment via the CLI

**Checklist**
- [ ] Unit tests
~[ ] Smoke tests (will do in future PR)~
~[ ] System tests (will do in future PR)~
~[ ] Documentation (will do in future PR)~
