### PR TITLE
MAINT: Make l0 deploy list only return active task definitions

### DIFF
--- a/common/aws/ecs/ecs.go
+++ b/common/aws/ecs/ecs.go
@@ -973,6 +973,8 @@ func (this *ECS) ListTaskDefinitionFamiliesPages(prefix string) ([]*string, erro
 		FamilyPrefix: &prefix,
 	}
 
+	input.SetStatus(ecs.TaskDefinitionFamilyStatusActive)
+
 	connection, err := this.Connect()
 	if err != nil {
 		return nil, err
@@ -1043,6 +1045,8 @@ func (this *ECS) ListTaskDefinitions(familyName string, nextToken *string) ([]*s
 		FamilyPrefix: aws.String(familyName),
 		NextToken:    nextToken,
 	}
+
+	input.SetStatus(ecs.TaskDefinitionStatusActive)
 
 	connection, err := this.Connect()
 	if err != nil {


### PR DESCRIPTION
**What does this pull request do?**
The methods called in the AWS SDK that pull back Task Definitions should only be retrieving Task Definitions that are active. Without filtering Task Definitions by status, inactive Task Definitions can still be retrieved. For Layer0 instances that have been up for a long time, inactive Task Definitions can accumulate and has been known to slow the operation `l0 deploy list` down considerably.

**How should this be tested?**
Running `l0 deploy list` operations (both with and without the `--all` flag)

**Checklist**
~- [ ] Unit tests~
~- [ ] Smoke tests (if applicable)~
~- [ ] System tests (if applicable)~
~- [ ] Documentation (if applicable)~
