### PR TITLE
455: Add ssh key pair variable to l0 api task definition

### DIFF
--- a/setup/module/api/Dockerrun.aws.json
+++ b/setup/module/api/Dockerrun.aws.json
@@ -21,6 +21,7 @@
         "environment": [
             { "name": "LAYER0_AWS_ACCESS_KEY_ID", "value": "${access_key}" },
             { "name": "LAYER0_AWS_SECRET_ACCESS_KEY", "value": "${secret_key}" },
+            { "name": "LAYER0_AWS_SSH_KEY_PAIR", "value": "${ssh_key_pair}" },
             { "name": "LAYER0_AWS_REGION", "value": "${region}" },
             { "name": "LAYER0_AWS_PUBLIC_SUBNETS", "value": "${public_subnets}" },
             { "name": "LAYER0_AWS_PRIVATE_SUBNETS", "value": "${private_subnets}" },

--- a/setup/module/api/core.tf
+++ b/setup/module/api/core.tf
@@ -107,26 +107,28 @@ resource "aws_iam_group_policy" "mod" {
 
 data "aws_ami" "linux" {
   most_recent = true
+
   filter {
     name   = "owner-alias"
     values = ["amazon"]
   }
 
   filter {
-    name = "name"
+    name   = "name"
     values = ["amzn-ami-2017.09.d-amazon-ecs-optimized"]
   }
 }
 
 data "aws_ami" "windows" {
   most_recent = true
+
   filter {
     name   = "owner-alias"
     values = ["amazon"]
   }
 
   filter {
-    name = "name"
+    name   = "name"
     values = ["Windows_Server-2016-English-Full-ECS_Optimized-2017.11.24"]
   }
 }

--- a/setup/module/main.tf
+++ b/setup/module/main.tf
@@ -10,9 +10,9 @@ module "vpc" {
   # todo: count_hack is workaround for https://github.com/hashicorp/terraform/issues/953
   count_hack = "${ var.vpc_id == "" ? 1 : 0 }"
 
-  source              = "./vpc"
-  name                = "${var.name}"
-  cidr                = "10.100.0.0/16"
+  source = "./vpc"
+  name   = "${var.name}"
+  cidr   = "10.100.0.0/16"
 
   tags {
     "layer0" = "${var.name}"

--- a/setup/module/vpc/main.tf
+++ b/setup/module/vpc/main.tf
@@ -48,7 +48,7 @@ resource "aws_route_table" "private" {
 
 resource "aws_subnet" "private" {
   vpc_id            = "${aws_vpc.mod.id}"
-  cidr_block        = "${cidrsubnet(aws_vpc.mod.cidr_block, 8, count.index + 1)}" 
+  cidr_block        = "${cidrsubnet(aws_vpc.mod.cidr_block, 8, count.index + 1)}"
   availability_zone = "${element(data.aws_availability_zones.available.names, count.index)}"
   count             = "${length(data.aws_availability_zones.available.names) * var.count_hack}"
   tags              = "${merge(var.tags, map("Tier", "Private"), map("Name", format("l0-%s-subnet-private-%s", var.name, element(data.aws_availability_zones.available.names, count.index))))}"


### PR DESCRIPTION
terraform fmt was also run to correct formatting issues for the module

**What does this pull request do?**
Fixes an issue where the l0 api service's task will not run because of a missing ssh key variable.

**How should this be tested?**
Create a new l0 instance with `l0-setup` and upload a docker image through `flow.sh api` and make sure your new l0 instance uses that version. Make sure the task definition runs and starts without issue.

**Checklist**
~- [ ] Unit tests~
~- [ ] Smoke tests (if applicable)~
~- [ ] System tests (if applicable)~
~- [ ] Documentation (if applicable)~

closes #455 
