### PR TITLE
MAINT: Remove default AWS region from config

### DIFF
--- a/common/config/config.go
+++ b/common/config/config.go
@@ -47,7 +47,6 @@ const (
 	DEFAULT_AUTH_TOKEN            = "bGF5ZXIwOm5vaGF4cGx6"
 	DEFAULT_API_ENDPOINT          = "http://localhost:9090/"
 	DEFAULT_API_PORT              = "9090"
-	DEFAULT_AWS_REGION            = "us-west-2"
 	DEFAULT_TIME_BETWEEN_REQUESTS = "10ms"
 	DEFAULT_MAX_RETRIES           = 999
 )


### PR DESCRIPTION
**What does this pull request do?**
The previous PR #476 was supposed to remove this line, as we are not recognizing a default AWS region any longer.


**Checklist**
- [x] Manual testing
~- [ ] Unit tests~
~- [ ] Smoke tests (if applicable)~
~- [ ] System tests (if applicable)~
~- [ ] Documentation (if applicable)~