### PR TITLE
Create API tags on startup

### DIFF
--- a/api/main.go
+++ b/api/main.go
@@ -21,7 +21,6 @@ import (
 	awsclient "github.com/quintilesims/layer0/common/aws"
 	"github.com/quintilesims/layer0/common/config"
 	"github.com/quintilesims/layer0/common/logging"
-	"github.com/quintilesims/layer0/common/models"
 	"github.com/urfave/cli"
 	"github.com/zpatrick/fireball"
 )
@@ -74,10 +73,7 @@ func main() {
 		tagStore := tag.NewDynamoStore(session, cfg.DynamoTagTable())
 		jobStore := job.NewDynamoStore(session, cfg.DynamoJobTable())
 
-		if err := addAPIEntityTags(tagStore); err != nil {
-			return err
-		}
-
+		adminProvider := aws.NewAdminProvider(client, tagStore, cfg)
 		deployProvider := aws.NewDeployProvider(client, tagStore, cfg)
 		environmentProvider := aws.NewEnvironmentProvider(client, tagStore, cfg)
 		loadBalancerProvider := aws.NewLoadBalancerProvider(client, tagStore, cfg)
@@ -85,6 +81,10 @@ func main() {
 		taskProvider := aws.NewTaskProvider(client, tagStore, cfg)
 		environmentScaler := aws.NewEnvironmentScaler()
 		scalerDispatcher := scaler.NewDispatcher(jobStore, time.Second*15)
+
+		if err := adminProvider.Init(); err != nil {
+			return err
+		}
 
 		jobRunner := aws.NewJobRunner(
 			deployProvider,
@@ -155,45 +155,4 @@ func main() {
 	if err := app.Run(os.Args); err != nil {
 		log.Fatal(err)
 	}
-}
-
-// todo: add 'arn' tags for all active task definitions for the api
-func addAPIEntityTags(store tag.Store) error {
-	for _, entityType := range []string{
-		"deploy",
-		"environment",
-		"load_balancer",
-		"service"} {
-
-		t := models.Tag{
-			EntityID:   "api",
-			EntityType: entityType,
-			Key:        "name",
-			Value:      "api",
-		}
-
-		if err := store.Insert(t); err != nil {
-			return err
-		}
-
-		if entityType == "environment" {
-			t.Key = "os"
-			t.Value = "linux"
-
-			if err := store.Insert(t); err != nil {
-				return err
-			}
-		}
-
-		if entityType == "load_balancer" || entityType == "service" {
-			t.Key = "environment_id"
-			t.Value = "api"
-
-			if err := store.Insert(t); err != nil {
-				return err
-			}
-		}
-	}
-
-	return nil
 }

--- a/api/provider/aws/admin.go
+++ b/api/provider/aws/admin.go
@@ -1,0 +1,61 @@
+package aws
+
+import (
+	"log"
+	"strings"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/quintilesims/layer0/api/tag"
+	awsc "github.com/quintilesims/layer0/common/aws"
+	"github.com/quintilesims/layer0/common/config"
+	"github.com/quintilesims/layer0/common/models"
+)
+
+type AdminProvider struct {
+	AWS      *awsc.Client
+	TagStore tag.Store
+	Config   config.APIConfig
+}
+
+func NewAdminProvider(a *awsc.Client, t tag.Store, c config.APIConfig) *AdminProvider {
+	return &AdminProvider{
+		AWS:      a,
+		TagStore: t,
+		Config:   c,
+	}
+}
+
+func (a *AdminProvider) Init() error {
+	log.Printf("[DEBUG] Adding API tags")
+
+	fqAPI := addLayer0Prefix(a.Config.Instance(), "api")
+	service, err := readService(a.AWS.ECS, fqAPI, fqAPI)
+	if err != nil {
+		return err
+	}
+
+	// arn format: "arn:aws:ecs:region:123:task-definition/l0-instance-api:1"
+	taskDefinitionARN := aws.StringValue(service.TaskDefinition)
+	split := strings.Split(taskDefinitionARN, ":")
+	taskDefinitionRevision := split[len(split)-1]
+
+	tags := []models.Tag{
+		{EntityID: "api", EntityType: "deploy", Key: "name", Value: "api"},
+		{EntityID: "api", EntityType: "deploy", Key: "arn", Value: taskDefinitionARN},
+		{EntityID: "api", EntityType: "deploy", Key: "version", Value: taskDefinitionRevision},
+		{EntityID: "api", EntityType: "environment", Key: "name", Value: "api"},
+		{EntityID: "api", EntityType: "environment", Key: "os", Value: "linux"},
+		{EntityID: "api", EntityType: "load_balancer", Key: "name", Value: "api"},
+		{EntityID: "api", EntityType: "load_balancer", Key: "environment_id", Value: "api"},
+		{EntityID: "api", EntityType: "service", Key: "name", Value: "api"},
+		{EntityID: "api", EntityType: "service", Key: "environment_id", Value: "api"},
+	}
+
+	for _, tag := range tags {
+		if err := a.TagStore.Insert(tag); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}

--- a/api/provider/aws/service_delete.go
+++ b/api/provider/aws/service_delete.go
@@ -23,7 +23,7 @@ func (s *ServiceProvider) Delete(serviceID string) error {
 	clusterName := addLayer0Prefix(s.Config.Instance(), environmentID)
 	fqServiceID := addLayer0Prefix(s.Config.Instance(), serviceID)
 
-	service, err := s.readService(clusterName, fqServiceID)
+	service, err := readService(s.AWS.ECS, clusterName, fqServiceID)
 	if err != nil {
 		return err
 	}

--- a/api/provider/aws/service_logs.go
+++ b/api/provider/aws/service_logs.go
@@ -17,7 +17,7 @@ func (s *ServiceProvider) Logs(serviceID string, tail int, start, end time.Time)
 	fqEnvironmentID := addLayer0Prefix(s.Config.Instance(), environmentID)
 	fqServiceID := addLayer0Prefix(s.Config.Instance(), serviceID)
 	clusterName := fqEnvironmentID
-	service, err := s.readService(clusterName, fqServiceID)
+	service, err := readService(s.AWS.ECS, clusterName, fqServiceID)
 	if err != nil {
 		return nil, err
 	}

--- a/api/provider/aws/test_aws/admin_init_test.go
+++ b/api/provider/aws/test_aws/admin_init_test.go
@@ -1,0 +1,62 @@
+package test_aws
+
+import (
+	"testing"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/ecs"
+	"github.com/golang/mock/gomock"
+	provider "github.com/quintilesims/layer0/api/provider/aws"
+	"github.com/quintilesims/layer0/api/tag"
+	awsc "github.com/quintilesims/layer0/common/aws"
+	"github.com/quintilesims/layer0/common/config/mock_config"
+	"github.com/quintilesims/layer0/common/models"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestAdminInit(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockAWS := awsc.NewMockClient(ctrl)
+	tagStore := tag.NewMemoryStore()
+	mockConfig := mock_config.NewMockAPIConfig(ctrl)
+
+	mockConfig.EXPECT().Instance().Return("test").AnyTimes()
+
+	describeServicesInput := &ecs.DescribeServicesInput{}
+	describeServicesInput.SetCluster("l0-test-api")
+	describeServicesInput.SetServices([]*string{aws.String("l0-test-api")})
+
+	service := &ecs.Service{}
+	taskDefinitionARN := "arn:aws:ecs:region:123:task-definition/l0-test-api:1"
+	service.SetTaskDefinition(taskDefinitionARN)
+
+	describeServicesOutput := &ecs.DescribeServicesOutput{}
+	describeServicesOutput.SetServices([]*ecs.Service{service})
+
+	mockAWS.ECS.EXPECT().
+		DescribeServices(describeServicesInput).
+		Return(describeServicesOutput, nil)
+
+	target := provider.NewAdminProvider(mockAWS.Client(), tagStore, mockConfig)
+	if err := target.Init(); err != nil {
+		t.Fatal(err)
+	}
+
+	expectedTags := []models.Tag{
+		{EntityID: "api", EntityType: "deploy", Key: "name", Value: "api"},
+		{EntityID: "api", EntityType: "deploy", Key: "arn", Value: taskDefinitionARN},
+		{EntityID: "api", EntityType: "deploy", Key: "version", Value: "1"},
+		{EntityID: "api", EntityType: "environment", Key: "name", Value: "api"},
+		{EntityID: "api", EntityType: "environment", Key: "os", Value: "linux"},
+		{EntityID: "api", EntityType: "load_balancer", Key: "name", Value: "api"},
+		{EntityID: "api", EntityType: "load_balancer", Key: "environment_id", Value: "api"},
+		{EntityID: "api", EntityType: "service", Key: "name", Value: "api"},
+		{EntityID: "api", EntityType: "service", Key: "environment_id", Value: "api"},
+	}
+
+	for _, tag := range expectedTags {
+		assert.Contains(t, tagStore.Tags(), tag)
+	}
+}


### PR DESCRIPTION
**What does this pull request do?**
Adds an `AdminProvider` object to the `provider/aws` package. 
This object has an `Init()` function that will add all of the necessary tags for the API entities. 

**How should this be tested?**
* Unit tests
* Manually remove all api-related tags from the Dynamo table, run the api locally, and the tags should get re-populated. All `l0 entity get` commands should succeed for `api` entities. 


**Checklist**
- [x] Unit tests

