### PR TITLE
510: Modify flow.sh to fix the delete environment stage

### DIFF
--- a/scripts/flow.sh
+++ b/scripts/flow.sh
@@ -33,7 +33,7 @@ delete() {
     for id in $environment_ids; do
         if [ "$id" != "api" ]; then
             echo -e $BULLET "$id"
-            l0 environment delete $id --wait > /dev/null &
+            l0 environment delete $id > /dev/null
         fi
     done
 


### PR DESCRIPTION
**What does this pull request do?**
Changes `scripts/flow.sh` to fix an issue where the environments are not deleted due to a CLI syntax change made for `l0 environment delete`.

The --wait flag has been removed from l0 environment delete, and each of the iterations of the environments to delete should not be sent to the background.


**How should this be tested?**
Create a few environments and deploys and then run `flow.sh delete`. Confirm that everything except for the api environment and deploy are deleted.

**Checklist**
~- [ ] Unit tests~
~- [ ] Smoke tests (if applicable)~
~- [ ] System tests (if applicable)~
~- [ ] Documentation (if applicable)~

closes #510 
