### PR TITLE
444: Fix l0-setup apply issue for instances created in another region

### DIFF
--- a/setup/command/apply.go
+++ b/setup/command/apply.go
@@ -3,6 +3,7 @@ package command
 import (
 	"fmt"
 
+	"github.com/quintilesims/layer0/setup/instance"
 	"github.com/urfave/cli"
 )
 
@@ -27,18 +28,23 @@ func (f *CommandFactory) Apply() cli.Command {
 				return err
 			}
 
-			instance := f.NewInstance(args["NAME"])
-			if err := instance.Apply(!c.Bool("quick")); err != nil {
+			i := f.NewInstance(args["NAME"])
+			if err := i.Apply(!c.Bool("quick")); err != nil {
 				return err
 			}
 
 			if c.Bool("push") {
-				provider, err := f.newAWSProviderHelper(c)
+				region, err := i.Output(instance.OUTPUT_AWS_REGION)
 				if err != nil {
 					return err
 				}
 
-				if err := instance.Push(provider.S3); err != nil {
+				provider, err := f.newAWSProviderHelper(c, region)
+				if err != nil {
+					return err
+				}
+
+				if err := i.Push(provider.S3); err != nil {
 					return err
 				}
 			}

--- a/setup/command/apply.go
+++ b/setup/command/apply.go
@@ -3,7 +3,7 @@ package command
 import (
 	"fmt"
 
-	setup_instance "github.com/quintilesims/layer0/setup/instance"
+	"github.com/quintilesims/layer0/setup/instance"
 	"github.com/urfave/cli"
 )
 
@@ -28,13 +28,13 @@ func (f *CommandFactory) Apply() cli.Command {
 				return err
 			}
 
-			instance := f.NewInstance(args["NAME"])
-			if err := instance.Apply(!c.Bool("quick")); err != nil {
+			inst := f.NewInstance(args["NAME"])
+			if err := inst.Apply(!c.Bool("quick")); err != nil {
 				return err
 			}
 
 			if c.Bool("push") {
-				region, err := instance.Output(setup_instance.OUTPUT_AWS_REGION)
+				region, err := inst.Output(instance.OUTPUT_AWS_REGION)
 				if err != nil {
 					return err
 				}
@@ -44,7 +44,7 @@ func (f *CommandFactory) Apply() cli.Command {
 					return err
 				}
 
-				if err := instance.Push(provider.S3); err != nil {
+				if err := inst.Push(provider.S3); err != nil {
 					return err
 				}
 			}

--- a/setup/command/apply.go
+++ b/setup/command/apply.go
@@ -3,7 +3,7 @@ package command
 import (
 	"fmt"
 
-	"github.com/quintilesims/layer0/setup/instance"
+	setup_instance "github.com/quintilesims/layer0/setup/instance"
 	"github.com/urfave/cli"
 )
 
@@ -28,13 +28,13 @@ func (f *CommandFactory) Apply() cli.Command {
 				return err
 			}
 
-			i := f.NewInstance(args["NAME"])
-			if err := i.Apply(!c.Bool("quick")); err != nil {
+			instance := f.NewInstance(args["NAME"])
+			if err := instance.Apply(!c.Bool("quick")); err != nil {
 				return err
 			}
 
 			if c.Bool("push") {
-				region, err := i.Output(instance.OUTPUT_AWS_REGION)
+				region, err := instance.Output(setup_instance.OUTPUT_AWS_REGION)
 				if err != nil {
 					return err
 				}
@@ -44,7 +44,7 @@ func (f *CommandFactory) Apply() cli.Command {
 					return err
 				}
 
-				if err := i.Push(provider.S3); err != nil {
+				if err := instance.Push(provider.S3); err != nil {
 					return err
 				}
 			}

--- a/setup/command/aws.go
+++ b/setup/command/aws.go
@@ -23,14 +23,9 @@ var awsFlags = []cli.Flag{
 		Usage:  "secret key portion on an AWS key",
 		EnvVar: config.AWS_SECRET_ACCESS_KEY,
 	},
-	cli.StringFlag{
-		Name:   "aws-region",
-		Usage:  "AWS region",
-		EnvVar: config.AWS_REGION,
-	},
 }
 
-func (f *CommandFactory) newAWSProviderHelper(c *cli.Context) (*aws.Provider, error) {
+func (f *CommandFactory) newAWSProviderHelper(c *cli.Context, region string) (*aws.Provider, error) {
 	// use default credentials and region settings
 	config := defaults.Get().Config
 
@@ -55,13 +50,7 @@ func (f *CommandFactory) newAWSProviderHelper(c *cli.Context) (*aws.Provider, er
 		return nil, err
 	}
 
-	// use region if passed in by the user
-	config.WithRegion(aws.DEFAULT_AWS_REGION)
-	if region := c.String("aws-region"); region != "" {
-		config.WithRegion(region)
-	} else {
-		logrus.Debugf("aws-region was not specified. Using default")
-	}
+	config.WithRegion(region)
 
 	return f.NewAWSProvider(config), nil
 }

--- a/setup/command/aws.go
+++ b/setup/command/aws.go
@@ -26,7 +26,7 @@ var awsFlags = []cli.Flag{
 }
 
 func (f *CommandFactory) newAWSProviderHelper(c *cli.Context, region string) (*aws.Provider, error) {
-	// use default credentials and region settings
+	// first grab default config settings
 	config := defaults.Get().Config
 
 	// use static credentials if passed in by the user
@@ -50,6 +50,8 @@ func (f *CommandFactory) newAWSProviderHelper(c *cli.Context, region string) (*a
 		return nil, err
 	}
 
+	// ensure that the correct region is set for AWS services
+	// that have region-specific operations
 	config.WithRegion(region)
 
 	return f.NewAWSProvider(config), nil

--- a/setup/command/list.go
+++ b/setup/command/list.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"sort"
 
+	"github.com/quintilesims/layer0/common/config"
+	"github.com/quintilesims/layer0/setup/aws"
 	"github.com/quintilesims/layer0/setup/instance"
 	"github.com/urfave/cli"
 )
@@ -25,6 +27,11 @@ func (f *CommandFactory) List() cli.Command {
 			cli.BoolTFlag{
 				Name:  "r, remote",
 				Usage: "show remote Layer0 instances, denoted by 'r' (default: true)",
+			},
+			cli.StringFlag{
+				Name:   "aws-region",
+				Usage:  "AWS region",
+				EnvVar: config.AWS_REGION,
 			}),
 		Action: func(c *cli.Context) error {
 			instances := map[string]status{}
@@ -58,7 +65,12 @@ func (f *CommandFactory) List() cli.Command {
 }
 
 func (f *CommandFactory) addRemoteInstances(c *cli.Context, current map[string]status) error {
-	provider, err := f.newAWSProviderHelper(c)
+	region := aws.DEFAULT_AWS_REGION
+	if c.String("aws-region") != "" {
+		region = c.String("aws-region")
+	}
+
+	provider, err := f.newAWSProviderHelper(c, region)
 	if err != nil {
 		return err
 	}

--- a/setup/command/list.go
+++ b/setup/command/list.go
@@ -59,6 +59,10 @@ func (f *CommandFactory) List() cli.Command {
 }
 
 func (f *CommandFactory) addRemoteInstances(c *cli.Context, current map[string]status) error {
+	// The default AWS region is passed here (as opposed to other l0-setup
+	// operations) because listing buckets from S3 is a region-agnostic
+	// operation. All S3 buckets in the AWS account will be retrieved
+	// regardless of what region is provided.
 	provider, err := f.newAWSProviderHelper(c, aws.DEFAULT_AWS_REGION)
 	if err != nil {
 		return err

--- a/setup/command/list.go
+++ b/setup/command/list.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"sort"
 
-	"github.com/quintilesims/layer0/common/config"
 	"github.com/quintilesims/layer0/setup/aws"
 	"github.com/quintilesims/layer0/setup/instance"
 	"github.com/urfave/cli"
@@ -27,11 +26,6 @@ func (f *CommandFactory) List() cli.Command {
 			cli.BoolTFlag{
 				Name:  "r, remote",
 				Usage: "show remote Layer0 instances, denoted by 'r' (default: true)",
-			},
-			cli.StringFlag{
-				Name:   "aws-region",
-				Usage:  "AWS region",
-				EnvVar: config.AWS_REGION,
 			}),
 		Action: func(c *cli.Context) error {
 			instances := map[string]status{}
@@ -65,12 +59,7 @@ func (f *CommandFactory) List() cli.Command {
 }
 
 func (f *CommandFactory) addRemoteInstances(c *cli.Context, current map[string]status) error {
-	region := aws.DEFAULT_AWS_REGION
-	if c.String("aws-region") != "" {
-		region = c.String("aws-region")
-	}
-
-	provider, err := f.newAWSProviderHelper(c, region)
+	provider, err := f.newAWSProviderHelper(c, aws.DEFAULT_AWS_REGION)
 	if err != nil {
 		return err
 	}

--- a/setup/command/pull.go
+++ b/setup/command/pull.go
@@ -23,6 +23,7 @@ func (f *CommandFactory) Pull() cli.Command {
 				return err
 			}
 
+			// Use the default AWS region first to retrieve the list of buckets
 			provider, err := f.newAWSProviderHelper(c, aws_provider.DEFAULT_AWS_REGION)
 			if err != nil {
 				return err
@@ -44,6 +45,8 @@ func (f *CommandFactory) Pull() cli.Command {
 				region = "us-east-1"
 			}
 
+			// Change the AWS provider configuration to match the region of the bucket
+			// to pull from
 			provider, err = f.newAWSProviderHelper(c, region)
 			if err != nil {
 				return err

--- a/setup/command/pull.go
+++ b/setup/command/pull.go
@@ -2,8 +2,12 @@ package command
 
 import (
 	"fmt"
+	"strings"
 
-	"github.com/quintilesims/layer0/setup/instance"
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/s3"
+	"github.com/aws/aws-sdk-go/service/s3/s3iface"
+	aws_provider "github.com/quintilesims/layer0/setup/aws"
 	"github.com/urfave/cli"
 )
 
@@ -19,18 +23,34 @@ func (f *CommandFactory) Pull() cli.Command {
 				return err
 			}
 
-			i := f.NewInstance(args["NAME"])
-			region, err := i.Output(instance.OUTPUT_AWS_REGION)
+			provider, err := f.newAWSProviderHelper(c, aws_provider.DEFAULT_AWS_REGION)
 			if err != nil {
 				return err
 			}
 
-			provider, err := f.newAWSProviderHelper(c, region)
+			remoteInstanceBucket, err := getRemoteInstanceBucket(provider.S3, args["NAME"])
 			if err != nil {
 				return err
 			}
 
-			if err := i.Pull(provider.S3); err != nil {
+			region, err := getBucketLocation(provider.S3, remoteInstanceBucket)
+			if err != nil {
+				return err
+			}
+
+			if region == "" {
+				// See: https://docs.aws.amazon.com/AmazonS3/latest/API/RESTBucketGETlocation.html
+				// When GetBucketLocation returns an empty string, the bucket is in us-east-1
+				region = "us-east-1"
+			}
+
+			provider, err = f.newAWSProviderHelper(c, region)
+			if err != nil {
+				return err
+			}
+
+			instance := f.NewInstance(args["NAME"])
+			if err := instance.Pull(provider.S3); err != nil {
 				return err
 			}
 
@@ -38,4 +58,33 @@ func (f *CommandFactory) Pull() cli.Command {
 			return nil
 		},
 	}
+}
+
+func getRemoteInstanceBucket(s s3iface.S3API, instanceName string) (string, error) {
+	listBucketsOutput, err := s.ListBuckets(&s3.ListBucketsInput{})
+	if err != nil {
+		return "", err
+	}
+
+	for _, bucket := range listBucketsOutput.Buckets {
+		bucketName := aws.StringValue(bucket.Name)
+
+		if split := strings.Split(bucketName, "-"); len(split) == 3 && split[0] == "layer0" && split[1] == instanceName {
+			return bucketName, nil
+		}
+	}
+
+	return "", fmt.Errorf("No S3 bucket found for given instance name")
+}
+
+func getBucketLocation(s s3iface.S3API, bucketName string) (string, error) {
+	getBucketLocationInput := &s3.GetBucketLocationInput{}
+	getBucketLocationInput.SetBucket(bucketName)
+
+	getBucketLocationOutput, err := s.GetBucketLocation(getBucketLocationInput)
+	if err != nil {
+		return "", err
+	}
+
+	return aws.StringValue(getBucketLocationOutput.LocationConstraint), nil
 }

--- a/setup/command/pull.go
+++ b/setup/command/pull.go
@@ -3,6 +3,7 @@ package command
 import (
 	"fmt"
 
+	"github.com/quintilesims/layer0/setup/instance"
 	"github.com/urfave/cli"
 )
 
@@ -18,13 +19,18 @@ func (f *CommandFactory) Pull() cli.Command {
 				return err
 			}
 
-			provider, err := f.newAWSProviderHelper(c)
+			i := f.NewInstance(args["NAME"])
+			region, err := i.Output(instance.OUTPUT_AWS_REGION)
 			if err != nil {
 				return err
 			}
 
-			instance := f.NewInstance(args["NAME"])
-			if err := instance.Pull(provider.S3); err != nil {
+			provider, err := f.newAWSProviderHelper(c, region)
+			if err != nil {
+				return err
+			}
+
+			if err := i.Pull(provider.S3); err != nil {
 				return err
 			}
 

--- a/setup/command/push.go
+++ b/setup/command/push.go
@@ -3,7 +3,7 @@ package command
 import (
 	"fmt"
 
-	setup_instance "github.com/quintilesims/layer0/setup/instance"
+	"github.com/quintilesims/layer0/setup/instance"
 	"github.com/urfave/cli"
 )
 
@@ -19,8 +19,8 @@ func (f *CommandFactory) Push() cli.Command {
 				return err
 			}
 
-			instance := f.NewInstance(args["NAME"])
-			region, err := instance.Output(setup_instance.OUTPUT_AWS_REGION)
+			inst := f.NewInstance(args["NAME"])
+			region, err := inst.Output(instance.OUTPUT_AWS_REGION)
 			if err != nil {
 				return err
 			}
@@ -30,7 +30,7 @@ func (f *CommandFactory) Push() cli.Command {
 				return err
 			}
 
-			if err := instance.Push(provider.S3); err != nil {
+			if err := inst.Push(provider.S3); err != nil {
 				return err
 			}
 

--- a/setup/command/push.go
+++ b/setup/command/push.go
@@ -3,7 +3,7 @@ package command
 import (
 	"fmt"
 
-	"github.com/quintilesims/layer0/setup/instance"
+	setup_instance "github.com/quintilesims/layer0/setup/instance"
 	"github.com/urfave/cli"
 )
 
@@ -19,8 +19,8 @@ func (f *CommandFactory) Push() cli.Command {
 				return err
 			}
 
-			i := f.NewInstance(args["NAME"])
-			region, err := i.Output(instance.OUTPUT_AWS_REGION)
+			instance := f.NewInstance(args["NAME"])
+			region, err := instance.Output(setup_instance.OUTPUT_AWS_REGION)
 			if err != nil {
 				return err
 			}
@@ -30,7 +30,7 @@ func (f *CommandFactory) Push() cli.Command {
 				return err
 			}
 
-			if err := i.Push(provider.S3); err != nil {
+			if err := instance.Push(provider.S3); err != nil {
 				return err
 			}
 

--- a/setup/command/push.go
+++ b/setup/command/push.go
@@ -3,6 +3,7 @@ package command
 import (
 	"fmt"
 
+	"github.com/quintilesims/layer0/setup/instance"
 	"github.com/urfave/cli"
 )
 
@@ -18,13 +19,18 @@ func (f *CommandFactory) Push() cli.Command {
 				return err
 			}
 
-			provider, err := f.newAWSProviderHelper(c)
+			i := f.NewInstance(args["NAME"])
+			region, err := i.Output(instance.OUTPUT_AWS_REGION)
 			if err != nil {
 				return err
 			}
 
-			instance := f.NewInstance(args["NAME"])
-			if err := instance.Push(provider.S3); err != nil {
+			provider, err := f.newAWSProviderHelper(c, region)
+			if err != nil {
+				return err
+			}
+
+			if err := i.Push(provider.S3); err != nil {
 				return err
 			}
 


### PR DESCRIPTION
**What does this pull request do?**
When a new AWS Provider needs to be created or an AWS session needs to be established, aws.Config needs to contain the correct region for interactions with AWS to work.

In the case where l0 instances are initialized and set up in a region other than the default us-west-2, the resources will create in the region specified in the init wizard, but pushing terraform state to the S3 bucket fails because it was always assumed that the AWS region would be us-west-2.

To fix this, anytime an AWS Provider is needed, the instance derives what region it's in (assuming that l0-setup apply ran to completion), and then passes that region into the AWS Provider helper function so that aws.Config sets the correct region for API operations via the WithRegion() method.

The cli flag `--aws-region` is now no longer required in any l0-setup operation. The region the user specifies in `l0-setup init` is going to be the region used for AWS Provider operations through `l0-setup`

**How should this be tested?**
Unit tests, making a new l0 instance in a region other than us-west-2. `l0-setup apply` should correctly push terraform state to the bucket after apply. `l0-setup push` and `l0-setup pull` should also work.

**Checklist**
- [x] Unit tests
~- [ ] Smoke tests (if applicable)~
~- [ ] System tests (if applicable)~
~- [ ] Documentation (if applicable)~

closes #444

  