### PR TITLE
update windows ECS agent version

### DIFF
--- a/api/backend/ecs/environment_manager.go
+++ b/api/backend/ecs/environment_manager.go
@@ -503,7 +503,7 @@ Write-Host Cluster name set as: $clusterName -foreground green
 
 [Environment]::SetEnvironmentVariable("ECS_CLUSTER", $clusterName, "Machine")
 [Environment]::SetEnvironmentVariable("ECS_ENABLE_TASK_IAM_ROLE", "false", "Machine")
-$agentVersion = 'v1.14.0-1.windows.1'
+$agentVersion = 'v1.15.2'
 $agentZipUri = "https://s3.amazonaws.com/amazon-ecs-agent/ecs-agent-windows-$agentVersion.zip"
 $agentZipMD5Uri = "$agentZipUri.md5"
 

--- a/tests/smoke/admin.bats
+++ b/tests/smoke/admin.bats
@@ -11,7 +11,3 @@
 @test "admin debug" {
     l0 admin debug
 }
-
-@test "admin scale api" {
-    l0 admin scale api
-}


### PR DESCRIPTION
**What does this pull request do?**
Updates the Windows ECS Agent to the latest version as specified in the canonical Windows ECS script https://github.com/aws/amazon-ecs-agent/blob/master/misc/windows-deploy/user-data.ps1#L7:17

Also removes a test target from our smoketests.


**How should this be tested?**
Create a Windows environment with `-os windows` and a sample windows service.


**Checklist**
- [X] Manual tests
