### PR TITLE
enable ecs metrics via IAM policy

### DIFF
--- a/setup/module/api/policies/ecs_role_policy.json
+++ b/setup/module/api/policies/ecs_role_policy.json
@@ -12,6 +12,7 @@
                 "ecs:DiscoverPollEndpoint",
                 "ecs:Submit*",
                 "ecs:Poll",
+                "ecs:StartTelemetrySession",
                 "logs:CreateLogStream",
                 "logs:PutLogEvents",
                 "logs:CreateLogGroup",


### PR DESCRIPTION
**What does this pull request do?**
Adds Cloudwatch metrics to default IAM ecs role.


**How should this be tested?**
Tested manually via l0-setup and a new cluster creation; verified that ECS metrics became populated for a given cluster. 


closes #
https://github.com/quintilesims/layer0/issues/464
