### PR TITLE
573: Modify l0-setup to create CloudTrail trail and send events to CloudWatch

### DIFF
--- a/setup/module/api/core.tf
+++ b/setup/module/api/core.tf
@@ -52,7 +52,7 @@ resource "aws_cloudtrail" "mod" {
   cloud_watch_logs_group_arn = "${aws_cloudwatch_log_group.mod.arn}"
   is_multi_region_trail      = true
 
-  depends_on = ["aws_s3_bucket.mod"]
+  depends_on = ["aws_s3_bucket_policy.cloudtrail"]
 }
 
 data "template_file" "ecs_assume_role_policy" {

--- a/setup/module/api/policies/cloudtrail_assume_role_policy.json
+++ b/setup/module/api/policies/cloudtrail_assume_role_policy.json
@@ -1,0 +1,14 @@
+{
+    "Version": "2008-10-17",
+    "Statement": [
+        {
+            "Effect": "Allow",
+            "Action": [
+                "sts:AssumeRole"
+            ],
+            "Principal": {
+                "Service": "cloudtrail.amazonaws.com"
+            }
+        }
+    ]
+}

--- a/setup/module/api/policies/cloudtrail_role_policy.json
+++ b/setup/module/api/policies/cloudtrail_role_policy.json
@@ -1,0 +1,15 @@
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Effect": "Allow",
+            "Action": "logs:CreateLogStream",
+            "Resource": "arn:aws:logs:${region}:${account_id}:log-group:l0-${name}:log-stream:${account_id}_CloudTrail_${region}*"
+        },
+        {
+            "Effect": "Allow",
+            "Action": "logs:PutLogEvents",
+            "Resource": "arn:aws:logs:${region}:${account_id}:log-group:l0-${name}:log-stream:${account_id}_CloudTrail_${region}*"
+        }
+    ]
+}

--- a/setup/module/api/policies/s3_cloudtrail_bucket_policy.json
+++ b/setup/module/api/policies/s3_cloudtrail_bucket_policy.json
@@ -1,0 +1,26 @@
+{
+  "Version": "2012-10-17",
+  "Statement" : [
+    {
+      "Effect": "Allow",
+      "Principal": {
+        "Service": "cloudtrail.amazonaws.com"
+      },
+      "Action": "s3:GetBucketAcl",
+      "Resource": "arn:aws:s3:::${s3_bucket}"
+    },
+    {
+      "Effect": "Allow",
+      "Principal": {
+        "Service": "cloudtrail.amazonaws.com"
+      },
+      "Action": "s3:PutObject",
+      "Resource": "arn:aws:s3:::${s3_bucket}/*",
+      "Condition": {
+        "StringEquals": {
+          "s3:x-amz-acl": "bucket-owner-full-control"
+        }
+      }
+    }
+  ]
+}


### PR DESCRIPTION
**What does this pull request do?**
Modifies the Terraform structure of l0-setup, specifically the api module, to create the following:

* A CloudTrail trail that will send events to the CloudWatch log group setup creates
* An IAM Role and an inline policy that allows CloudTrail to create log streams and send logs to CloudWatch
* An S3 bucket policy on the bucket that setup creates that lets CloudWatch also send events there


**How should this be tested?**
Create a new l0 instance with l0-setup. A CloudTrail trail with the FQDN should be created, and it should send events to a stream in the CloudWatch log group created when the instance is created.

**Checklist**
~- [ ] Unit tests~
~- [ ] Smoke tests (if applicable)~
~- [ ] System tests (if applicable)~
~- [ ] Documentation (if applicable)~

closes #573 
