### PR TITLE
[v0.10.4] scaler patch

### DIFF
--- a/api/backend/ecs/resource_manager.go
+++ b/api/backend/ecs/resource_manager.go
@@ -61,6 +61,10 @@ func (r *ECSResourceManager) getResourceProvider(ecsEnvironmentID id.ECSEnvironm
 		return nil, false
 	}
 
+	if !pbool(instance.AgentConnected) {
+		r.logger.Infof("Instance %s agent is disconnected", instanceID)
+	}
+
 	// this is non-intuitive, but the ports being used by tasks are kept in
 	// instance.ReminaingResources, not instance.RegisteredResources
 	var usedPorts []int

--- a/api/backend/ecs/resource_manager.go
+++ b/api/backend/ecs/resource_manager.go
@@ -61,11 +61,6 @@ func (r *ECSResourceManager) getResourceProvider(ecsEnvironmentID id.ECSEnvironm
 		return nil, false
 	}
 
-	if !pbool(instance.AgentConnected) {
-		r.logger.Errorf("Instance %s agent is disconnected", instanceID)
-		return nil, false
-	}
-
 	// this is non-intuitive, but the ports being used by tasks are kept in
 	// instance.ReminaingResources, not instance.RegisteredResources
 	var usedPorts []int

--- a/api/backend/ecs/resource_manager_test.go
+++ b/api/backend/ecs/resource_manager_test.go
@@ -71,7 +71,7 @@ func TestResourceManager_GetProviders(t *testing.T) {
 		{
 			&awsecs.ContainerInstance{
 				Status:            stringp("ACTIVE"),
-				AgentConnected:    boolp(true),
+				AgentConnected:    boolp(false),
 				RunningTasksCount: int64p(0),
 				PendingTasksCount: int64p(0),
 				RemainingResources: []*awsecs.Resource{


### PR DESCRIPTION
**What does this pull request do?**
Removes a check for the ECS agent being connected when gathering resource providers; an instance should still be considered to exist even when the agent happens to be disconnected.


**How should this be tested?**
Run unit tests. Manually perform and monitor scaling operations.


**Checklist**
- [x] Unit tests
- ~[ ] Smoke tests (if applicable)~
- ~[ ] System tests (if applicable)~
- ~[ ] Documentation (if applicable)~


closes #461 
