### PR TITLE
541: Add AWS region output to -d flag for endpoint and allow spaces for inputs

### DIFF
--- a/setup/command/endpoint.go
+++ b/setup/command/endpoint.go
@@ -55,6 +55,7 @@ func (f *CommandFactory) Endpoint() cli.Command {
 				outputEnvvars[instance.OUTPUT_WINDOWS_SERVICE_AMI] = config.ENVVAR_AWS_WINDOWS_AMI
 				outputEnvvars[instance.OUTPUT_AWS_DYNAMO_TAG_TABLE] = config.ENVVAR_AWS_DYNAMO_TAG_TABLE
 				outputEnvvars[instance.OUTPUT_AWS_DYNAMO_LOCK_TABLE] = config.ENVVAR_AWS_DYNAMO_LOCK_TABLE
+				outputEnvvars[instance.OUTPUT_AWS_REGION] = config.ENVVAR_AWS_REGION
 			}
 
 			fmt.Println("# set the following environment variables in your current session: ")

--- a/setup/command/endpoint_test.go
+++ b/setup/command/endpoint_test.go
@@ -62,6 +62,7 @@ func TestEndpointDev(t *testing.T) {
 			instance.OUTPUT_WINDOWS_SERVICE_AMI,
 			instance.OUTPUT_AWS_DYNAMO_TAG_TABLE,
 			instance.OUTPUT_AWS_DYNAMO_LOCK_TABLE,
+			instance.OUTPUT_AWS_REGION,
 		}
 
 		for _, output := range outputs {

--- a/setup/instance/inputs.go
+++ b/setup/instance/inputs.go
@@ -194,7 +194,7 @@ func RequiredStringPrompter(m ModuleInput, current interface{}) (interface{}, er
 			scanner := bufio.NewScanner(os.Stdin)
 			scanner.Scan()
 			if err := scanner.Err(); err != nil {
-				return nil, fmt.Errorf("Error for '%s': %e", m.Name, err)
+				return nil, fmt.Errorf("Error for '%s': %s", m.Name, err.Error())
 			}
 
 			input := scanner.Text()

--- a/setup/instance/inputs.go
+++ b/setup/instance/inputs.go
@@ -1,8 +1,10 @@
 package instance
 
 import (
+	"bufio"
 	"fmt"
 	"log"
+	"os"
 
 	"github.com/quintilesims/layer0/common/config"
 )
@@ -188,8 +190,10 @@ func RequiredStringPrompter(m ModuleInput, current interface{}) (interface{}, er
 		for i := 0; i < 3; i++ {
 			fmt.Printf("\tInput: ")
 
-			var input string
-			fmt.Scanln(&input)
+			// Allow spaces for input
+			reader := bufio.NewReader(os.Stdin)
+			bytes, _, _ := reader.ReadLine()
+			input := string(bytes)
 
 			// user pressed 'enter' with a value already in place
 			if input == "" && currentOrDefault != nil {

--- a/setup/instance/inputs.go
+++ b/setup/instance/inputs.go
@@ -192,7 +192,10 @@ func RequiredStringPrompter(m ModuleInput, current interface{}) (interface{}, er
 
 			// Allow spaces for input
 			reader := bufio.NewReader(os.Stdin)
-			bytes, _, _ := reader.ReadLine()
+			bytes, _, err := reader.ReadLine()
+			if err != nil {
+				continue
+			}
 			input := string(bytes)
 
 			// user pressed 'enter' with a value already in place

--- a/setup/instance/inputs.go
+++ b/setup/instance/inputs.go
@@ -191,12 +191,13 @@ func RequiredStringPrompter(m ModuleInput, current interface{}) (interface{}, er
 			fmt.Printf("\tInput: ")
 
 			// Allow spaces for input
-			reader := bufio.NewReader(os.Stdin)
-			bytes, _, err := reader.ReadLine()
-			if err != nil {
-				continue
+			scanner := bufio.NewScanner(os.Stdin)
+			scanner.Scan()
+			if err := scanner.Err(); err != nil {
+				return nil, fmt.Errorf("Error for '%s': %e", m.Name, err)
 			}
-			input := string(bytes)
+
+			input := scanner.Text()
 
 			// user pressed 'enter' with a value already in place
 			if input == "" && currentOrDefault != nil {

--- a/setup/instance/outputs.go
+++ b/setup/instance/outputs.go
@@ -20,4 +20,5 @@ const (
 	OUTPUT_AWS_DYNAMO_TAG_TABLE        = "dynamo_tag_table"
 	OUTPUT_AWS_DYNAMO_LOCK_TABLE       = "dynamo_lock_table"
 	OUTPUT_AWS_LOG_GROUP_NAME          = "log_group_name"
+	OUTPUT_AWS_REGION                  = "region"
 )


### PR DESCRIPTION
**What does this pull request do?**
Adds region to the outputs for -d flag

**Checklist**
- [x] Unit tests

closes #541 