### PR TITLE
517: Fix flow.sh to not delete api deploy

### DIFF
--- a/scripts/flow.sh
+++ b/scripts/flow.sh
@@ -42,9 +42,10 @@ delete() {
     echo "Deleting Deploys"
     deploy_ids=$(l0 -o json deploy list --all | jq .[] | jq 'select(.deploy_name != "")' | jq -r .deploy_id)
     for id in $deploy_ids; do
-        echo -e $BULLET "$id"
-        l0 deploy delete $id > /dev/null
-        echo -e $BULLET "$id"
+        if [ "$id" != "api" ]; then
+            echo -e $BULLET "$id"
+            l0 deploy delete $id > /dev/null
+        fi
     done
 
     echo "Deleting Jobs"


### PR DESCRIPTION
**What does this pull request do?**

Fixes `flow.sh delete` so that it doesn't delete the layer0 api's deploy.

**How should this be tested?**

`flow.sh delete` on an existing layer0 instance you can destroy. Confirm that the layer0 api deploy is not deleted `l0 deploy list`

**Checklist**
~- [ ] Unit tests~
~- [ ] Smoke tests (if applicable)~
~- [ ] System tests (if applicable)~
~- [ ] Documentation (if applicable)~

closes #517 
