### PR TITLE
577: api-refactor, Fix for issue preventing L0 API instances from registering to ECS cluster

### DIFF
--- a/setup/module/api/user_data.sh
+++ b/setup/module/api/user_data.sh
@@ -1,12 +1,11 @@
-# The majority of this script was largely taken from AWS's documentation
-# on using CloudWatch logs with container instances
-# https://docs.aws.amazon.com/AmazonECS/latest/developerguide/using_cloudwatch_logs.html
-
 Content-Type: multipart/mixed; boundary="==BOUNDARY=="
 MIME-Version: 1.0
 
 --==BOUNDARY==
 #!/bin/bash
+# The majority of this script was largely taken from AWS's documentation
+# on using CloudWatch logs with container instances
+# https://docs.aws.amazon.com/AmazonECS/latest/developerguide/using_cloudwatch_logs.html
 exec > >(tee /var/log/user-data.log|logger -t user-data -s 2>/dev/console) 2>&1
 echo ECS_CLUSTER=${cluster_id} >> /etc/ecs/ecs.config
 echo ECS_ENGINE_AUTH_TYPE=dockercfg >> /etc/ecs/ecs.config


### PR DESCRIPTION
**What does this pull request do?**

This PR resolves an issue in the `api-refactor` (and children branches) with the ECS container's user data script where the Layer0 API service's EC2 instances would not register with the ECS cluster created for the API service.

**How should this be tested?**

Create a new layer0 instance through `l0-setup`. `l0-setup` must complete without failure. The API service's EC2 instances should register correctly with the ECS cluster and the service's task should run without issue. Confirm that the EC2 instances are registering correctly by reviewing the `ECS Instances` tab for the cluster called `l0-<prefix>` where prefix is the name of the layer0 instance specified at `l0-setup` time.

**Checklist**
~- [ ] Unit tests~
~- [ ] Smoke tests (if applicable)~
~- [ ] System tests (if applicable)~
~- [ ] Documentation (if applicable)~


closes #577 
