### PR TITLE
Add common retry 

### DIFF
--- a/common/errors/code.go
+++ b/common/errors/code.go
@@ -16,4 +16,5 @@ const (
 	ServiceDoesNotExist      ErrorCode = "ServiceDoesNotExist"
 	TaskDoesNotExist         ErrorCode = "TaskDoesNotExist"
 	UnexpectedError          ErrorCode = "UnexpectedError"
+	FailedRequestTimeout     ErrorCode = "FailedRequestTimeout"
 )

--- a/common/utils/retry.go
+++ b/common/utils/retry.go
@@ -6,8 +6,8 @@ import (
 	"github.com/quintilesims/layer0/common/errors"
 )
 
-func Retry(timeout, delay time.Duration, fn func() (bool, error)) error {
-	ticker := time.NewTicker(delay)
+func Retry(timeout, interval time.Duration, fn func() (bool, error)) error {
+	ticker := time.NewTicker(interval)
 	errc := make(chan error)
 	defer func() {
 		ticker.Stop()

--- a/common/utils/retry.go
+++ b/common/utils/retry.go
@@ -1,0 +1,40 @@
+package utils
+
+import (
+	"time"
+
+	"github.com/quintilesims/layer0/common/errors"
+)
+
+func Retry(timeout, delay time.Duration, fn func() (bool, error)) error {
+	ticker := time.NewTicker(delay)
+	errc := make(chan error)
+	defer func() {
+		ticker.Stop()
+		close(errc)
+	}()
+
+	go func() { errc <- retry(ticker, fn) }()
+
+	select {
+	case err := <-errc:
+		return err
+	case <-time.After(timeout):
+		return errors.New(errors.FailedRequestTimeout, nil)
+	}
+}
+
+func retry(ticker *time.Ticker, fn func() (bool, error)) error {
+	for ; true; <-ticker.C {
+		shouldContinue, err := fn()
+		if err != nil {
+			return err
+		}
+
+		if !shouldContinue {
+			return err
+		}
+	}
+
+	return nil
+}

--- a/common/utils/retry_test.go
+++ b/common/utils/retry_test.go
@@ -1,0 +1,93 @@
+package utils
+
+import (
+	"math/rand"
+	"testing"
+	"time"
+
+	"github.com/quintilesims/layer0/common/errors"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestRetryTimeout(t *testing.T) {
+	start := time.Now()
+	fn := func() (bool, error) {
+		time.Sleep((time.Duration(rand.Intn(2))) * time.Millisecond)
+		return true, nil
+	}
+
+	if err := Retry(time.Millisecond*1, time.Millisecond*1, fn); err != nil {
+		assert.WithinDuration(t, start.Add(time.Millisecond*1), time.Now(), time.Millisecond)
+	}
+}
+
+func TestRetryNoTimeout(t *testing.T) {
+	retries := 0
+	fn := func() (bool, error) {
+		retries++
+		time.Sleep(1 * time.Millisecond)
+
+		if retries == 5 {
+			return false, nil
+		}
+
+		return true, nil
+	}
+
+	if err := Retry(time.Millisecond*100, time.Millisecond*1, fn); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestRetryFuncTimeRandom(t *testing.T) {
+	start := time.Now()
+	fn := func() (bool, error) {
+		time.Sleep((time.Duration(rand.Intn(2))) * time.Millisecond)
+		return true, nil
+	}
+
+	if err := Retry(time.Millisecond*5, time.Millisecond*1, fn); err != nil {
+		assert.WithinDuration(t, time.Now(), start.Add(time.Millisecond*5), time.Millisecond)
+	}
+}
+
+func TestRetryWaitTimeLongerThanTimeout(t *testing.T) {
+	start := time.Now()
+	retries := 0
+	fn := func() (bool, error) {
+		retries++
+		time.Sleep(10 * time.Millisecond)
+		return true, nil
+	}
+
+	if err := Retry(time.Millisecond*5, time.Millisecond*1, fn); err != nil {
+		assert.Equal(t, retries, 1)
+		assert.Equal(t, err, errors.New(errors.FailedRequestTimeout, nil))
+		assert.WithinDuration(t, time.Now(), start.Add(time.Millisecond*5), time.Millisecond)
+	}
+}
+
+func TestRetryCount(t *testing.T) {
+	retries := 0
+	fn := func() (bool, error) {
+		retries++
+		time.Sleep(1 * time.Millisecond)
+		return true, nil
+	}
+
+	if err := Retry(time.Millisecond*5, time.Millisecond*1, fn); err != nil {
+		assert.Equal(t, retries, 5)
+		assert.Equal(t, err, errors.New(errors.FailedRequestTimeout, nil))
+	}
+}
+
+func TestRetryFNRanBeforeDelay(t *testing.T) {
+	start := time.Now()
+	fn := func() (bool, error) {
+		assert.WithinDuration(t, time.Now(), start, time.Millisecond)
+		time.Sleep(1 * time.Second)
+		return true, nil
+	}
+
+	Retry(time.Millisecond*5, time.Millisecond*1, fn)
+}


### PR DESCRIPTION
**What does this pull request do?**
This adds a common **retry function** in the common repo within the new **utils** package. This will be used to help with eventual consistency in the future, but also is designed to be used in other scenarios. 

**Detals**
- We chose to use channels, so that we can be as true as possible to the desired timeout param. This is represented in the unit tests. 
- Channels can add unwanted complexity and our goal was to keep it simple and readable, please point out anything that doesn't make sense.

**How should this be tested?**
- This can be tested [here](https://play.golang.org/p/7u9lyI0K33j), since there is no current implementation in code.

**Added**
- [x] Unit tests
- [x] Retry function
- [x] Timeout error coded