### PR TITLE
Set the LoadBalancer's port's CertificateARN 

### DIFF
--- a/api/backend/ecs/load_balancer_manager.go
+++ b/api/backend/ecs/load_balancer_manager.go
@@ -220,6 +220,7 @@ func (e *ECSLoadBalancerManager) listenerToPort(listener *awselb.Listener) model
 	}
 
 	if listener.SSLCertificateId != nil {
+		port.CertificateARN = *listener.SSLCertificateId
 		port.CertificateName = id.CertificateARNToName(*listener.SSLCertificateId)
 	}
 


### PR DESCRIPTION


**What does this pull request do?**
It sets a CertificateARN property on a port as well as the CertificateName. The TF Provider will use the ARN to populate its `certificate` property in the schema. 


**How should this be tested?**
Use the sample terraform config below
```
resource "layer0_environment" "env_a" {
  name = "a"
}

resource "layer0_load_balancer" "haproxy" {
  name        = "test-lb"
  environment = "${layer0_environment.env_a.id}"
  private     = false

  port {
    host_port      = 443
    container_port = 80
    protocol       = "https"
    certificate    = "<redacted>"
  }
}
```

Apply the changes using `terraform apply`

Confirm that a consecutive apply won't detect any changes and try to recreate any resources.

**Checklist**
- ~[ ] Unit tests~
- ~[ ] Smoke tests (if applicable)~
- ~[ ] System tests (if applicable)~
- ~[ ] Documentation (if applicable)~


closes #531 