### PR TITLE
MAINT: Fix import system test after merge of env max scale changes

### DIFF
--- a/tests/system/import_test.go
+++ b/tests/system/import_test.go
@@ -5,7 +5,7 @@ import (
 	"log"
 	"testing"
 
-	"github.com/quintilesims/layer0/api/provider/aws"
+	"github.com/quintilesims/layer0/common/config"
 	"github.com/quintilesims/layer0/common/models"
 )
 
@@ -28,8 +28,9 @@ func TestImport(t *testing.T) {
 	log.Printf("[DEBUG] Creating test resources")
 	createEnvironmentReq := models.CreateEnvironmentRequest{
 		EnvironmentName: "import",
-		InstanceSize:    "t2.micro",
-		MinClusterCount: 0,
+		InstanceType:    "t2.micro",
+		MinScale:        1,
+		MaxScale:        2,
 		OperatingSystem: "linux",
 	}
 
@@ -39,8 +40,8 @@ func TestImport(t *testing.T) {
 		LoadBalancerName: "sts",
 		EnvironmentID:    environmentID,
 		IsPublic:         true,
-		Ports:            []models.Port{aws.DefaultLoadBalancerPort},
-		HealthCheck:      aws.DefaultHealthCheck,
+		Ports:            []models.Port{config.DefaultLoadBalancerPort},
+		HealthCheck:      config.DefaultLoadBalancerHealthCheck,
 	}
 
 	loadBalancerID := s.Layer0.CreateLoadBalancer(createLoadBalancerReq)


### PR DESCRIPTION
**What does this pull request do?**
After a recent merge, some things broke in the import system test. These changes should resolve those breaks.

**How should this be tested?**
`go test ./... -v -dry` should compile. Note the tests will not succeed as that is for a future PR.


**Checklist**
~- [ ] Unit tests~
~- [ ] Smoke tests (if applicable)~
~- [ ] System tests (if applicable)~
~- [ ] Documentation (if applicable)~
