### PR TITLE
456: Allow the Layer0 API Health check to not require basic auth

### DIFF
--- a/api/controllers/admin.go
+++ b/api/controllers/admin.go
@@ -26,12 +26,6 @@ func (a *AdminController) Routes() []*fireball.Route {
 				"GET": a.GetConfig,
 			},
 		},
-		{
-			Path: "/admin/health",
-			Handlers: fireball.Handlers{
-				"GET": a.GetHealth,
-			},
-		},
 	}
 }
 
@@ -45,8 +39,4 @@ func (a *AdminController) GetConfig(c *fireball.Context) (fireball.Response, err
 	}
 
 	return fireball.NewJSONResponse(200, model)
-}
-
-func (a *AdminController) GetHealth(c *fireball.Context) (fireball.Response, error) {
-	return fireball.NewJSONResponse(200, "")
 }

--- a/api/controllers/health.go
+++ b/api/controllers/health.go
@@ -1,33 +1,26 @@
 package controllers
 
 import (
-	"github.com/quintilesims/layer0/common/config"
 	"github.com/zpatrick/fireball"
 )
 
-type HealthController struct {
-	Config  config.APIConfig
-	Version string
+type HealthController struct{}
+
+func NewHealthController() *HealthController {
+	return &HealthController{}
 }
 
-func NewHealthController(c config.APIConfig, version string) *HealthController {
-	return &HealthController{
-		Config:  c,
-		Version: version,
-	}
-}
-
-func (a *HealthController) Routes() []*fireball.Route {
+func (h *HealthController) Routes() []*fireball.Route {
 	return []*fireball.Route{
 		{
 			Path: "/health",
 			Handlers: fireball.Handlers{
-				"GET": a.GetHealth,
+				"GET": h.GetHealth,
 			},
 		},
 	}
 }
 
-func (a *HealthController) GetHealth(c *fireball.Context) (fireball.Response, error) {
+func (h *HealthController) GetHealth(c *fireball.Context) (fireball.Response, error) {
 	return fireball.NewJSONResponse(200, "")
 }

--- a/api/controllers/health.go
+++ b/api/controllers/health.go
@@ -1,0 +1,33 @@
+package controllers
+
+import (
+	"github.com/quintilesims/layer0/common/config"
+	"github.com/zpatrick/fireball"
+)
+
+type HealthController struct {
+	Config  config.APIConfig
+	Version string
+}
+
+func NewHealthController(c config.APIConfig, version string) *HealthController {
+	return &HealthController{
+		Config:  c,
+		Version: version,
+	}
+}
+
+func (a *HealthController) Routes() []*fireball.Route {
+	return []*fireball.Route{
+		{
+			Path: "/health",
+			Handlers: fireball.Handlers{
+				"GET": a.GetHealth,
+			},
+		},
+	}
+}
+
+func (a *HealthController) GetHealth(c *fireball.Context) (fireball.Response, error) {
+	return fireball.NewJSONResponse(200, "")
+}

--- a/api/main.go
+++ b/api/main.go
@@ -96,6 +96,7 @@ func main() {
 			scalerDispatcher)
 
 		routes := controllers.NewSwaggerController(Version).Routes()
+		routes = append(routes, controllers.NewAdminController(cfg, Version).Routes()...)
 		routes = append(routes, controllers.NewDeployController(deployProvider, jobStore, tagStore).Routes()...)
 		routes = append(routes, controllers.NewEnvironmentController(environmentProvider, jobStore, tagStore).Routes()...)
 		routes = append(routes, controllers.NewJobController(jobStore, tagStore).Routes()...)
@@ -103,15 +104,6 @@ func main() {
 		routes = append(routes, controllers.NewServiceController(serviceProvider, jobStore, tagStore).Routes()...)
 		routes = append(routes, controllers.NewTagController(tagStore).Routes()...)
 		routes = append(routes, controllers.NewTaskController(taskProvider, jobStore, tagStore).Routes()...)
-
-		adminRoutes := controllers.NewAdminController(cfg, Version).Routes()
-
-		// Admin health check should be safe to not require basic auth
-		for i, v := range adminRoutes {
-			if v.Path != "/admin/health" {
-				routes = append(routes, adminRoutes[i])
-			}
-		}
 
 		user, pass, err := cfg.ParseAuthToken()
 		if err != nil {
@@ -122,11 +114,7 @@ func main() {
 			fireball.LogDecorator(),
 			fireball.BasicAuthDecorator(user, pass))
 
-		for i, v := range adminRoutes {
-			if v.Path == "/admin/health" {
-				routes = append(routes, adminRoutes[i])
-			}
-		}
+		routes = append(routes, controllers.NewHealthController(cfg, Version).Routes()...)
 
 		server := fireball.NewApp(routes)
 		server.ErrorHandler = controllers.ErrorHandler

--- a/api/main.go
+++ b/api/main.go
@@ -114,7 +114,8 @@ func main() {
 			fireball.LogDecorator(),
 			fireball.BasicAuthDecorator(user, pass))
 
-		routes = append(routes, controllers.NewHealthController(cfg, Version).Routes()...)
+		// Health check endpoint should not require basic auth, append after decoration
+		routes = append(routes, controllers.NewHealthController().Routes()...)
 
 		server := fireball.NewApp(routes)
 		server.ErrorHandler = controllers.ErrorHandler

--- a/api/main.go
+++ b/api/main.go
@@ -96,6 +96,7 @@ func main() {
 			scalerDispatcher)
 
 		routes := controllers.NewSwaggerController(Version).Routes()
+		routes = append(routes, controllers.NewDeployController(deployProvider, jobStore, tagStore).Routes()...)
 		routes = append(routes, controllers.NewEnvironmentController(environmentProvider, jobStore, tagStore).Routes()...)
 		routes = append(routes, controllers.NewJobController(jobStore, tagStore).Routes()...)
 		routes = append(routes, controllers.NewLoadBalancerController(loadBalancerProvider, jobStore, tagStore).Routes()...)

--- a/setup/instance/apply.go
+++ b/setup/instance/apply.go
@@ -22,7 +22,7 @@ func (l *LocalInstance) Apply(wait bool) error {
 		return err
 	}
 
-	hcEndpoint := endpoint + "/admin/health/"
+	hcEndpoint := endpoint + "/health"
 	if wait {
 		return l.waitForHealthyAPI(hcEndpoint, time.Minute*10)
 	}

--- a/setup/instance/apply.go
+++ b/setup/instance/apply.go
@@ -22,8 +22,9 @@ func (l *LocalInstance) Apply(wait bool) error {
 		return err
 	}
 
+	hcEndpoint := endpoint + "/admin/health/"
 	if wait {
-		return l.waitForHealthyAPI(endpoint, time.Minute*10)
+		return l.waitForHealthyAPI(hcEndpoint, time.Minute*10)
 	}
 
 	return nil

--- a/setup/module/api/load_balancer.tf
+++ b/setup/module/api/load_balancer.tf
@@ -65,7 +65,7 @@ resource "aws_elb" "api" {
     healthy_threshold   = 2
     unhealthy_threshold = 2
     timeout             = 5
-    target              = "HTTP:80/admin/health"
+    target              = "HTTP:80/health"
     interval            = 6
   }
 }


### PR DESCRIPTION
**What does this pull request do?**
The admin endpoint /admin/health should not require basic auth.
The way the fireball controller is coded, even if the ELB health check ping target is changed to TCP:port, the controller will still return an HTTP 401 response. 

This change removes /admin/health and instead creates a new endpoint, /health that will not require basic auth.

**How should this be tested?**
Create a new layer0 instance (as of this writing, include the fix in issue #455). When `l0-setup apply` is run, the instance should come up healthy and the apply should finish without issue.

**Checklist**
~- [ ] Unit tests~
~- [ ] Smoke tests (if applicable)~
~- [ ] System tests (if applicable)~
~- [ ] Documentation (if applicable)~


closes #456 
