### PR TITLE
Use AWS AZ data source when creating Layer0 API subnets

### DIFF
--- a/setup/instance/inputs.go
+++ b/setup/instance/inputs.go
@@ -56,12 +56,13 @@ Layer0 API will use its own key with limited permissions to provision AWS resour
 
 const INPUT_AWS_REGION_DESCRIPTION = `
 AWS Region: The region input variable specifies which region to provision the
-AWS resources required for Layer0. The following regions can be used: 
+AWS resources required for Layer0. Regions that support the following services 
+can be used: 
 
-    - us-west-1
-    - us-west-2
-    - us-east-1
-    - eu-west-1
+    - ECS
+    - VPC
+    - S3
+    - DynamoDB
 
 Note that changing this value will destroy and recreate any existing resources.
 `

--- a/setup/module/main.tf
+++ b/setup/module/main.tf
@@ -10,12 +10,9 @@ module "vpc" {
   # todo: count_hack is workaround for https://github.com/hashicorp/terraform/issues/953
   count_hack = "${ var.vpc_id == "" ? 1 : 0 }"
 
-  source          = "./vpc"
-  name            = "${var.name}"
-  cidr            = "10.100.0.0/16"
-  private_subnets = ["10.100.1.0/24", "10.100.2.0/24", "10.100.3.0/24"]
-  public_subnets  = ["10.100.101.0/24", "10.100.102.0/24", "10.100.103.0/24"]
-  azs             = ["${var.region}a", "${var.region}b", "${var.region}c"]
+  source              = "./vpc"
+  name                = "${var.name}"
+  cidr                = "10.100.0.0/16"
 
   tags {
     "layer0" = "${var.name}"

--- a/setup/module/vpc/main.tf
+++ b/setup/module/vpc/main.tf
@@ -1,3 +1,5 @@
+data "aws_availability_zones" "available" {}
+
 resource "aws_vpc" "mod" {
   count = "${var.count_hack}"
 
@@ -46,18 +48,18 @@ resource "aws_route_table" "private" {
 
 resource "aws_subnet" "private" {
   vpc_id            = "${aws_vpc.mod.id}"
-  cidr_block        = "${var.private_subnets[count.index]}"
-  availability_zone = "${element(var.azs, count.index)}"
-  count             = "${length(var.private_subnets) * var.count_hack}"
-  tags              = "${merge(var.tags, map("Tier", "Private"), map("Name", format("l0-%s-subnet-private-%s", var.name, element(var.azs, count.index))))}"
+  cidr_block        = "${cidrsubnet(aws_vpc.mod.cidr_block, 8, count.index + 1)}" 
+  availability_zone = "${element(data.aws_availability_zones.available.names, count.index)}"
+  count             = "${length(data.aws_availability_zones.available.names) * var.count_hack}"
+  tags              = "${merge(var.tags, map("Tier", "Private"), map("Name", format("l0-%s-subnet-private-%s", var.name, element(data.aws_availability_zones.available.names, count.index))))}"
 }
 
 resource "aws_subnet" "public" {
   vpc_id            = "${aws_vpc.mod.id}"
-  cidr_block        = "${var.public_subnets[count.index]}"
-  availability_zone = "${element(var.azs, count.index)}"
-  count             = "${length(var.public_subnets) * var.count_hack}"
-  tags              = "${merge(var.tags, map("Tier", "Public"), map("Name", format("l0-%s-subnet-public-%s", var.name, element(var.azs, count.index))))}"
+  cidr_block        = "${cidrsubnet(aws_vpc.mod.cidr_block, 8, count.index + 1 + 100)}"
+  availability_zone = "${element(data.aws_availability_zones.available.names, count.index)}"
+  count             = "${length(data.aws_availability_zones.available.names) * var.count_hack}"
+  tags              = "${merge(var.tags, map("Tier", "Public"), map("Name", format("l0-%s-subnet-public-%s", var.name, element(data.aws_availability_zones.available.names, count.index))))}"
 
   map_public_ip_on_launch = "${var.map_public_ip_on_launch}"
 }
@@ -78,13 +80,13 @@ resource "aws_nat_gateway" "natgw" {
 }
 
 resource "aws_route_table_association" "private" {
-  count          = "${length(var.private_subnets) * var.count_hack}"
+  count          = "${length(data.aws_availability_zones.available.names) * var.count_hack}"
   subnet_id      = "${element(aws_subnet.private.*.id, count.index)}"
   route_table_id = "${aws_route_table.private.id}"
 }
 
 resource "aws_route_table_association" "public" {
-  count          = "${length(var.public_subnets) * var.count_hack}"
+  count          = "${length(data.aws_availability_zones.available.names) * var.count_hack}"
   subnet_id      = "${element(aws_subnet.public.*.id, count.index)}"
   route_table_id = "${aws_route_table.public.id}"
 }

--- a/setup/module/vpc/variables.tf
+++ b/setup/module/vpc/variables.tf
@@ -4,21 +4,6 @@ variable "name" {}
 
 variable "cidr" {}
 
-variable "public_subnets" {
-  description = "A list of public subnets inside the VPC."
-  default     = []
-}
-
-variable "private_subnets" {
-  description = "A list of private subnets inside the VPC."
-  default     = []
-}
-
-variable "azs" {
-  description = "A list of Availability zones in the region"
-  default     = []
-}
-
 variable "map_public_ip_on_launch" {
   description = "Auto-assign public IP on launch"
   default     = false


### PR DESCRIPTION
**What does this pull request do?**
Updates the API's VPC module to rely on Availability data source rather than hardcoded values of a,b & c. This allows a layer0 instance to be created in any regions that don't have the expected AZs.


**How should this be tested?**
Create a new Layer0 Instance for a region that has more/less than the standard a, b & c zones like `us-west-1`. The creation via l0-setup should succeed. 


**Checklist**
- ~[ ] Unit tests~
- ~[ ] Smoke tests (if applicable)~
- ~[ ] System tests (if applicable)~
- ~[ ] Documentation (if applicable)~


closes #452 
