### PR TITLE
[WIP] 500: Set launch type for services and tasks

### DIFF
--- a/api/provider/aws/common.go
+++ b/api/provider/aws/common.go
@@ -12,6 +12,8 @@ import (
 	"github.com/aws/aws-sdk-go/service/ecs/ecsiface"
 	"github.com/aws/aws-sdk-go/service/elb"
 	"github.com/aws/aws-sdk-go/service/elb/elbiface"
+	"github.com/aws/aws-sdk-go/service/iam"
+	"github.com/aws/aws-sdk-go/service/iam/iamiface"
 	"github.com/quintilesims/layer0/api/tag"
 	"github.com/quintilesims/layer0/common/errors"
 	"github.com/quintilesims/layer0/common/models"
@@ -72,6 +74,21 @@ func getLaunchTypeFromEnvironmentID(store tag.Store, environmentID string) (stri
 	}
 
 	return "", fmt.Errorf("Could not find instance launch type for environment '%s'", environmentID)
+}
+
+func getRoleARNFromRoleName(iamapi iamiface.IAMAPI, roleName string) (string, error) {
+	input := &iam.GetRoleInput{}
+	input.SetRoleName(roleName)
+	if err := input.Validate(); err != nil {
+		return "", err
+	}
+
+	output, err := iamapi.GetRole(input)
+	if err != nil {
+		return "", err
+	}
+
+	return aws.StringValue(output.Role.Arn), nil
 }
 
 func lookupDeployIDFromTaskDefinitionARN(store tag.Store, taskDefinitionARN string) (string, error) {

--- a/api/provider/aws/common.go
+++ b/api/provider/aws/common.go
@@ -14,6 +14,7 @@ import (
 	"github.com/aws/aws-sdk-go/service/elb/elbiface"
 	"github.com/quintilesims/layer0/api/tag"
 	"github.com/quintilesims/layer0/common/errors"
+	"github.com/quintilesims/layer0/common/models"
 )
 
 func describeLoadBalancer(elbapi elbiface.ELBAPI, loadBalancerName string) (*elb.LoadBalancerDescription, error) {
@@ -51,6 +52,26 @@ func describeTaskDefinition(ecsapi ecsiface.ECSAPI, taskDefinitionARN string) (*
 	}
 
 	return output.TaskDefinition, nil
+}
+
+func getLaunchTypeFromEnvironmentID(store tag.Store, environmentID string) (string, error) {
+	var launchType string
+	tags, err := store.SelectByTypeAndID("environment", environmentID)
+	if err != nil {
+		return "", err
+	}
+
+	if tag, ok := tags.WithKey("type").First(); ok {
+		if tag.Value == models.EnvironmentTypeDynamic {
+			launchType = ecs.LaunchTypeFargate
+		}
+
+		if tag.Value == models.EnvironmentTypeStatic {
+			launchType = ecs.LaunchTypeEc2
+		}
+	}
+
+	return launchType, nil
 }
 
 func lookupDeployIDFromTaskDefinitionARN(store tag.Store, taskDefinitionARN string) (string, error) {

--- a/api/provider/aws/common.go
+++ b/api/provider/aws/common.go
@@ -55,23 +55,23 @@ func describeTaskDefinition(ecsapi ecsiface.ECSAPI, taskDefinitionARN string) (*
 }
 
 func getLaunchTypeFromEnvironmentID(store tag.Store, environmentID string) (string, error) {
-	var launchType string
 	tags, err := store.SelectByTypeAndID("environment", environmentID)
 	if err != nil {
 		return "", err
 	}
 
 	if tag, ok := tags.WithKey("type").First(); ok {
-		if tag.Value == models.EnvironmentTypeDynamic {
-			launchType = ecs.LaunchTypeFargate
-		}
-
-		if tag.Value == models.EnvironmentTypeStatic {
-			launchType = ecs.LaunchTypeEc2
+		switch tag.Value {
+		case models.EnvironmentTypeDynamic:
+			return ecs.LaunchTypeFargate, nil
+		case models.EnvironmentTypeStatic:
+			return ecs.LaunchTypeEc2, nil
+		default:
+			return "", fmt.Errorf("Could not find instance launch type for environment '%s'", environmentID)
 		}
 	}
 
-	return launchType, nil
+	return "", fmt.Errorf("Could not find instance launch type for environment '%s'", environmentID)
 }
 
 func lookupDeployIDFromTaskDefinitionARN(store tag.Store, taskDefinitionARN string) (string, error) {

--- a/api/provider/aws/common.go
+++ b/api/provider/aws/common.go
@@ -67,7 +67,7 @@ func getLaunchTypeFromEnvironmentID(store tag.Store, environmentID string) (stri
 		case models.EnvironmentTypeStatic:
 			return ecs.LaunchTypeEc2, nil
 		default:
-			return "", fmt.Errorf("Could not find instance launch type for environment '%s'", environmentID)
+			return "", fmt.Errorf("Environment '%s' has invalid 'type' tag: '%s'.", environmentID, tag.Value)
 		}
 	}
 

--- a/api/provider/aws/common.go
+++ b/api/provider/aws/common.go
@@ -12,8 +12,6 @@ import (
 	"github.com/aws/aws-sdk-go/service/ecs/ecsiface"
 	"github.com/aws/aws-sdk-go/service/elb"
 	"github.com/aws/aws-sdk-go/service/elb/elbiface"
-	"github.com/aws/aws-sdk-go/service/iam"
-	"github.com/aws/aws-sdk-go/service/iam/iamiface"
 	"github.com/quintilesims/layer0/api/tag"
 	"github.com/quintilesims/layer0/common/errors"
 	"github.com/quintilesims/layer0/common/models"
@@ -74,21 +72,6 @@ func getLaunchTypeFromEnvironmentID(store tag.Store, environmentID string) (stri
 	}
 
 	return "", fmt.Errorf("Could not find instance launch type for environment '%s'", environmentID)
-}
-
-func getRoleARNFromRoleName(iamapi iamiface.IAMAPI, roleName string) (string, error) {
-	input := &iam.GetRoleInput{}
-	input.SetRoleName(roleName)
-	if err := input.Validate(); err != nil {
-		return "", err
-	}
-
-	output, err := iamapi.GetRole(input)
-	if err != nil {
-		return "", err
-	}
-
-	return aws.StringValue(output.Role.Arn), nil
 }
 
 func lookupDeployIDFromTaskDefinitionARN(store tag.Store, taskDefinitionARN string) (string, error) {

--- a/api/provider/aws/common_test.go
+++ b/api/provider/aws/common_test.go
@@ -3,10 +3,85 @@ package aws
 import (
 	"testing"
 
+	"github.com/aws/aws-sdk-go/service/ecs"
 	"github.com/quintilesims/layer0/api/tag"
 	"github.com/quintilesims/layer0/common/models"
 	"github.com/stretchr/testify/assert"
 )
+
+func Test_getLaunchTypeFromEnvironmentID(t *testing.T) {
+	tagStore := tag.NewMemoryStore()
+
+	envIDs := []string{"env_id0", "env_id1"}
+
+	tags := models.Tags{
+		{
+			EntityID:   envIDs[0],
+			EntityType: "environment",
+			Key:        "type",
+			Value:      models.EnvironmentTypeDynamic,
+		},
+		{
+			EntityID:   envIDs[1],
+			EntityType: "environment",
+			Key:        "type",
+			Value:      models.EnvironmentTypeStatic,
+		},
+	}
+
+	for _, tag := range tags {
+		if err := tagStore.Insert(tag); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	cases := map[string]string{
+		envIDs[0]: ecs.LaunchTypeFargate,
+		envIDs[1]: ecs.LaunchTypeEc2,
+	}
+
+	for id, expected := range cases {
+		result, err := getLaunchTypeFromEnvironmentID(tagStore, id)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		assert.Equal(t, expected, result)
+	}
+}
+
+func Test_getLaunchTypeFromEnvironmentID_Errors(t *testing.T) {
+	tagStore := tag.NewMemoryStore()
+
+	envIDs := []string{"env_id0", "env_id1"}
+
+	tags := models.Tags{
+		{
+			EntityID:   envIDs[0],
+			EntityType: "environment",
+			Key:        "type",
+			Value:      "",
+		},
+		{
+			EntityID:   envIDs[1],
+			EntityType: "environment",
+			Key:        "",
+			Value:      "",
+		},
+	}
+
+	for _, tag := range tags {
+		if err := tagStore.Insert(tag); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	for _, id := range envIDs {
+		if _, err := getLaunchTypeFromEnvironmentID(tagStore, id); err == nil {
+			t.Fatal("Err was nil!")
+		}
+	}
+}
 
 func Test_lookupDeployIDFromTaskDefinitionARN(t *testing.T) {
 	tagStore := tag.NewMemoryStore()

--- a/api/provider/aws/common_test.go
+++ b/api/provider/aws/common_test.go
@@ -52,7 +52,7 @@ func Test_getLaunchTypeFromEnvironmentID(t *testing.T) {
 	}
 }
 
-func Test_getLaunchTypeFromEnvironmentID_Errors(t *testing.T) {
+func Test_getLaunchTypeFromEnvironmentID_errors(t *testing.T) {
 	tagStore := tag.NewMemoryStore()
 
 	envIDs := []string{"env_id0", "env_id1", "env_id2"}

--- a/api/provider/aws/common_test.go
+++ b/api/provider/aws/common_test.go
@@ -41,19 +41,21 @@ func Test_getLaunchTypeFromEnvironmentID(t *testing.T) {
 	}
 
 	for id, expected := range cases {
-		result, err := getLaunchTypeFromEnvironmentID(tagStore, id)
-		if err != nil {
-			t.Fatal(err)
-		}
+		t.Run(id, func(t *testing.T) {
+			result, err := getLaunchTypeFromEnvironmentID(tagStore, id)
+			if err != nil {
+				t.Fatal(err)
+			}
 
-		assert.Equal(t, expected, result)
+			assert.Equal(t, expected, result)
+		})
 	}
 }
 
 func Test_getLaunchTypeFromEnvironmentID_Errors(t *testing.T) {
 	tagStore := tag.NewMemoryStore()
 
-	envIDs := []string{"env_id0", "env_id1"}
+	envIDs := []string{"env_id0", "env_id1", "env_id2"}
 
 	tags := models.Tags{
 		{
@@ -64,6 +66,12 @@ func Test_getLaunchTypeFromEnvironmentID_Errors(t *testing.T) {
 		},
 		{
 			EntityID:   envIDs[1],
+			EntityType: "environment",
+			Key:        "type",
+			Value:      "neither static nor dynamic",
+		},
+		{
+			EntityID:   envIDs[2],
 			EntityType: "environment",
 			Key:        "",
 			Value:      "",
@@ -77,9 +85,11 @@ func Test_getLaunchTypeFromEnvironmentID_Errors(t *testing.T) {
 	}
 
 	for _, id := range envIDs {
-		if _, err := getLaunchTypeFromEnvironmentID(tagStore, id); err == nil {
-			t.Fatal("Err was nil!")
-		}
+		t.Run(id, func(t *testing.T) {
+			if _, err := getLaunchTypeFromEnvironmentID(tagStore, id); err == nil {
+				t.Fatal("Err was nil!")
+			}
+		})
 	}
 }
 

--- a/api/provider/aws/common_test.go
+++ b/api/provider/aws/common_test.go
@@ -12,17 +12,15 @@ import (
 func Test_getLaunchTypeFromEnvironmentID(t *testing.T) {
 	tagStore := tag.NewMemoryStore()
 
-	envIDs := []string{"env_id0", "env_id1"}
-
 	tags := models.Tags{
 		{
-			EntityID:   envIDs[0],
+			EntityID:   "env_id1",
 			EntityType: "environment",
 			Key:        "type",
 			Value:      models.EnvironmentTypeDynamic,
 		},
 		{
-			EntityID:   envIDs[1],
+			EntityID:   "env_id2",
 			EntityType: "environment",
 			Key:        "type",
 			Value:      models.EnvironmentTypeStatic,
@@ -36,8 +34,8 @@ func Test_getLaunchTypeFromEnvironmentID(t *testing.T) {
 	}
 
 	cases := map[string]string{
-		envIDs[0]: ecs.LaunchTypeFargate,
-		envIDs[1]: ecs.LaunchTypeEc2,
+		"env_id1": ecs.LaunchTypeFargate,
+		"env_id2": ecs.LaunchTypeEc2,
 	}
 
 	for id, expected := range cases {
@@ -55,7 +53,7 @@ func Test_getLaunchTypeFromEnvironmentID(t *testing.T) {
 func Test_getLaunchTypeFromEnvironmentID_errors(t *testing.T) {
 	tagStore := tag.NewMemoryStore()
 
-	envIDs := []string{"env_id0", "env_id1", "env_id2"}
+	envIDs := []string{"env_id1", "env_id2", "env_id3"}
 
 	tags := models.Tags{
 		{

--- a/api/provider/aws/deploy_create.go
+++ b/api/provider/aws/deploy_create.go
@@ -49,10 +49,8 @@ func (d *DeployProvider) createTaskDefinition(taskDefinition *ecs.TaskDefinition
 
 	// We'll be explicit here and set any and all compatibilities that a user specifies in the task definition.
 	// At the moment, that should only be "FARGATE" and "EC2".
-	requiresCompatibilities := []*string{}
+	input.SetRequiresCompatibilities(taskDefinition.RequiresCompatibilities)
 	for _, compatibility := range taskDefinition.RequiresCompatibilities {
-		requiresCompatibilities = append(requiresCompatibilities, compatibility)
-
 		// There are some additional requirements for a task definition to be considered Fargate-compatible:
 		// https://github.com/aws/aws-sdk-go/blob/master/service/ecs/api.go#L8172
 		// https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task_definition_parameters.html#task_size
@@ -84,8 +82,6 @@ func (d *DeployProvider) createTaskDefinition(taskDefinition *ecs.TaskDefinition
 			input.SetExecutionRoleArn(ecsTaskExecutionRoleARN)
 		}
 	}
-
-	input.SetRequiresCompatibilities(requiresCompatibilities)
 
 	if err := input.Validate(); err != nil {
 		return nil, err

--- a/api/provider/aws/deploy_create.go
+++ b/api/provider/aws/deploy_create.go
@@ -11,6 +11,8 @@ import (
 	"github.com/quintilesims/layer0/common/models"
 )
 
+const ecsTaskExecutionRoleName = "ecsTaskExecutionRole"
+
 // Create registers an ECS Task Definition using the specified Create Deploy Request.
 // The Create Deploy Request contains the name of the Deploy and the JSON
 // representation of the Task Definition to create.
@@ -61,13 +63,12 @@ func (d *DeployProvider) createTaskDefinition(taskDefinition *ecs.TaskDefinition
 			input.SetCpu(cpu)
 			input.SetMemory(memory)
 
-			ecsRoleName := d.Config.ECSRole()
-			ecsRoleARN, err := getRoleARNFromRoleName(d.AWS.IAM, ecsRoleName)
+			ecsTaskExecutionRoleARN, err := getRoleARNFromRoleName(d.AWS.IAM, ecsTaskExecutionRoleName)
 			if err != nil {
 				return nil, err
 			}
 
-			input.SetExecutionRoleArn(ecsRoleARN)
+			input.SetExecutionRoleArn(ecsTaskExecutionRoleARN)
 
 			input.SetRequiresCompatibilities([]*string{aws.String(ecs.LaunchTypeFargate)})
 		}

--- a/api/provider/aws/service_create.go
+++ b/api/provider/aws/service_create.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/ecs"
+	"github.com/quintilesims/layer0/common/config"
 	"github.com/quintilesims/layer0/common/models"
 )
 
@@ -12,18 +13,26 @@ func (s *ServiceProvider) Create(req models.CreateServiceRequest) (string, error
 	fqEnvironmentID := addLayer0Prefix(s.Config.Instance(), req.EnvironmentID)
 	cluster := fqEnvironmentID
 
-	var securityGroupIDs []*string
-	environmentSecurityGroupName := getEnvironmentSGName(fqEnvironmentID)
-	environmentSecurityGroup, err := readSG(s.AWS.EC2, environmentSecurityGroupName)
+	launchType, err := getLaunchTypeFromEnvironmentID(s.TagStore, req.EnvironmentID)
 	if err != nil {
 		return "", err
 	}
 
-	securityGroupIDs = append(securityGroupIDs, environmentSecurityGroup.GroupId)
+	var fargatePlatformVersion string
+	var securityGroupIDs []*string
+	var subnets []string
+	if launchType == ecs.LaunchTypeFargate {
+		fargatePlatformVersion = config.DefaultFargatePlatformVersion
 
-	launchType, err := getLaunchTypeFromEnvironmentID(s.TagStore, req.EnvironmentID)
-	if err != nil {
-		return "", err
+		environmentSecurityGroupName := getEnvironmentSGName(fqEnvironmentID)
+		environmentSecurityGroup, err := readSG(s.AWS.EC2, environmentSecurityGroupName)
+		if err != nil {
+			return "", err
+		}
+
+		securityGroupIDs = append(securityGroupIDs, environmentSecurityGroup.GroupId)
+
+		subnets = s.Config.PrivateSubnets()
 	}
 
 	serviceID := entityIDGenerator(req.ServiceName)
@@ -82,12 +91,6 @@ func (s *ServiceProvider) Create(req models.CreateServiceRequest) (string, error
 		scale = 1
 	}
 
-	privateSubnets := s.Config.PrivateSubnets()
-	subnets := make([]*string, len(privateSubnets))
-	for i := range privateSubnets {
-		subnets[i] = aws.String(privateSubnets[i])
-	}
-
 	if err := s.createService(
 		cluster,
 		launchType,
@@ -97,7 +100,8 @@ func (s *ServiceProvider) Create(req models.CreateServiceRequest) (string, error
 		loadBalancerRole,
 		loadBalancer,
 		securityGroupIDs,
-		subnets); err != nil {
+		subnets,
+		fargatePlatformVersion); err != nil {
 		return "", err
 	}
 
@@ -117,7 +121,8 @@ func (s *ServiceProvider) createService(
 	loadBalancerRole string,
 	loadBalancer *ecs.LoadBalancer,
 	securityGroupIDs []*string,
-	subnets []*string,
+	subnets []string,
+	fargatePlatformVersion string,
 ) error {
 	input := &ecs.CreateServiceInput{}
 	input.SetCluster(cluster)
@@ -127,14 +132,19 @@ func (s *ServiceProvider) createService(
 	input.SetTaskDefinition(taskDefinition)
 
 	if launchType == ecs.LaunchTypeFargate {
+		s := make([]*string, len(subnets))
+		for i := range subnets {
+			s[i] = aws.String(subnets[i])
+		}
+
 		awsvpcConfig := &ecs.AwsVpcConfiguration{}
 		awsvpcConfig.SetAssignPublicIp(ecs.AssignPublicIpDisabled)
 		awsvpcConfig.SetSecurityGroups(securityGroupIDs)
-		awsvpcConfig.SetSubnets(subnets)
+		awsvpcConfig.SetSubnets(s)
 		networkConfig := &ecs.NetworkConfiguration{}
 		networkConfig.SetAwsvpcConfiguration(awsvpcConfig)
 		input.SetNetworkConfiguration(networkConfig)
-		input.SetPlatformVersion("LATEST")
+		input.SetPlatformVersion(fargatePlatformVersion)
 	}
 
 	if loadBalancer != nil {

--- a/api/provider/aws/service_create.go
+++ b/api/provider/aws/service_create.go
@@ -96,12 +96,13 @@ func (s *ServiceProvider) Create(req models.CreateServiceRequest) (string, error
 		launchType,
 		serviceName,
 		taskDefinitionARN,
-		scale,
 		loadBalancerRole,
-		loadBalancer,
-		securityGroupIDs,
+		fargatePlatformVersion,
+		scale,
 		subnets,
-		fargatePlatformVersion); err != nil {
+		securityGroupIDs,
+		loadBalancer,
+	); err != nil {
 		return "", err
 	}
 
@@ -113,16 +114,16 @@ func (s *ServiceProvider) Create(req models.CreateServiceRequest) (string, error
 }
 
 func (s *ServiceProvider) createService(
-	cluster string,
-	launchType string,
-	serviceName string,
-	taskDefinition string,
-	desiredCount int,
-	loadBalancerRole string,
-	loadBalancer *ecs.LoadBalancer,
-	securityGroupIDs []*string,
-	subnets []string,
+	cluster,
+	launchType,
+	serviceName,
+	taskDefinition,
+	loadBalancerRole,
 	fargatePlatformVersion string,
+	desiredCount int,
+	subnets []string,
+	securityGroupIDs []*string,
+	loadBalancer *ecs.LoadBalancer,
 ) error {
 	input := &ecs.CreateServiceInput{}
 	input.SetCluster(cluster)

--- a/api/provider/aws/service_create.go
+++ b/api/provider/aws/service_create.go
@@ -12,20 +12,9 @@ func (s *ServiceProvider) Create(req models.CreateServiceRequest) (string, error
 	fqEnvironmentID := addLayer0Prefix(s.Config.Instance(), req.EnvironmentID)
 	cluster := fqEnvironmentID
 
-	var launchType string
-	tags, err := s.TagStore.SelectByTypeAndID("environment", req.EnvironmentID)
+	launchType, err := getLaunchTypeFromEnvironmentID(s.TagStore, req.EnvironmentID)
 	if err != nil {
 		return "", err
-	}
-
-	if tag, ok := tags.WithKey("type").First(); ok {
-		if tag.Value == models.EnvironmentTypeDynamic {
-			launchType = ecs.LaunchTypeFargate
-		}
-
-		if tag.Value == models.EnvironmentTypeStatic {
-			launchType = ecs.LaunchTypeEc2
-		}
 	}
 
 	serviceID := entityIDGenerator(req.ServiceName)

--- a/api/provider/aws/service_create.go
+++ b/api/provider/aws/service_create.go
@@ -2,7 +2,6 @@ package aws
 
 import (
 	"fmt"
-	"log"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/ecs"
@@ -127,32 +126,16 @@ func (s *ServiceProvider) createService(
 	input.SetServiceName(serviceName)
 	input.SetTaskDefinition(taskDefinition)
 
-	// LAUNCH TYPE TESTING
-
-	awsvpcConfig := &ecs.AwsVpcConfiguration{}
-	awsvpcConfig.SetAssignPublicIp(ecs.AssignPublicIpDisabled) // DISABLED by default
-
-	// environment's security group; add load balancer sg as well if exists and is public
-	// (look into the security groups of a public vs private load balancer)
-	awsvpcConfig.SetSecurityGroups(securityGroupIDs)
-
-	// get from config (maybe config.privateSubnets or something)
-	awsvpcConfig.SetSubnets(subnets)
-
-	networkConfig := &ecs.NetworkConfiguration{}
-	networkConfig.SetAwsvpcConfiguration(awsvpcConfig)
-
-	input.SetNetworkConfiguration(networkConfig)
-
-	// possibly unnecessary
-	input.SetPlatformVersion("LATEST")
-
-	// may also need to do this (unsure if these are created by default):
-	// deploymentConfig := &ecs.DeploymentConfiguration{}
-	// deploymentConfig.Set[somethingsabouthealthypercent]
-	// input.SetDeploymentConfiguration(deploymentConfig)
-
-	// END OF LAUNCH TYPE TESTING
+	if launchType == ecs.LaunchTypeFargate {
+		awsvpcConfig := &ecs.AwsVpcConfiguration{}
+		awsvpcConfig.SetAssignPublicIp(ecs.AssignPublicIpDisabled)
+		awsvpcConfig.SetSecurityGroups(securityGroupIDs)
+		awsvpcConfig.SetSubnets(subnets)
+		networkConfig := &ecs.NetworkConfiguration{}
+		networkConfig.SetAwsvpcConfiguration(awsvpcConfig)
+		input.SetNetworkConfiguration(networkConfig)
+		input.SetPlatformVersion("LATEST")
+	}
 
 	if loadBalancer != nil {
 		input.SetLoadBalancers([]*ecs.LoadBalancer{loadBalancer})
@@ -162,8 +145,6 @@ func (s *ServiceProvider) createService(
 	if err := input.Validate(); err != nil {
 		return err
 	}
-
-	log.Printf("[DEBUG] [createService] CreateServiceInput: %#v", input)
 
 	if _, err := s.AWS.ECS.CreateService(input); err != nil {
 		return err

--- a/api/provider/aws/task_create.go
+++ b/api/provider/aws/task_create.go
@@ -109,32 +109,16 @@ func (t *TaskProvider) runTask(
 	input.SetStartedBy(startedBy)
 	input.SetOverrides(overrides)
 
-	// LAUNCH TYPE TESTING
-
-	awsvpcConfig := &ecs.AwsVpcConfiguration{}
-	awsvpcConfig.SetAssignPublicIp(ecs.AssignPublicIpDisabled) // DISABLED by default
-
-	// environment's security group; add load balancer sg as well if exists and is public
-	// (look into the security groups of a public vs private load balancer)
-	awsvpcConfig.SetSecurityGroups(securityGroupIDs)
-
-	// get from config (maybe config.privateSubnets or something)
-	awsvpcConfig.SetSubnets(subnets)
-
-	networkConfig := &ecs.NetworkConfiguration{}
-	networkConfig.SetAwsvpcConfiguration(awsvpcConfig)
-
-	input.SetNetworkConfiguration(networkConfig)
-
-	// possibly unnecessary
-	input.SetPlatformVersion("LATEST")
-
-	// may also need to do this (unsure if these are created by default):
-	// deploymentConfig := &ecs.DeploymentConfiguration{}
-	// deploymentConfig.Set[somethingsabouthealthypercent]
-	// input.SetDeploymentConfiguration(deploymentConfig)
-
-	// END OF LAUNCH TYPE TESTING
+	if launchType == ecs.LaunchTypeFargate {
+		awsvpcConfig := &ecs.AwsVpcConfiguration{}
+		awsvpcConfig.SetAssignPublicIp(ecs.AssignPublicIpDisabled)
+		awsvpcConfig.SetSecurityGroups(securityGroupIDs)
+		awsvpcConfig.SetSubnets(subnets)
+		networkConfig := &ecs.NetworkConfiguration{}
+		networkConfig.SetAwsvpcConfiguration(awsvpcConfig)
+		input.SetNetworkConfiguration(networkConfig)
+		input.SetPlatformVersion("LATEST")
+	}
 
 	taskFamilyRevision := fmt.Sprintf("%s:%s", taskDefinitionFamily, taskDefinitionRevision)
 	input.SetTaskDefinition(taskFamilyRevision)

--- a/api/provider/aws/task_create.go
+++ b/api/provider/aws/task_create.go
@@ -124,6 +124,7 @@ func (t *TaskProvider) runTask(
 		awsvpcConfig.SetAssignPublicIp(ecs.AssignPublicIpDisabled)
 		awsvpcConfig.SetSecurityGroups(securityGroupIDs)
 		awsvpcConfig.SetSubnets(s)
+
 		networkConfig := &ecs.NetworkConfiguration{}
 		networkConfig.SetAwsvpcConfiguration(awsvpcConfig)
 		input.SetNetworkConfiguration(networkConfig)

--- a/api/provider/aws/task_create.go
+++ b/api/provider/aws/task_create.go
@@ -16,20 +16,9 @@ func (t *TaskProvider) Create(req models.CreateTaskRequest) (string, error) {
 	taskID := entityIDGenerator(req.TaskName)
 	fqEnvironmentID := addLayer0Prefix(t.Config.Instance(), req.EnvironmentID)
 
-	var launchType string
-	tags, err := t.TagStore.SelectByTypeAndID("environment", req.EnvironmentID)
+	launchType, err := getLaunchTypeFromEnvironmentID(t.TagStore, req.EnvironmentID)
 	if err != nil {
 		return "", err
-	}
-
-	if tag, ok := tags.WithKey("type").First(); ok {
-		if tag.Value == models.EnvironmentTypeDynamic {
-			launchType = ecs.LaunchTypeFargate
-		}
-
-		if tag.Value == models.EnvironmentTypeStatic {
-			launchType = ecs.LaunchTypeEc2
-		}
 	}
 
 	deployName, deployVersion, err := lookupDeployNameAndVersion(t.TagStore, req.DeployID)

--- a/api/provider/aws/test_aws/deploy_create_test.go
+++ b/api/provider/aws/test_aws/deploy_create_test.go
@@ -15,7 +15,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestDeployCreate(t *testing.T) {
+func TestDeployCreate_ec2(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 
@@ -56,10 +56,13 @@ func TestDeployCreate(t *testing.T) {
 
 	containers := []*ecs.ContainerDefinition{cntr1, cntr2}
 
+	compatibilities := []*string{aws.String("EC2")}
+
 	// define request
 	reqDeployFile := &ecs.TaskDefinition{}
 	reqDeployFile.SetContainerDefinitions(containers)
 	reqDeployFile.SetTaskRoleArn("arn:aws:iam::012345678910:role/test-role")
+	reqDeployFile.SetRequiresCompatibilities(compatibilities)
 	deployFile, err := json.Marshal(reqDeployFile)
 	if err != nil {
 		t.Fatal(err)
@@ -77,7 +80,7 @@ func TestDeployCreate(t *testing.T) {
 	registerTaskDefinitionInput := &ecs.RegisterTaskDefinitionInput{}
 	registerTaskDefinitionInput.SetTaskRoleArn("arn:aws:iam::012345678910:role/test-role")
 	registerTaskDefinitionInput.SetFamily("l0-test-dpl_name")
-	registerTaskDefinitionInput.SetRequiresCompatibilities([]*string{})
+	registerTaskDefinitionInput.SetRequiresCompatibilities(compatibilities)
 	registerTaskDefinitionInput.SetContainerDefinitions(containers)
 
 	taskDefinitionOutput := &ecs.TaskDefinition{}

--- a/api/provider/aws/test_aws/deploy_create_test.go
+++ b/api/provider/aws/test_aws/deploy_create_test.go
@@ -77,6 +77,7 @@ func TestDeployCreate(t *testing.T) {
 	registerTaskDefinitionInput := &ecs.RegisterTaskDefinitionInput{}
 	registerTaskDefinitionInput.SetTaskRoleArn("arn:aws:iam::012345678910:role/test-role")
 	registerTaskDefinitionInput.SetFamily("l0-test-dpl_name")
+	registerTaskDefinitionInput.SetRequiresCompatibilities([]*string{})
 	registerTaskDefinitionInput.SetContainerDefinitions(containers)
 
 	taskDefinitionOutput := &ecs.TaskDefinition{}

--- a/api/provider/aws/test_aws/environment_create_test.go
+++ b/api/provider/aws/test_aws/environment_create_test.go
@@ -12,7 +12,6 @@ import (
 	provider "github.com/quintilesims/layer0/api/provider/aws"
 	"github.com/quintilesims/layer0/api/tag"
 	awsc "github.com/quintilesims/layer0/common/aws"
-	"github.com/quintilesims/layer0/common/config"
 	"github.com/quintilesims/layer0/common/config/mock_config"
 	"github.com/quintilesims/layer0/common/models"
 	"github.com/stretchr/testify/assert"
@@ -260,30 +259,6 @@ func TestEnvironmentCreateDefaults(t *testing.T) {
 	mockAWS.EC2.EXPECT().
 		AuthorizeSecurityGroupIngress(gomock.Any()).
 		Return(&ec2.AuthorizeSecurityGroupIngressOutput{}, nil)
-
-	// ensure we pass the default instance type, ami id, and user data to the launch configuration
-	renderedUserData, err := provider.RenderUserData(
-		"l0-test-env_id",
-		"bucket",
-		[]byte(provider.DefaultLinuxUserdataTemplate))
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	validateCreateLCInput := func(input *autoscaling.CreateLaunchConfigurationInput) {
-		assert.Equal(t, config.DefaultEnvironmentInstanceType, aws.StringValue(input.InstanceType))
-		assert.Equal(t, "lx_ami", aws.StringValue(input.ImageId))
-		assert.Equal(t, renderedUserData, aws.StringValue(input.UserData))
-	}
-
-	mockAWS.AutoScaling.EXPECT().
-		CreateLaunchConfiguration(gomock.Any()).
-		Do(validateCreateLCInput).
-		Return(&autoscaling.CreateLaunchConfigurationOutput{}, nil)
-
-	mockAWS.AutoScaling.EXPECT().
-		CreateAutoScalingGroup(gomock.Any()).
-		Return(&autoscaling.CreateAutoScalingGroupOutput{}, nil)
 
 	mockAWS.ECS.EXPECT().
 		CreateCluster(gomock.Any()).

--- a/api/provider/aws/test_aws/environment_create_test.go
+++ b/api/provider/aws/test_aws/environment_create_test.go
@@ -12,6 +12,7 @@ import (
 	provider "github.com/quintilesims/layer0/api/provider/aws"
 	"github.com/quintilesims/layer0/api/tag"
 	awsc "github.com/quintilesims/layer0/common/aws"
+	"github.com/quintilesims/layer0/common/config"
 	"github.com/quintilesims/layer0/common/config/mock_config"
 	"github.com/quintilesims/layer0/common/models"
 	"github.com/stretchr/testify/assert"
@@ -259,6 +260,74 @@ func TestEnvironmentCreateDefaults(t *testing.T) {
 	mockAWS.EC2.EXPECT().
 		AuthorizeSecurityGroupIngress(gomock.Any()).
 		Return(&ec2.AuthorizeSecurityGroupIngressOutput{}, nil)
+
+	mockAWS.ECS.EXPECT().
+		CreateCluster(gomock.Any()).
+		Return(&ecs.CreateClusterOutput{}, nil)
+
+	target := provider.NewEnvironmentProvider(mockAWS.Client(), tagStore, mockConfig)
+	if _, err := target.Create(req); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestEnvironmentCreateDefaults_static(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockAWS := awsc.NewMockClient(ctrl)
+	tagStore := tag.NewMemoryStore()
+	mockConfig := mock_config.NewMockAPIConfig(ctrl)
+
+	// todo: setup helper for config
+	mockConfig.EXPECT().Instance().Return("test").AnyTimes()
+	mockConfig.EXPECT().LinuxAMI().Return("lx_ami").AnyTimes()
+	mockConfig.EXPECT().WindowsAMI().Return("win_ami").AnyTimes()
+	mockConfig.EXPECT().S3Bucket().Return("bucket").AnyTimes()
+	mockConfig.EXPECT().VPC().Return("vpc_id").AnyTimes()
+	mockConfig.EXPECT().InstanceProfile().Return("profile").AnyTimes()
+	mockConfig.EXPECT().PrivateSubnets().Return([]string{"priv1", "priv2"}).AnyTimes()
+	mockConfig.EXPECT().SSHKeyPair().Return("keypair").AnyTimes()
+
+	defer provider.SetEntityIDGenerator("env_id")()
+
+	req := models.CreateEnvironmentRequest{
+		EnvironmentName: "env_name",
+		EnvironmentType: "static",
+		Scale:           1,
+	}
+
+	// using create/read helpers instead of gomock.Any() for readability
+	createSGHelper(t, mockAWS, "l0-test-env_id-env", "vpc_id")
+	readSGHelper(mockAWS, "l0-test-env_id-env", "sg_id")
+
+	mockAWS.EC2.EXPECT().
+		AuthorizeSecurityGroupIngress(gomock.Any()).
+		Return(&ec2.AuthorizeSecurityGroupIngressOutput{}, nil)
+
+	// ensure we pass the default instance type, ami id, and user data to the launch configuration
+	renderedUserData, err := provider.RenderUserData(
+		"l0-test-env_id",
+		"bucket",
+		[]byte(provider.DefaultLinuxUserdataTemplate))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	validateCreateLCInput := func(input *autoscaling.CreateLaunchConfigurationInput) {
+		assert.Equal(t, config.DefaultEnvironmentInstanceType, aws.StringValue(input.InstanceType))
+		assert.Equal(t, "lx_ami", aws.StringValue(input.ImageId))
+		assert.Equal(t, renderedUserData, aws.StringValue(input.UserData))
+	}
+
+	mockAWS.AutoScaling.EXPECT().
+		CreateLaunchConfiguration(gomock.Any()).
+		Do(validateCreateLCInput).
+		Return(&autoscaling.CreateLaunchConfigurationOutput{}, nil)
+
+	mockAWS.AutoScaling.EXPECT().
+		CreateAutoScalingGroup(gomock.Any()).
+		Return(&autoscaling.CreateAutoScalingGroupOutput{}, nil)
 
 	mockAWS.ECS.EXPECT().
 		CreateCluster(gomock.Any()).

--- a/api/provider/aws/test_aws/service_create_test.go
+++ b/api/provider/aws/test_aws/service_create_test.go
@@ -33,6 +33,12 @@ func TestServiceCreate(t *testing.T) {
 			Key:        "arn",
 			Value:      "dpl_arn",
 		},
+		{
+			EntityID:   "env_id",
+			EntityType: "environment",
+			Key:        "type",
+			Value:      models.EnvironmentTypeDynamic,
+		},
 	}
 
 	for _, tag := range tags {
@@ -104,6 +110,7 @@ func TestServiceCreate(t *testing.T) {
 	createServiceInput := &ecs.CreateServiceInput{}
 	createServiceInput.SetCluster("l0-test-env_id")
 	createServiceInput.SetDesiredCount(1)
+	createServiceInput.SetLaunchType(ecs.LaunchTypeFargate)
 	createServiceInput.SetServiceName("l0-test-svc_id")
 	createServiceInput.SetTaskDefinition("dpl_arn")
 
@@ -179,6 +186,12 @@ func TestServiceCreate_defaults(t *testing.T) {
 			Key:        "arn",
 			Value:      "dpl_arn",
 		},
+		{
+			EntityID:   "env_id",
+			EntityType: "environment",
+			Key:        "type",
+			Value:      models.EnvironmentTypeStatic,
+		},
 	}
 
 	for _, tag := range tags {
@@ -192,6 +205,7 @@ func TestServiceCreate_defaults(t *testing.T) {
 	createServiceInput := &ecs.CreateServiceInput{}
 	createServiceInput.SetCluster("l0-test-env_id")
 	createServiceInput.SetDesiredCount(1)
+	createServiceInput.SetLaunchType(ecs.LaunchTypeEc2)
 	createServiceInput.SetServiceName("l0-test-svc_id")
 	createServiceInput.SetTaskDefinition("dpl_arn")
 

--- a/api/provider/aws/test_aws/service_create_test.go
+++ b/api/provider/aws/test_aws/service_create_test.go
@@ -17,7 +17,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestServiceCreate(t *testing.T) {
+func TestServiceCreate_dynamicDefaults(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 
@@ -142,7 +142,7 @@ func TestServiceCreate(t *testing.T) {
 	createServiceInput.SetServiceName("l0-test-svc_id")
 	createServiceInput.SetTaskDefinition("dpl_arn")
 	createServiceInput.SetNetworkConfiguration(networkConfig)
-	createServiceInput.SetPlatformVersion("LATEST")
+	createServiceInput.SetPlatformVersion(config.DefaultFargatePlatformVersion)
 
 	loadBalancer := &ecs.LoadBalancer{}
 	loadBalancer.SetContainerName("ctn_name")
@@ -199,7 +199,7 @@ func TestServiceCreate(t *testing.T) {
 	}
 }
 
-func TestServiceCreate_defaults(t *testing.T) {
+func TestServiceCreate_staticDefaults(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 
@@ -231,26 +231,6 @@ func TestServiceCreate_defaults(t *testing.T) {
 	}
 
 	defer provider.SetEntityIDGenerator("svc_id")()
-
-	ec2Filter := &ec2.Filter{}
-	ec2Filter.SetName("group-name")
-	ec2Filter.SetValues([]*string{aws.String("l0-test-env_id-env")})
-
-	describeSecurityGroupsInput := &ec2.DescribeSecurityGroupsInput{}
-	describeSecurityGroupsInput.SetFilters([]*ec2.Filter{ec2Filter})
-
-	securityGroup := &ec2.SecurityGroup{}
-	securityGroup.SetGroupName("l0-test-env_id-env")
-	securityGroup.SetGroupId("sg-test")
-	securityGroups := []*ec2.SecurityGroup{securityGroup}
-	describeSecurityGroupsOutput := &ec2.DescribeSecurityGroupsOutput{}
-	describeSecurityGroupsOutput.SetSecurityGroups(securityGroups)
-
-	mockAWS.EC2.EXPECT().
-		DescribeSecurityGroups(describeSecurityGroupsInput).
-		Return(describeSecurityGroupsOutput, nil)
-
-	mockConfig.EXPECT().PrivateSubnets().Return([]string{"subnet-test"})
 
 	createServiceInput := &ecs.CreateServiceInput{}
 	createServiceInput.SetCluster("l0-test-env_id")

--- a/api/provider/aws/test_aws/service_create_test.go
+++ b/api/provider/aws/test_aws/service_create_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/aws/aws-sdk-go/service/ecs"
 	"github.com/aws/aws-sdk-go/service/elb"
 	"github.com/golang/mock/gomock"
@@ -48,6 +49,26 @@ func TestServiceCreate(t *testing.T) {
 	}
 
 	defer provider.SetEntityIDGenerator("svc_id")()
+
+	ec2Filter := &ec2.Filter{}
+	ec2Filter.SetName("group-name")
+	ec2Filter.SetValues([]*string{aws.String("l0-test-env_id-env")})
+
+	describeSecurityGroupsInput := &ec2.DescribeSecurityGroupsInput{}
+	describeSecurityGroupsInput.SetFilters([]*ec2.Filter{ec2Filter})
+
+	securityGroup := &ec2.SecurityGroup{}
+	securityGroup.SetGroupName("l0-test-env_id-env")
+	securityGroup.SetGroupId("sg-test")
+	securityGroups := []*ec2.SecurityGroup{securityGroup}
+	describeSecurityGroupsOutput := &ec2.DescribeSecurityGroupsOutput{}
+	describeSecurityGroupsOutput.SetSecurityGroups(securityGroups)
+
+	mockAWS.EC2.EXPECT().
+		DescribeSecurityGroups(describeSecurityGroupsInput).
+		Return(describeSecurityGroupsOutput, nil)
+
+	mockConfig.EXPECT().PrivateSubnets().Return([]string{"subnet-test"})
 
 	loadBalancerInput := &elb.DescribeLoadBalancersInput{}
 	loadBalancerInput.SetLoadBalancerNames([]*string{aws.String("l0-test-lb_id")})
@@ -107,12 +128,21 @@ func TestServiceCreate(t *testing.T) {
 		DescribeTaskDefinition(taskDefinitionInput).
 		Return(taskDefinitionOutput, nil)
 
+	awsvpcConfig := &ecs.AwsVpcConfiguration{}
+	awsvpcConfig.SetAssignPublicIp(ecs.AssignPublicIpDisabled)
+	awsvpcConfig.SetSecurityGroups([]*string{aws.String("sg-test")})
+	awsvpcConfig.SetSubnets([]*string{aws.String("subnet-test")})
+	networkConfig := &ecs.NetworkConfiguration{}
+	networkConfig.SetAwsvpcConfiguration(awsvpcConfig)
+
 	createServiceInput := &ecs.CreateServiceInput{}
 	createServiceInput.SetCluster("l0-test-env_id")
 	createServiceInput.SetDesiredCount(1)
 	createServiceInput.SetLaunchType(ecs.LaunchTypeFargate)
 	createServiceInput.SetServiceName("l0-test-svc_id")
 	createServiceInput.SetTaskDefinition("dpl_arn")
+	createServiceInput.SetNetworkConfiguration(networkConfig)
+	createServiceInput.SetPlatformVersion("LATEST")
 
 	loadBalancer := &ecs.LoadBalancer{}
 	loadBalancer.SetContainerName("ctn_name")
@@ -201,6 +231,26 @@ func TestServiceCreate_defaults(t *testing.T) {
 	}
 
 	defer provider.SetEntityIDGenerator("svc_id")()
+
+	ec2Filter := &ec2.Filter{}
+	ec2Filter.SetName("group-name")
+	ec2Filter.SetValues([]*string{aws.String("l0-test-env_id-env")})
+
+	describeSecurityGroupsInput := &ec2.DescribeSecurityGroupsInput{}
+	describeSecurityGroupsInput.SetFilters([]*ec2.Filter{ec2Filter})
+
+	securityGroup := &ec2.SecurityGroup{}
+	securityGroup.SetGroupName("l0-test-env_id-env")
+	securityGroup.SetGroupId("sg-test")
+	securityGroups := []*ec2.SecurityGroup{securityGroup}
+	describeSecurityGroupsOutput := &ec2.DescribeSecurityGroupsOutput{}
+	describeSecurityGroupsOutput.SetSecurityGroups(securityGroups)
+
+	mockAWS.EC2.EXPECT().
+		DescribeSecurityGroups(describeSecurityGroupsInput).
+		Return(describeSecurityGroupsOutput, nil)
+
+	mockConfig.EXPECT().PrivateSubnets().Return([]string{"subnet-test"})
 
 	createServiceInput := &ecs.CreateServiceInput{}
 	createServiceInput.SetCluster("l0-test-env_id")

--- a/api/provider/aws/test_aws/task_create_test.go
+++ b/api/provider/aws/test_aws/task_create_test.go
@@ -10,6 +10,7 @@ import (
 	provider "github.com/quintilesims/layer0/api/provider/aws"
 	"github.com/quintilesims/layer0/api/tag"
 	awsc "github.com/quintilesims/layer0/common/aws"
+	"github.com/quintilesims/layer0/common/config"
 	"github.com/quintilesims/layer0/common/config/mock_config"
 	"github.com/quintilesims/layer0/common/models"
 	"github.com/stretchr/testify/assert"
@@ -112,7 +113,7 @@ func TestTaskCreate(t *testing.T) {
 	runTaskInput.SetTaskDefinition("l0-test-dpl_name:version")
 	runTaskInput.SetOverrides(taskOverride)
 	runTaskInput.SetNetworkConfiguration(networkConfig)
-	runTaskInput.SetPlatformVersion("LATEST")
+	runTaskInput.SetPlatformVersion(config.DefaultFargatePlatformVersion)
 
 	task := &ecs.Task{}
 	task.SetTaskArn("arn:aws:ecs:region:012345678910:task/arn")

--- a/api/provider/aws/test_aws/task_create_test.go
+++ b/api/provider/aws/test_aws/task_create_test.go
@@ -37,6 +37,12 @@ func TestTaskCreate(t *testing.T) {
 			Key:        "version",
 			Value:      "version",
 		},
+		{
+			EntityID:   "env_id",
+			EntityType: "environment",
+			Key:        "type",
+			Value:      models.EnvironmentTypeDynamic,
+		},
 	}
 
 	for _, tag := range tags {
@@ -72,6 +78,7 @@ func TestTaskCreate(t *testing.T) {
 
 	runTaskInput := &ecs.RunTaskInput{}
 	runTaskInput.SetCluster("l0-test-env_id")
+	runTaskInput.SetLaunchType(ecs.LaunchTypeFargate)
 	runTaskInput.SetStartedBy("test")
 	runTaskInput.SetTaskDefinition("l0-test-dpl_name:version")
 	runTaskInput.SetOverrides(taskOverride)

--- a/common/config/defaults.go
+++ b/common/config/defaults.go
@@ -15,6 +15,9 @@ const (
 	DefaultEnvironmentType         = models.EnvironmentTypeDynamic
 	DefaultEnvironmentOS           = "linux"
 	DefaultServiceScale            = 1
+
+	// https://docs.aws.amazon.com/AmazonECS/latest/developerguide/platform_versions.html
+	DefaultFargatePlatformVersion = "1.0.0"
 )
 
 func DefaultLoadBalancerHealthCheck() models.HealthCheck {

--- a/common/models/validation_test.go
+++ b/common/models/validation_test.go
@@ -49,7 +49,7 @@ func TestRequestModelValidation(t *testing.T) {
 			EnvironmentID:    "env_id",
 			IsPublic:         true,
 			Ports: []Port{
-				{HostPort: 443, ContainerPort: 80, Protocol: "https", CertificateName: "cert"},
+				{HostPort: 443, ContainerPort: 80, Protocol: "https", CertificateARN: "cert"},
 				{HostPort: 22, ContainerPort: 22, Protocol: "tcp"},
 			},
 			HealthCheck: HealthCheck{
@@ -108,10 +108,10 @@ func TestRequestModelValidation(t *testing.T) {
 
 	port := func(fn func(*Port)) *Port {
 		p := &Port{
-			HostPort:        443,
-			ContainerPort:   80,
-			Protocol:        "https",
-			CertificateName: "cert",
+			HostPort:       443,
+			ContainerPort:  80,
+			Protocol:       "https",
+			CertificateARN: "cert",
 		}
 
 		fn(p)

--- a/setup/module/api/policies/ecs_group_policy.json
+++ b/setup/module/api/policies/ecs_group_policy.json
@@ -17,18 +17,18 @@
             ],
             "Resource": "*"
         },
-	    {
+        {
             "Effect": "Allow",
             "Action": [
-		        "ecs:StartTask",
-		        "ecs:StopTask"
+                "ecs:StartTask",
+                "ecs:StopTask"
             ],
             "Resource": "*",
-	        "Condition": {
-		        "ArnEquals": {
-		            "ecs:cluster": "arn:aws:ecs:${region}:${account_id}:cluster/l0-${name}-*"
-		        }
-	        }
+            "Condition": {
+                "ArnEquals": {
+                    "ecs:cluster": "arn:aws:ecs:${region}:${account_id}:cluster/l0-${name}-*"
+                }
+            }
         },
         {
             "Effect": "Allow",
@@ -44,8 +44,8 @@
                 "ecs:DeleteCluster"
             ],
             "Resource": [
-		        "arn:aws:ecs:${region}:${account_id}:cluster/l0-${name}-*"
-	        ]
+                "arn:aws:ecs:${region}:${account_id}:cluster/l0-${name}-*"
+            ]
         }
     ]
 }

--- a/setup/module/api/policies/ecs_group_policy.json
+++ b/setup/module/api/policies/ecs_group_policy.json
@@ -17,18 +17,26 @@
             ],
             "Resource": "*"
         },
-	{
+	    {
             "Effect": "Allow",
             "Action": [
-		"ecs:StartTask",
-		"ecs:StopTask"
+		        "ecs:StartTask",
+		        "ecs:StopTask"
             ],
             "Resource": "*",
-	    "Condition": {
-		"ArnEquals": {
-		    "ecs:cluster": "arn:aws:ecs:${region}:${account_id}:cluster/l0-${name}-*"
-		}
-	    }
+	        "Condition": {
+		        "ArnEquals": {
+		            "ecs:cluster": "arn:aws:ecs:${region}:${account_id}:cluster/l0-${name}-*"
+		        }
+	        }
+        },
+        {
+            "Effect": "Allow",
+            "Action": [
+                "iam:PassRole",
+                "iam:GetRole"
+            ],
+            "Resource": "arn:aws:iam::${account_id}:role/ecsTaskExecutionRole"
         },
         {
             "Effect": "Allow",
@@ -36,8 +44,8 @@
                 "ecs:DeleteCluster"
             ],
             "Resource": [
-		"arn:aws:ecs:${region}:${account_id}:cluster/l0-${name}-*"
-	    ]
+		        "arn:aws:ecs:${region}:${account_id}:cluster/l0-${name}-*"
+	        ]
         }
     ]
 }


### PR DESCRIPTION
**What does this pull request do?**
Services and tasks now check the environment's type (static or dynamic) and use that value to determine the type of instance (Fargate or EC2) on which they should be deployed.


**How should this be tested?**
Spin up services and tasks in both dynamic and static environments, and confirm that dynamic environments yield Fargate instances and that static environments yield EC2 instances. Also, run unit tests at least for the `provider` package.

**Notes:**
- Fargate is only available in `us-east-1` right now, so make sure that's set in `l0-setup`.
- I've pushed an API binary to dockerhub: specify `tlaketest` in `l0-setup`.
- There are some requirements for a task definition file to be Fargate-compatible. Probably the most notable are the following four parameters (defined at the same level as `"containerDefinitions"`):
```
    "requiresCompatibilities": [ "FARGATE" ], 
    "networkMode": "awsvpc", 
    "cpu": "256", 
    "memory": "512",
```
More info at https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task_definition_parameters.html - in particular, note that there are specific values allowed for `"cpu"` and `"memory"`.

**Checklist**
- [x] Unit tests
- ~[ ] Smoke tests (if applicable)~
- ~[ ] System tests (if applicable)~
- ~[ ] Documentation (if applicable)~


closes #500 
