### PR TITLE
559: Add load balancer idle timeout support for api-refactor

### DIFF
--- a/api/provider/aws/common.go
+++ b/api/provider/aws/common.go
@@ -43,10 +43,6 @@ func describeLoadBalancerAttributes(elbapi elbiface.ELBAPI, loadBalancerName str
 
 	output, err := elbapi.DescribeLoadBalancerAttributes(input)
 	if err != nil {
-		if err, ok := err.(awserr.Error); ok && err.Code() == "LoadBalancerAttributeNotFound" {
-			return nil, errors.Newf(errors.LoadBalancerAttributeNotFound, "LoadBalancer attributes cannot be described for LoadBalancer '%s'", loadBalancerName)
-		}
-
 		return nil, err
 	}
 

--- a/api/provider/aws/common.go
+++ b/api/provider/aws/common.go
@@ -37,6 +37,22 @@ func describeLoadBalancer(elbapi elbiface.ELBAPI, loadBalancerName string) (*elb
 	return output.LoadBalancerDescriptions[0], nil
 }
 
+func describeLoadBalancerAttributes(elbapi elbiface.ELBAPI, loadBalancerName string) (*elb.LoadBalancerAttributes, error) {
+	input := &elb.DescribeLoadBalancerAttributesInput{}
+	input.SetLoadBalancerName(loadBalancerName)
+
+	output, err := elbapi.DescribeLoadBalancerAttributes(input)
+	if err != nil {
+		if err, ok := err.(awserr.Error); ok && err.Code() == "LoadBalancerAttributeNotFound" {
+			return nil, errors.Newf(errors.LoadBalancerAttributeNotFound, "LoadBalancer attributes cannot be described for LoadBalancer '%s'", loadBalancerName)
+		}
+
+		return nil, err
+	}
+
+	return output.LoadBalancerAttributes, nil
+}
+
 func describeTaskDefinition(ecsapi ecsiface.ECSAPI, taskDefinitionARN string) (*ecs.TaskDefinition, error) {
 	input := &ecs.DescribeTaskDefinitionInput{}
 	input.SetTaskDefinition(taskDefinitionARN)

--- a/api/provider/aws/load_balancer_create.go
+++ b/api/provider/aws/load_balancer_create.go
@@ -120,6 +120,11 @@ func (l *LoadBalancerProvider) Create(req models.CreateLoadBalancerRequest) (str
 		return "", err
 	}
 
+	idleTimeout := req.IdleTimeout
+	if err := l.setIdleTimeout(fqLoadBalancerID, idleTimeout); err != nil {
+		return "", err
+	}
+
 	if err := l.createTags(loadBalancerID, req.LoadBalancerName, req.EnvironmentID); err != nil {
 		return "", err
 	}

--- a/api/provider/aws/load_balancer_read.go
+++ b/api/provider/aws/load_balancer_read.go
@@ -14,6 +14,11 @@ func (l *LoadBalancerProvider) Read(loadBalancerID string) (*models.LoadBalancer
 		return nil, err
 	}
 
+	loadBalancerAttributes, err := describeLoadBalancerAttributes(l.AWS.ELB, fqLoadBalancerID)
+	if err != nil {
+		return nil, err
+	}
+
 	model, err := l.makeLoadBalancerModel(loadBalancerID)
 	if err != nil {
 		return nil, err
@@ -44,6 +49,7 @@ func (l *LoadBalancerProvider) Read(loadBalancerID string) (*models.LoadBalancer
 
 	model.IsPublic = aws.StringValue(loadBalancer.Scheme) == "internet-facing"
 	model.URL = aws.StringValue(loadBalancer.DNSName)
+	model.IdleTimeout = int(aws.Int64Value(loadBalancerAttributes.ConnectionSettings.IdleTimeout))
 
 	return model, nil
 }

--- a/api/provider/aws/load_balancer_update.go
+++ b/api/provider/aws/load_balancer_update.go
@@ -82,6 +82,13 @@ func (l *LoadBalancerProvider) Update(loadBalancerID string, req models.UpdateLo
 		}
 	}
 
+	if req.IdleTimeout != 0 {
+		idleTimeout := req.IdleTimeout
+		if err := l.setIdleTimeout(loadBalancerName, idleTimeout); err != nil {
+			return err
+		}
+	}
+
 	return nil
 }
 
@@ -95,6 +102,28 @@ func (l *LoadBalancerProvider) updateHealthCheck(loadBalancerName string, health
 	}
 
 	if _, err := l.AWS.ELB.ConfigureHealthCheck(input); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (l *LoadBalancerProvider) setIdleTimeout(loadBalancerName string, idleTimeout int) error {
+	connectionSettings := &elb.ConnectionSettings{}
+	connectionSettings.SetIdleTimeout(int64(idleTimeout))
+
+	loadBalancerAttributes := &elb.LoadBalancerAttributes{}
+	loadBalancerAttributes.SetConnectionSettings(connectionSettings)
+
+	input := &elb.ModifyLoadBalancerAttributesInput{}
+	input.SetLoadBalancerName(loadBalancerName)
+	input.SetLoadBalancerAttributes(loadBalancerAttributes)
+
+	if err := input.Validate(); err != nil {
+		return err
+	}
+
+	if _, err := l.AWS.ELB.ModifyLoadBalancerAttributes(input); err != nil {
 		return err
 	}
 

--- a/api/provider/aws/load_balancer_update.go
+++ b/api/provider/aws/load_balancer_update.go
@@ -82,9 +82,9 @@ func (l *LoadBalancerProvider) Update(loadBalancerID string, req models.UpdateLo
 		}
 	}
 
-	if req.IdleTimeout != 0 {
+	if req.IdleTimeout != nil {
 		idleTimeout := req.IdleTimeout
-		if err := l.setIdleTimeout(loadBalancerName, idleTimeout); err != nil {
+		if err := l.setIdleTimeout(loadBalancerName, *idleTimeout); err != nil {
 			return err
 		}
 	}

--- a/api/provider/aws/test_aws/environment_create_test.go
+++ b/api/provider/aws/test_aws/environment_create_test.go
@@ -12,7 +12,6 @@ import (
 	provider "github.com/quintilesims/layer0/api/provider/aws"
 	"github.com/quintilesims/layer0/api/tag"
 	awsc "github.com/quintilesims/layer0/common/aws"
-	"github.com/quintilesims/layer0/common/config"
 	"github.com/quintilesims/layer0/common/config/mock_config"
 	"github.com/quintilesims/layer0/common/models"
 	"github.com/stretchr/testify/assert"
@@ -260,30 +259,6 @@ func TestEnvironmentCreateDefaults(t *testing.T) {
 	mockAWS.EC2.EXPECT().
 		AuthorizeSecurityGroupIngress(gomock.Any()).
 		Return(&ec2.AuthorizeSecurityGroupIngressOutput{}, nil)
-
-	// ensure we pass the default instance type, ami id, and user data to the launch configuration
-	renderedUserData, err := provider.RenderUserData(
-		"l0-test-env_id",
-		"bucket",
-		[]byte(provider.DefaultLinuxUserdataTemplate))
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	validateCreateLCInput := func(input *autoscaling.CreateLaunchConfigurationInput) {
-		assert.Equal(t, config.DefaultEnvironmentInstanceType, aws.StringValue(input.InstanceType))
-		assert.Equal(t, "lx_ami", aws.StringValue(input.ImageId))
-		assert.Equal(t, renderedUserData, aws.StringValue(input.UserData))
-	}
-
-	mockAWS.AutoScaling.EXPECT().
-		CreateLaunchConfiguration(gomock.Any()).
-		Do(validateCreateLCInput).
-		Return(&autoscaling.CreateLaunchConfigurationOutput{}, nil)
-
-	mockAWS.AutoScaling.EXPECT().
-		CreateAutoScalingGroup(gomock.Any()).
-		Return(&autoscaling.CreateAutoScalingGroupOutput{}, nil)
 
 	mockAWS.ECS.EXPECT().
 		CreateCluster(gomock.Any()).

--- a/api/provider/aws/test_aws/load_balancer_create_test.go
+++ b/api/provider/aws/test_aws/load_balancer_create_test.go
@@ -59,6 +59,7 @@ func TestLoadBalancerCreate(t *testing.T) {
 			HealthyThreshold:   4,
 			UnhealthyThreshold: 3,
 		},
+		IdleTimeout: 90,
 	}
 
 	readSGHelper(mockAWS, "l0-test-env_id-env", "env_sg")
@@ -145,6 +146,21 @@ func TestLoadBalancerCreate(t *testing.T) {
 		ConfigureHealthCheck(configureHealthCheckInput).
 		Return(&elb.ConfigureHealthCheckOutput{}, nil)
 
+	idleTimeout := req.IdleTimeout
+	connectionSettings := &elb.ConnectionSettings{}
+	connectionSettings.SetIdleTimeout(int64(idleTimeout))
+
+	loadBalancerAttributes := &elb.LoadBalancerAttributes{}
+	loadBalancerAttributes.SetConnectionSettings(connectionSettings)
+
+	modifyLoadBalancerAttributesInput := &elb.ModifyLoadBalancerAttributesInput{}
+	modifyLoadBalancerAttributesInput.SetLoadBalancerName("l0-test-lb_id")
+	modifyLoadBalancerAttributesInput.SetLoadBalancerAttributes(loadBalancerAttributes)
+
+	mockAWS.ELB.EXPECT().
+		ModifyLoadBalancerAttributes(modifyLoadBalancerAttributesInput).
+		Return(&elb.ModifyLoadBalancerAttributesOutput{}, nil)
+
 	target := provider.NewLoadBalancerProvider(mockAWS.Client(), tagStore, mockConfig)
 	result, err := target.Create(req)
 	if err != nil {
@@ -194,6 +210,7 @@ func TestLoadBalancerCreateDefaults(t *testing.T) {
 		EnvironmentID:    "env_id",
 		Ports:            []models.Port{},
 		HealthCheck:      models.HealthCheck{},
+		IdleTimeout:      60,
 	}
 
 	readSGHelper(mockAWS, "l0-test-env_id-env", "env_sg")
@@ -233,6 +250,21 @@ func TestLoadBalancerCreateDefaults(t *testing.T) {
 	mockAWS.ELB.EXPECT().
 		ConfigureHealthCheck(configureHealthCheckInput).
 		Return(&elb.ConfigureHealthCheckOutput{}, nil)
+
+	idleTimeout := req.IdleTimeout
+	connectionSettings := &elb.ConnectionSettings{}
+	connectionSettings.SetIdleTimeout(int64(idleTimeout))
+
+	loadBalancerAttributes := &elb.LoadBalancerAttributes{}
+	loadBalancerAttributes.SetConnectionSettings(connectionSettings)
+
+	modifyLoadBalancerAttributesInput := &elb.ModifyLoadBalancerAttributesInput{}
+	modifyLoadBalancerAttributesInput.SetLoadBalancerName("l0-test-lb_id")
+	modifyLoadBalancerAttributesInput.SetLoadBalancerAttributes(loadBalancerAttributes)
+
+	mockAWS.ELB.EXPECT().
+		ModifyLoadBalancerAttributes(modifyLoadBalancerAttributesInput).
+		Return(&elb.ModifyLoadBalancerAttributesOutput{}, nil)
 
 	target := provider.NewLoadBalancerProvider(mockAWS.Client(), tagStore, mockConfig)
 	result, err := target.Create(req)

--- a/api/provider/aws/test_aws/load_balancer_update_test.go
+++ b/api/provider/aws/test_aws/load_balancer_update_test.go
@@ -54,7 +54,7 @@ func TestLoadBalancerUpdate(t *testing.T) {
 	req := models.UpdateLoadBalancerRequest{
 		Ports:       &requestPorts,
 		HealthCheck: requestHealthCheck,
-		IdleTimeout: idleTimeout,
+		IdleTimeout: &idleTimeout,
 	}
 
 	configureHealthCheckInput := &elb.ConfigureHealthCheckInput{}

--- a/cli/command/load_balancer.go
+++ b/cli/command/load_balancer.go
@@ -238,6 +238,7 @@ func (l *LoadBalancerCommand) create(c *cli.Context) error {
 		IsPublic:         !c.Bool("private"),
 		Ports:            ports,
 		HealthCheck:      healthCheck,
+		IdleTimeout:      c.Int("idle-timeout"),
 	}
 
 	loadBalancerID, err := l.client.CreateLoadBalancer(req)

--- a/cli/command/load_balancer.go
+++ b/cli/command/load_balancer.go
@@ -394,7 +394,7 @@ func (l *LoadBalancerCommand) idletimeout(c *cli.Context) error {
 
 	idleTimeout, err := strconv.Atoi(args["TIMEOUT"])
 	if err != nil {
-		return fmt.Errorf("Failed to parse TIMEOUT argument: %v", args["TIMEOUT"])
+		return fmt.Errorf("Failed to parse TIMEOUT argument: %v", err)
 	}
 
 	loadBalancerID, err := l.resolveSingleEntityIDHelper("load_balancer", args["LOAD_BALANCER_NAME"])

--- a/cli/command/load_balancer.go
+++ b/cli/command/load_balancer.go
@@ -84,6 +84,11 @@ func (l *LoadBalancerCommand) Command() cli.Command {
 						Value: dhc.UnhealthyThreshold,
 						Usage: "Number of consecutive failures required to count as unhealthy",
 					},
+					cli.IntFlag{
+						Name:  "idle-timeout",
+						Value: 60,
+						Usage: "Idle timeout of the load balancer in seconds",
+					},
 				},
 			},
 			{
@@ -131,6 +136,12 @@ func (l *LoadBalancerCommand) Command() cli.Command {
 						Usage: "Number of consecutive failures required to count as unhealthy",
 					},
 				},
+			},
+			{
+				Name:      "idletimeout",
+				Usage:     "Update the idle timeout of a load balancer",
+				Action:    l.idletimeout,
+				ArgsUsage: "LOAD_BALANCER_NAME TIMEOUT",
 			},
 			{
 				Name:      "list",
@@ -372,6 +383,38 @@ func (l *LoadBalancerCommand) healthcheck(c *cli.Context) error {
 	}
 
 	return l.printer.PrintLoadBalancerHealthCheck(loadBalancer)
+}
+
+func (l *LoadBalancerCommand) idletimeout(c *cli.Context) error {
+	args, err := extractArgs(c.Args(), "LOAD_BALANCER_NAME", "TIMEOUT")
+	if err != nil {
+		return err
+	}
+
+	idleTimeout, err := strconv.Atoi(args["TIMEOUT"])
+	if err != nil {
+		return fmt.Errorf("Failed to parse TIMEOUT argument: %v", args["TIMEOUT"])
+	}
+
+	loadBalancerID, err := l.resolveSingleEntityIDHelper("load_balancer", args["LOAD_BALANCER_NAME"])
+	if err != nil {
+		return err
+	}
+
+	req := models.UpdateLoadBalancerRequest{
+		IdleTimeout: idleTimeout,
+	}
+
+	if err := l.client.UpdateLoadBalancer(loadBalancerID, req); err != nil {
+		return err
+	}
+
+	loadBalancer, err := l.client.ReadLoadBalancer(loadBalancerID)
+	if err != nil {
+		return err
+	}
+
+	return l.printer.PrintLoadBalancerIdleTimeout(loadBalancer)
 }
 
 func (l *LoadBalancerCommand) list(c *cli.Context) error {

--- a/cli/command/load_balancer.go
+++ b/cli/command/load_balancer.go
@@ -403,7 +403,7 @@ func (l *LoadBalancerCommand) idletimeout(c *cli.Context) error {
 	}
 
 	req := models.UpdateLoadBalancerRequest{
-		IdleTimeout: idleTimeout,
+		IdleTimeout: &idleTimeout,
 	}
 
 	if err := l.client.UpdateLoadBalancer(loadBalancerID, req); err != nil {

--- a/cli/command/load_balancer_test.go
+++ b/cli/command/load_balancer_test.go
@@ -192,8 +192,9 @@ func TestLoadBalancerIdleTimeout(t *testing.T) {
 		Resolve("load_balancer", "lb_name").
 		Return([]string{"lb_id"}, nil)
 
+	idleTimeout := 80
 	req := models.UpdateLoadBalancerRequest{
-		IdleTimeout: 80,
+		IdleTimeout: &idleTimeout,
 	}
 
 	base.Client.EXPECT().
@@ -214,6 +215,7 @@ func TestLoadBalancerIdleTimeoutInputErrors(t *testing.T) {
 	testInputErrors(t, NewLoadBalancerCommand(nil).Command(), map[string]string{
 		"Missing LOAD_BALANCER_NAME arg": "l0 loadbalancer idletimeout",
 		"Missing TIMEOUT arg":            "l0 loadbalancer idletimeout name",
+		"Invalid TIMEOUT arg":            "l0 loadbalancer idletimeout name foo",
 	})
 }
 

--- a/cli/command/load_balancer_test.go
+++ b/cli/command/load_balancer_test.go
@@ -77,6 +77,7 @@ func TestCreateLoadBalancer(t *testing.T) {
 			HealthyThreshold:   7,
 			UnhealthyThreshold: 8,
 		},
+		IdleTimeout: 90,
 	}
 
 	base.Client.EXPECT().
@@ -97,6 +98,7 @@ func TestCreateLoadBalancer(t *testing.T) {
 	input += "--healthcheck-timeout 6 "
 	input += "--healthcheck-healthy-threshold 7 "
 	input += "--healthcheck-unhealthy-threshold 8 "
+	input += "--idle-timeout 90 "
 	input += "env_name lb_name"
 
 	if err := testutils.RunApp(command, input); err != nil {
@@ -178,6 +180,40 @@ func TestLoadBalancerDropPortInputErrors(t *testing.T) {
 	testInputErrors(t, NewLoadBalancerCommand(nil).Command(), map[string]string{
 		"Missing NAME arg": "l0 loadbalancer dropport",
 		"Missing PORT arg": "l0 loadbalancer dropport name",
+	})
+}
+
+func TestLoadBalancerIdleTimeout(t *testing.T) {
+	base, ctrl := newTestCommand(t)
+	defer ctrl.Finish()
+	command := NewLoadBalancerCommand(base.CommandBase()).Command()
+
+	base.Resolver.EXPECT().
+		Resolve("load_balancer", "lb_name").
+		Return([]string{"lb_id"}, nil)
+
+	req := models.UpdateLoadBalancerRequest{
+		IdleTimeout: 80,
+	}
+
+	base.Client.EXPECT().
+		UpdateLoadBalancer("lb_id", req).
+		Return(nil)
+
+	base.Client.EXPECT().
+		ReadLoadBalancer("lb_id").
+		Return(&models.LoadBalancer{}, nil)
+
+	input := "l0 loadbalancer idletimeout lb_name 80"
+	if err := testutils.RunApp(command, input); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestLoadBalancerIdleTimeoutInputErrors(t *testing.T) {
+	testInputErrors(t, NewLoadBalancerCommand(nil).Command(), map[string]string{
+		"Missing LOAD_BALANCER_NAME arg": "l0 loadbalancer idletimeout",
+		"Missing TIMEOUT arg":            "l0 loadbalancer idletimeout name",
 	})
 }
 

--- a/cli/printer/interface.go
+++ b/cli/printer/interface.go
@@ -12,6 +12,7 @@ type Printer interface {
 	PrintLoadBalancers(loadBalancers ...*models.LoadBalancer) error
 	PrintLoadBalancerSummaries(loadBalancers ...models.LoadBalancerSummary) error
 	PrintLoadBalancerHealthCheck(loadBalancer *models.LoadBalancer) error
+	PrintLoadBalancerIdleTimeout(loadBalancer *models.LoadBalancer) error
 	PrintLogs(logs ...models.LogFile) error
 	PrintServices(services ...*models.Service) error
 	PrintServiceSummaries(services ...models.ServiceSummary) error

--- a/cli/printer/json.go
+++ b/cli/printer/json.go
@@ -76,6 +76,10 @@ func (j *JSONPrinter) PrintLoadBalancerHealthCheck(loadBalancer *models.LoadBala
 	return j.print(loadBalancer)
 }
 
+func (j *JSONPrinter) PrintLoadBalancerIdleTimeout(loadBalancer *models.LoadBalancer) error {
+	return j.print(loadBalancer)
+}
+
 func (j *JSONPrinter) PrintLogs(logs ...models.LogFile) error {
 	return j.print(logs)
 }

--- a/cli/printer/test.go
+++ b/cli/printer/test.go
@@ -17,6 +17,7 @@ func (t *TestPrinter) PrintEnvironmentSummaries(...models.EnvironmentSummary) er
 func (t *TestPrinter) PrintLoadBalancers(...*models.LoadBalancer) error               { return nil }
 func (t *TestPrinter) PrintLoadBalancerSummaries(...models.LoadBalancerSummary) error { return nil }
 func (t *TestPrinter) PrintLoadBalancerHealthCheck(*models.LoadBalancer) error        { return nil }
+func (t *TestPrinter) PrintLoadBalancerIdleTimeout(*models.LoadBalancer) error        { return nil }
 func (t *TestPrinter) PrintLogs(...models.LogFile) error                              { return nil }
 func (t *TestPrinter) PrintServices(...*models.Service) error                         { return nil }
 func (t *TestPrinter) PrintServiceSummaries(...models.ServiceSummary) error           { return nil }

--- a/cli/printer/text.go
+++ b/cli/printer/text.go
@@ -115,7 +115,7 @@ func (t *TextPrinter) PrintLoadBalancers(loadBalancers ...*models.LoadBalancer) 
 		return fmt.Sprintf("%d:%d/%s", p.HostPort, p.ContainerPort, strings.ToUpper(p.Protocol))
 	}
 
-	rows := []string{"LOADBALANCER ID | LOADBALANCER NAME | ENVIRONMENT | SERVICE | PORTS | PUBLIC | URL"}
+	rows := []string{"LOADBALANCER ID | LOADBALANCER NAME | ENVIRONMENT | SERVICE | PORTS | PUBLIC | URL "}
 	for _, l := range loadBalancers {
 		row := fmt.Sprintf("%s | %s | %s | %s | %s | %t | %s",
 			l.LoadBalancerID,

--- a/cli/printer/text.go
+++ b/cli/printer/text.go
@@ -188,6 +188,28 @@ func (t *TextPrinter) PrintLoadBalancerHealthCheck(loadBalancer *models.LoadBala
 	return nil
 }
 
+func (t *TextPrinter) PrintLoadBalancerIdleTimeout(loadBalancer *models.LoadBalancer) error {
+	getEnvironment := func(l *models.LoadBalancer) string {
+		if l.EnvironmentName != "" {
+			return l.EnvironmentName
+		}
+
+		return l.EnvironmentID
+	}
+
+	rows := []string{"LOADBALANCER ID | LOADBALANCER NAME | ENVIRONMENT | IDLE TIMEOUT "}
+	row := fmt.Sprintf("%s | %s | %s | %d",
+		loadBalancer.LoadBalancerID,
+		loadBalancer.LoadBalancerName,
+		getEnvironment(loadBalancer),
+		loadBalancer.IdleTimeout)
+
+	rows = append(rows, row)
+
+	fmt.Println(columnize.SimpleFormat(rows))
+	return nil
+}
+
 func (t *TextPrinter) PrintLogs(logs ...models.LogFile) error {
 	for _, l := range logs {
 		fmt.Println(l.ContainerName)

--- a/cli/printer/text.go
+++ b/cli/printer/text.go
@@ -115,16 +115,17 @@ func (t *TextPrinter) PrintLoadBalancers(loadBalancers ...*models.LoadBalancer) 
 		return fmt.Sprintf("%d:%d/%s", p.HostPort, p.ContainerPort, strings.ToUpper(p.Protocol))
 	}
 
-	rows := []string{"LOADBALANCER ID | LOADBALANCER NAME | ENVIRONMENT | SERVICE | PORTS | PUBLIC | URL "}
+	rows := []string{"LOADBALANCER ID | LOADBALANCER NAME | ENVIRONMENT | SERVICE | PORTS | PUBLIC | URL | IDLE TIMEOUT"}
 	for _, l := range loadBalancers {
-		row := fmt.Sprintf("%s | %s | %s | %s | %s | %t | %s",
+		row := fmt.Sprintf("%s | %s | %s | %s | %s | %t | %s | %d",
 			l.LoadBalancerID,
 			l.LoadBalancerName,
 			getEnvironment(l),
 			getService(l),
 			getPort(l, 0),
 			l.IsPublic,
-			l.URL)
+			l.URL,
+			l.IdleTimeout)
 
 		rows = append(rows, row)
 

--- a/cli/printer/text.go
+++ b/cli/printer/text.go
@@ -115,17 +115,16 @@ func (t *TextPrinter) PrintLoadBalancers(loadBalancers ...*models.LoadBalancer) 
 		return fmt.Sprintf("%d:%d/%s", p.HostPort, p.ContainerPort, strings.ToUpper(p.Protocol))
 	}
 
-	rows := []string{"LOADBALANCER ID | LOADBALANCER NAME | ENVIRONMENT | SERVICE | PORTS | PUBLIC | URL | IDLE TIMEOUT"}
+	rows := []string{"LOADBALANCER ID | LOADBALANCER NAME | ENVIRONMENT | SERVICE | PORTS | PUBLIC | URL"}
 	for _, l := range loadBalancers {
-		row := fmt.Sprintf("%s | %s | %s | %s | %s | %t | %s | %d",
+		row := fmt.Sprintf("%s | %s | %s | %s | %s | %t | %s",
 			l.LoadBalancerID,
 			l.LoadBalancerName,
 			getEnvironment(l),
 			getService(l),
 			getPort(l, 0),
 			l.IsPublic,
-			l.URL,
-			l.IdleTimeout)
+			l.URL)
 
 		rows = append(rows, row)
 

--- a/cli/printer/text_test.go
+++ b/cli/printer/text_test.go
@@ -109,7 +109,6 @@ func ExampleTextPrintLoadBalancers() {
 					Protocol:      "http",
 				},
 			},
-			IdleTimeout: 80,
 		},
 		{
 			LoadBalancerID:   "id2",
@@ -130,7 +129,6 @@ func ExampleTextPrintLoadBalancers() {
 					Protocol:      "tcp",
 				},
 			},
-			IdleTimeout: 90,
 		},
 	}
 

--- a/cli/printer/text_test.go
+++ b/cli/printer/text_test.go
@@ -136,9 +136,9 @@ func ExampleTextPrintLoadBalancers() {
 
 	printer.PrintLoadBalancers(loadBalancers...)
 	// Output:
-	// LOADBALANCER ID  LOADBALANCER NAME  ENVIRONMENT  SERVICE  PORTS         PUBLIC  URL   IDLE TIMEOUT
-	// id1              lb1                ename1       sname1   80:80/HTTP    true    url1  80
-	// id2              lb2                eid2         sid2     443:80/HTTPS  false   url2  90
+	// LOADBALANCER ID  LOADBALANCER NAME  ENVIRONMENT  SERVICE  PORTS         PUBLIC  URL
+	// id1              lb1                ename1       sname1   80:80/HTTP    true    url1
+	// id2              lb2                eid2         sid2     443:80/HTTPS  false   url2
 	//                                                           22:22/TCP
 
 }

--- a/cli/printer/text_test.go
+++ b/cli/printer/text_test.go
@@ -109,6 +109,7 @@ func ExampleTextPrintLoadBalancers() {
 					Protocol:      "http",
 				},
 			},
+			IdleTimeout: 80,
 		},
 		{
 			LoadBalancerID:   "id2",
@@ -129,14 +130,15 @@ func ExampleTextPrintLoadBalancers() {
 					Protocol:      "tcp",
 				},
 			},
+			IdleTimeout: 90,
 		},
 	}
 
 	printer.PrintLoadBalancers(loadBalancers...)
 	// Output:
-	// LOADBALANCER ID  LOADBALANCER NAME  ENVIRONMENT  SERVICE  PORTS         PUBLIC  URL
-	// id1              lb1                ename1       sname1   80:80/HTTP    true    url1
-	// id2              lb2                eid2         sid2     443:80/HTTPS  false   url2
+	// LOADBALANCER ID  LOADBALANCER NAME  ENVIRONMENT  SERVICE  PORTS         PUBLIC  URL   IDLE TIMEOUT
+	// id1              lb1                ename1       sname1   80:80/HTTP    true    url1  80
+	// id2              lb2                eid2         sid2     443:80/HTTPS  false   url2  90
 	//                                                           22:22/TCP
 
 }
@@ -191,6 +193,46 @@ func ExampleTextPrintLoadBalancerHealthCheck() {
 	// id1              lb1                ename1       tcp:22  5         30       10                 2
 	// LOADBALANCER ID  LOADBALANCER NAME  ENVIRONMENT  TARGET          INTERVAL  TIMEOUT  HEALTHY THRESHOLD  UNHEALTHY THRESHOLD
 	// id2              lb2                eid1         http:80/health  6         10       3                  5
+}
+
+func ExampleTextPrintLoadBalancerIdleTimeout() {
+	printer := &TextPrinter{}
+	loadBalancer1 := &models.LoadBalancer{
+		LoadBalancerID:   "id1",
+		LoadBalancerName: "lb1",
+		EnvironmentID:    "eid1",
+		EnvironmentName:  "ename1",
+		HealthCheck: models.HealthCheck{
+			Target:             "tcp:22",
+			Interval:           5,
+			Timeout:            30,
+			HealthyThreshold:   10,
+			UnhealthyThreshold: 2,
+		},
+		IdleTimeout: 75,
+	}
+
+	loadBalancer2 := &models.LoadBalancer{
+		LoadBalancerID:   "id2",
+		LoadBalancerName: "lb2",
+		EnvironmentID:    "eid1",
+		HealthCheck: models.HealthCheck{
+			Target:             "http:80/health",
+			Interval:           6,
+			Timeout:            10,
+			HealthyThreshold:   3,
+			UnhealthyThreshold: 5,
+		},
+		IdleTimeout: 85,
+	}
+
+	printer.PrintLoadBalancerIdleTimeout(loadBalancer1)
+	printer.PrintLoadBalancerIdleTimeout(loadBalancer2)
+	// Output:
+	// LOADBALANCER ID  LOADBALANCER NAME  ENVIRONMENT  IDLE TIMEOUT
+	// id1              lb1                ename1       75
+	// LOADBALANCER ID  LOADBALANCER NAME  ENVIRONMENT  IDLE TIMEOUT
+	// id2              lb2                eid1         85
 }
 
 func ExampleTextPrintLogs() {

--- a/common/errors/code.go
+++ b/common/errors/code.go
@@ -7,13 +7,14 @@ func (e ErrorCode) String() string {
 }
 
 const (
-	InvalidRequest           ErrorCode = "InvalidReqest"
-	DeployDoesNotExist       ErrorCode = "DeployDoesNotExist"
-	EnvironmentDoesNotExist  ErrorCode = "EnvironmentDoesNotExist"
-	DependencyError          ErrorCode = "DependencyError"
-	JobDoesNotExist          ErrorCode = "JobDoesNotExist"
-	LoadBalancerDoesNotExist ErrorCode = "LoadBalancerDoesNotExist"
-	ServiceDoesNotExist      ErrorCode = "ServiceDoesNotExist"
-	TaskDoesNotExist         ErrorCode = "TaskDoesNotExist"
-	UnexpectedError          ErrorCode = "UnexpectedError"
+	InvalidRequest                ErrorCode = "InvalidReqest"
+	DeployDoesNotExist            ErrorCode = "DeployDoesNotExist"
+	EnvironmentDoesNotExist       ErrorCode = "EnvironmentDoesNotExist"
+	DependencyError               ErrorCode = "DependencyError"
+	JobDoesNotExist               ErrorCode = "JobDoesNotExist"
+	LoadBalancerDoesNotExist      ErrorCode = "LoadBalancerDoesNotExist"
+	LoadBalancerAttributeNotFound ErrorCode = "LoadBalancerAttributeNotFound"
+	ServiceDoesNotExist           ErrorCode = "ServiceDoesNotExist"
+	TaskDoesNotExist              ErrorCode = "TaskDoesNotExist"
+	UnexpectedError               ErrorCode = "UnexpectedError"
 )

--- a/common/errors/code.go
+++ b/common/errors/code.go
@@ -7,14 +7,13 @@ func (e ErrorCode) String() string {
 }
 
 const (
-	InvalidRequest                ErrorCode = "InvalidReqest"
-	DeployDoesNotExist            ErrorCode = "DeployDoesNotExist"
-	EnvironmentDoesNotExist       ErrorCode = "EnvironmentDoesNotExist"
-	DependencyError               ErrorCode = "DependencyError"
-	JobDoesNotExist               ErrorCode = "JobDoesNotExist"
-	LoadBalancerDoesNotExist      ErrorCode = "LoadBalancerDoesNotExist"
-	LoadBalancerAttributeNotFound ErrorCode = "LoadBalancerAttributeNotFound"
-	ServiceDoesNotExist           ErrorCode = "ServiceDoesNotExist"
-	TaskDoesNotExist              ErrorCode = "TaskDoesNotExist"
-	UnexpectedError               ErrorCode = "UnexpectedError"
+	InvalidRequest           ErrorCode = "InvalidReqest"
+	DeployDoesNotExist       ErrorCode = "DeployDoesNotExist"
+	EnvironmentDoesNotExist  ErrorCode = "EnvironmentDoesNotExist"
+	DependencyError          ErrorCode = "DependencyError"
+	JobDoesNotExist          ErrorCode = "JobDoesNotExist"
+	LoadBalancerDoesNotExist ErrorCode = "LoadBalancerDoesNotExist"
+	ServiceDoesNotExist      ErrorCode = "ServiceDoesNotExist"
+	TaskDoesNotExist         ErrorCode = "TaskDoesNotExist"
+	UnexpectedError          ErrorCode = "UnexpectedError"
 )

--- a/common/models/create_load_balancer_request.go
+++ b/common/models/create_load_balancer_request.go
@@ -12,6 +12,7 @@ type CreateLoadBalancerRequest struct {
 	IsPublic         bool        `json:"is_public"`
 	Ports            []Port      `json:"ports"`
 	HealthCheck      HealthCheck `json:"health_check"`
+	IdleTimeout      int         `json:"idle_timeout"`
 }
 
 func (c CreateLoadBalancerRequest) Validate() error {
@@ -45,6 +46,7 @@ func (l CreateLoadBalancerRequest) Definition() swagger.Definition {
 			"is_public":          swagger.NewBoolProperty(),
 			"ports":              swagger.NewObjectSliceProperty("Port"),
 			"health_check":       swagger.NewObjectProperty("HealthCheck"),
+			"idle_timeout":       swagger.NewIntProperty(),
 		},
 	}
 }

--- a/common/models/load_balancer.go
+++ b/common/models/load_balancer.go
@@ -6,6 +6,7 @@ type LoadBalancer struct {
 	EnvironmentID    string      `json:"environment_id"`
 	EnvironmentName  string      `json:"environment_name"`
 	HealthCheck      HealthCheck `json:"health_check"`
+	IdleTimeout      int         `json:"idle_timeout"`
 	IsPublic         bool        `json:"is_public"`
 	LoadBalancerID   string      `json:"load_balancer_id"`
 	LoadBalancerName string      `json:"load_balancer_name"`
@@ -22,6 +23,7 @@ func (l LoadBalancer) Definition() swagger.Definition {
 			"environment_id":     swagger.NewStringProperty(),
 			"environment_name":   swagger.NewStringProperty(),
 			"health_check":       swagger.NewObjectProperty("HealthCheck"),
+			"idle_timeout":       swagger.NewIntProperty(),
 			"is_public":          swagger.NewBoolProperty(),
 			"load_balancer_id":   swagger.NewStringProperty(),
 			"load_balancer_name": swagger.NewStringProperty(),

--- a/common/models/update_load_balancer_request.go
+++ b/common/models/update_load_balancer_request.go
@@ -7,7 +7,7 @@ import (
 type UpdateLoadBalancerRequest struct {
 	Ports       *[]Port      `json:"ports"`
 	HealthCheck *HealthCheck `json:"health_check"`
-	IdleTimeout int          `json:"idle_timeout"`
+	IdleTimeout *int         `json:"idle_timeout"`
 }
 
 func (u UpdateLoadBalancerRequest) Validate() error {

--- a/common/models/update_load_balancer_request.go
+++ b/common/models/update_load_balancer_request.go
@@ -7,6 +7,7 @@ import (
 type UpdateLoadBalancerRequest struct {
 	Ports       *[]Port      `json:"ports"`
 	HealthCheck *HealthCheck `json:"health_check"`
+	IdleTimeout int          `json:"idle_timeout"`
 }
 
 func (u UpdateLoadBalancerRequest) Validate() error {
@@ -33,6 +34,7 @@ func (u UpdateLoadBalancerRequest) Definition() swagger.Definition {
 		Properties: map[string]swagger.Property{
 			"ports":        swagger.NewObjectSliceProperty("Port"),
 			"health_check": swagger.NewObjectProperty("HealthCheck"),
+			"idle_timeout": swagger.NewIntProperty(),
 		},
 	}
 }

--- a/common/models/validation_test.go
+++ b/common/models/validation_test.go
@@ -49,7 +49,7 @@ func TestRequestModelValidation(t *testing.T) {
 			EnvironmentID:    "env_id",
 			IsPublic:         true,
 			Ports: []Port{
-				{HostPort: 443, ContainerPort: 80, Protocol: "https", CertificateName: "cert"},
+				{HostPort: 443, ContainerPort: 80, Protocol: "https", CertificateARN: "cert"},
 				{HostPort: 22, ContainerPort: 22, Protocol: "tcp"},
 			},
 			HealthCheck: HealthCheck{
@@ -108,10 +108,10 @@ func TestRequestModelValidation(t *testing.T) {
 
 	port := func(fn func(*Port)) *Port {
 		p := &Port{
-			HostPort:        443,
-			ContainerPort:   80,
-			Protocol:        "https",
-			CertificateName: "cert",
+			HostPort:       443,
+			ContainerPort:  80,
+			Protocol:       "https",
+			CertificateARN: "cert",
 		}
 
 		fn(p)

--- a/docs-src/docs/reference/cli.md
+++ b/docs-src/docs/reference/cli.md
@@ -375,8 +375,7 @@ l0 job list
 ---
 
 ## Load Balancer
-A load balancer is a component of a Layer0 environment. Load balancers listen for traffic on certain ports, and then forward that traffic to Layer0 [services](#service). The `loadbalancer` command is used with the following subcommands: [create](#loadbalancer-create), [delete](#loadbalancer-delete), [addport](#loadbalancer-addport), [dropport](#loadbalancer-dropport), [get](#loadbalancer-get), [list](#loadbalancer-list), [healthcheck](#loadbalancer-healthcheck), and
-[idletimeout](#loadbalancer-idletimeout).
+A load balancer is a component of a Layer0 environment. Load balancers listen for traffic on certain ports, and then forward that traffic to Layer0 [services](#service). The `loadbalancer` command is used with the following subcommands: [create](#loadbalancer-create), [delete](#loadbalancer-delete), [addport](#loadbalancer-addport), [dropport](#loadbalancer-dropport), [get](#loadbalancer-get), [list](#loadbalancer-list), [healthcheck](#loadbalancer-healthcheck), and [idletimeout](#loadbalancer-idletimeout).
 
 ### loadbalancer create
 Use the `create` subcommand to create a new load balancer.

--- a/docs-src/docs/reference/cli.md
+++ b/docs-src/docs/reference/cli.md
@@ -375,7 +375,8 @@ l0 job list
 ---
 
 ## Load Balancer
-A load balancer is a component of a Layer0 environment. Load balancers listen for traffic on certain ports, and then forward that traffic to Layer0 [services](#service). The `loadbalancer` command is used with the following subcommands: [create](#loadbalancer-create), [delete](#loadbalancer-delete), [addport](#loadbalancer-addport), [dropport](#loadbalancer-dropport), [get](#loadbalancer-get), [list](#loadbalancer-list), and [healthcheck](#loadbalancer-healthcheck).
+A load balancer is a component of a Layer0 environment. Load balancers listen for traffic on certain ports, and then forward that traffic to Layer0 [services](#service). The `loadbalancer` command is used with the following subcommands: [create](#loadbalancer-create), [delete](#loadbalancer-delete), [addport](#loadbalancer-addport), [dropport](#loadbalancer-dropport), [get](#loadbalancer-get), [list](#loadbalancer-list), [healthcheck](#loadbalancer-healthcheck), and
+[idletimeout](#loadbalancer-idletimeout).
 
 ### loadbalancer create
 Use the `create` subcommand to create a new load balancer.
@@ -385,7 +386,7 @@ Use the `create` subcommand to create a new load balancer.
 l0 loadbalancer create [--port port ... | --certificate certificateARN | 
     --private | --healthcheck-target target | --healthcheck-interval interval | 
     --healthcheck-timeout timeout | --healthcheck-healthy-threshold healthyThreshold | 
-    --healthcheck-unhealthy-threshold unhealthyThreshold] environmentName loadBalancerName
+    --healthcheck-unhealthy-threshold unhealthyThreshold | --idle-timeout idleTimeout] environmentName loadBalancerName
 ```
 
 #### Required parameters
@@ -406,6 +407,7 @@ l0 loadbalancer create [--port port ... | --certificate certificateARN |
 * `--healthcheck-timeout timeout` - The length of time before the check times out (default: `5`).
 * `--healthcheck-healthy-threshold healthyThreshold` - The number of checks before the instance is declared healthy (default: `2`).
 * `--healthcheck-unhealthy-threshold unhealthyThreshold` - The number of checks before the instance is declared unhealthy (default: `2`).
+* `--idle-timeout idleTimeout` - The idle timeout in seconds.
 
 !!! info "Ports and Health Checks"
     When both the `--port` and the `--healthcheck-target` options are omitted, Layer0 configures the load balancer with some default values: `80:80/TCP` for ports and `TCP:80` for healthcheck target.
@@ -512,6 +514,20 @@ l0 loadbalancer healthcheck [--set-target target | --set-interval interval |
 
 #### Additional information
 Calling the subcommand without flags will display the current configuration of the load balancer's health check. Setting any of the flags will update the corresponding field in the health check, and all omitted flags will leave the corresponding fields unchanged.
+
+### loadbalancer idletimeout
+Use the `idletimeout` subcommand to update the idle timeout of a load balancer.
+
+The load balancer manages an idle timeout that is triggered when no data is sent over a connection for the specified time period. If no data has been sent or received by the time that the idle timeout period elapses, the load balancer closes the connection. See the following documentation for more information: <https://docs.aws.amazon.com/elasticloadbalancing/latest/application/application-load-balancers.html#connection-idle-timeout>
+
+#### Usage
+```
+l0 loadbalancer idletimeout loadbalancerName idleTimeout
+```
+
+#### Required parameters
+* `loadBalancerName` - The name of the existing Layer0 load balancer you are modifying.
+* `idleTimeout` - The idle timeout in seconds.
 
 ---
 

--- a/docs-src/docs/reference/terraform-plugin.md
+++ b/docs-src/docs/reference/terraform-plugin.md
@@ -355,6 +355,8 @@ resource "layer0_load_balancer" "guestbook" {
     healthy_threshold   = 2
     unhealthy_threshold = 2
   }
+
+  idle_timeout = 300
 }
 ```
 
@@ -367,6 +369,7 @@ The following arguments are supported:
 * `private` - (Optional) If true, the load balancer will not be exposed to the public internet
 * `port` - (Optional, Default: 80:80/tcp) A list of port blocks. Ports documented below
 * `health_check` - (Optional, Default: `{"TCP:80" 30 5 2 2}`) A health_check block. Health check documented below
+* `idle_timeout` - (Optiona, Default: 60) The idle timeout of the load balancer in seconds
 
 Ports (`port`) support the following:
 
@@ -384,6 +387,8 @@ Healthcheck (`health_check`) supports the following:
 * `timeout` - (Required) The length of time before the check times out.
 * `healthy_threshold` - (Required) The number of checks before the instance is declared healthy.
 * `unhealthy_threshold` - (Required) The number of checks before the instance is declared unhealthy.
+
+The Idle Timeout (`idle_timeout`) is managed by the load balancer and is triggered when no data is sent over a connection for the specified time period. If no data has been sent or received by the time that the idle timeout period elapses, the load balancer closes the connection. See the following documentation for more information: <https://docs.aws.amazon.com/elasticloadbalancing/latest/application/application-load-balancers.html#connection-idle-timeout>
 
 ### Attribute Reference
 

--- a/plugins/terraform/layer0/resource_layer0_load_balancer.go
+++ b/plugins/terraform/layer0/resource_layer0_load_balancer.go
@@ -186,7 +186,7 @@ func resourceLayer0LoadBalancerUpdate(d *schema.ResourceData, meta interface{}) 
 		req.IdleTimeout = idleTimeout
 	}
 
-	if req.Ports != nil || req.HealthCheck != nil {
+	if req.Ports != nil || req.HealthCheck != nil || req.IdleTimeout != 0 {
 		if err := apiClient.UpdateLoadBalancer(loadBalancerID, req); err != nil {
 			return err
 		}

--- a/plugins/terraform/layer0/resource_layer0_load_balancer.go
+++ b/plugins/terraform/layer0/resource_layer0_load_balancer.go
@@ -104,6 +104,11 @@ func resourceLayer0LoadBalancer() *schema.Resource {
 					},
 				},
 			},
+			"idle_timeout": {
+				Type:     schema.TypeInt,
+				Optional: true,
+				Default:  60,
+			},
 		},
 	}
 }
@@ -122,6 +127,7 @@ func resourceLayer0LoadBalancerCreate(d *schema.ResourceData, meta interface{}) 
 		IsPublic:         !d.Get("private").(bool),
 		Ports:            ports,
 		HealthCheck:      expandHealthCheck(d.Get("health_check")),
+		IdleTimeout:      d.Get("idle_timeout").(int),
 	}
 
 	loadBalancerID, err := apiClient.CreateLoadBalancer(req)
@@ -154,6 +160,7 @@ func resourceLayer0LoadBalancerRead(d *schema.ResourceData, meta interface{}) er
 	d.Set("health_check", flattenHealthCheck(loadBalancer.HealthCheck))
 	d.Set("port", flattenPorts(loadBalancer.Ports))
 	d.Set("url", loadBalancer.URL)
+	d.Set("idle_timeout", loadBalancer.IdleTimeout)
 
 	return nil
 }
@@ -172,6 +179,11 @@ func resourceLayer0LoadBalancerUpdate(d *schema.ResourceData, meta interface{}) 
 	if d.HasChange("health_check") {
 		healthCheck := expandHealthCheck(d.Get("health_check"))
 		req.HealthCheck = &healthCheck
+	}
+
+	if d.HasChange("idle_timeout") {
+		idleTimeout := d.Get("idle_timeout").(int)
+		req.IdleTimeout = idleTimeout
 	}
 
 	if req.Ports != nil || req.HealthCheck != nil {

--- a/plugins/terraform/layer0/resource_layer0_load_balancer.go
+++ b/plugins/terraform/layer0/resource_layer0_load_balancer.go
@@ -183,10 +183,10 @@ func resourceLayer0LoadBalancerUpdate(d *schema.ResourceData, meta interface{}) 
 
 	if d.HasChange("idle_timeout") {
 		idleTimeout := d.Get("idle_timeout").(int)
-		req.IdleTimeout = idleTimeout
+		req.IdleTimeout = &idleTimeout
 	}
 
-	if req.Ports != nil || req.HealthCheck != nil || req.IdleTimeout != 0 {
+	if req.Ports != nil || req.HealthCheck != nil || req.IdleTimeout != nil {
 		if err := apiClient.UpdateLoadBalancer(loadBalancerID, req); err != nil {
 			return err
 		}

--- a/plugins/terraform/layer0/resource_layer0_load_balancer_test.go
+++ b/plugins/terraform/layer0/resource_layer0_load_balancer_test.go
@@ -44,12 +44,15 @@ func TestResourceLoadBalancerCreateRead(t *testing.T) {
 		UnhealthyThreshold: 2,
 	}
 
+	idleTimeout := 90
+
 	req := models.CreateLoadBalancerRequest{
 		LoadBalancerName: "lb_name",
 		EnvironmentID:    "env_id",
 		IsPublic:         false,
 		Ports:            ports,
 		HealthCheck:      healthCheck,
+		IdleTimeout:      idleTimeout,
 	}
 
 	mockClient.EXPECT().
@@ -63,6 +66,7 @@ func TestResourceLoadBalancerCreateRead(t *testing.T) {
 		Ports:            ports,
 		HealthCheck:      healthCheck,
 		URL:              "some_url",
+		IdleTimeout:      idleTimeout,
 	}
 
 	mockClient.EXPECT().
@@ -76,6 +80,7 @@ func TestResourceLoadBalancerCreateRead(t *testing.T) {
 		"private":      true,
 		"port":         flattenPorts(ports),
 		"health_check": flattenHealthCheck(healthCheck),
+		"idle_timeout": idleTimeout,
 	})
 
 	if err := resourceLayer0LoadBalancerCreate(d, mockClient); err != nil {
@@ -89,6 +94,7 @@ func TestResourceLoadBalancerCreateRead(t *testing.T) {
 	assert.Equal(t, ports, expandPorts(d.Get("port").(*schema.Set).List()))
 	assert.Equal(t, healthCheck, expandHealthCheck(d.Get("health_check")))
 	assert.Equal(t, "some_url", d.Get("url"))
+	assert.Equal(t, idleTimeout, d.Get("idle_timeout"))
 }
 
 func TestResourceLoadBalancerDelete(t *testing.T) {


### PR DESCRIPTION
**What does this pull request do?**
This adds idle timeout support for load balancers to the api-refactor branches.

* Adds an optional flag for `l0 loadbalancer create`, `--idle-timeout` to specify the idle timeout of the load balancer at creation time
* Adds loadbalancer subcommand `l0 loadbalancer idletimeout` which allows the user to specify the idle timeout of a given load balancer
* Adds terraform support for idle timeout by adding a new key to the load balancer resource `idle_timeout`

Unit tests have been added/modified.

Note: Other unit tests have been modified that are currently breaking in api-refactor.


**How should this be tested?**

Manually via the CLI: `l0 loadbalancer create env_a lb_a --idle-timeout 100` and then `l0 loadbalancer idletimeout lb_a 200`

Via terraform:

```
provider "layer0" {
  endpoint        = "${var.endpoint}"
  token           = "${var.token}"
  skip_ssl_verify = true
}

resource "layer0_environment" "env_a" {
  name = "env_a"
  scale = 1
  environment_type = "static"
  instance_type = "t2.small"
}

resource "layer0_load_balancer" "lb_a" {
  name        = "lb_a"
  environment = "${layer0_environment.env_a.id}"

  port {
    host_port      = 80
    container_port = 80
    protocol       = "http"
  }

  idle_timeout = 75
}
```

Apply, then change `idle_timeout` and apply again.

**Checklist**
- [x] Unit tests
~- [ ] Smoke tests (if applicable)~
~- [ ] System tests (if applicable)~
- [x] Documentation (if applicable)

closes #559
