### PR TITLE
Retry service create

### DIFF
--- a/common/errors/code.go
+++ b/common/errors/code.go
@@ -16,5 +16,5 @@ const (
 	ServiceDoesNotExist      ErrorCode = "ServiceDoesNotExist"
 	TaskDoesNotExist         ErrorCode = "TaskDoesNotExist"
 	UnexpectedError          ErrorCode = "UnexpectedError"
-	FailedRequestTimeout     ErrorCode = "FailedRequestTimeout"
+	EventualConsistencyError ErrorCode = "EventualConsistencyError"
 )


### PR DESCRIPTION
**What does this pull request do?**
Include a short summary of what this PR intends to fix and/or a reference to an existing issue.


**How should this be tested?**
Normally I would say smoketests. However, since `api-refactor` is in a bad state, I just wrote a tiny bash script that calls `l0 loadbalancer create ...` immediately followed by `l0 service create --loadbalancer ...`. The little-to-no delay between the requests should cause the eventual consistency issue to appear, and we should see the api gracefully handle + retry when that occurs. 
Here is an excerpt of my api logs when this happened:
```
2018/03/27 13:01:25 POST /service
2018/03/27 13:01:26 [DEBUG] Failed service create, will retry (InvalidParameterException: Unable to assume role and validate the listeners configured on your load balancer. Please verify that the ECS service role being passed has the proper permissions.
	status code: 400, request id: a1ddde6c-31f9-11e8-8964-430f308b1204)
2018/03/27 13:01:27 [DEBUG] Failed service create, will retry (InvalidParameterException: Unable to assume role and validate the listeners configured on your load balancer. Please verify that the ECS service role being passed has the proper permissions.
	status code: 400, request id: a284ccd3-31f9-11e8-8964-430f308b1204)
2018/03/27 13:01:29 [DEBUG] Failed service create, will retry (InvalidParameterException: Unable to assume role and validate the listeners configured on your load balancer. Please verify that the ECS service role being passed has the proper permissions.
	status code: 400, request id: a32886ee-31f9-11e8-8964-430f308b1204)
2018/03/27 13:01:30 [DEBUG] Failed service create, will retry (InvalidParameterException: Unable to assume role and validate the listeners configured on your load balancer. Please verify that the ECS service role being passed has the proper permissions.
	status code: 400, request id: a3cd2b67-31f9-11e8-8964-430f308b1204)
2018/03/27 13:01:31 [DEBUG] Failed service create, will retry (InvalidParameterException: Unable to assume role and validate the listeners configured on your load balancer. Please verify that the ECS service role being passed has the proper permissions.
	status code: 400, request id: a4721e14-31f9-11e8-8964-430f308b1204)
2018/03/27 13:01:32 [DEBUG] Failed service create, will retry (InvalidParameterException: Unable to assume role and validate the listeners configured on your load balancer. Please verify that the ECS service role being passed has the proper permissions.
	status code: 400, request id: a5187045-31f9-11e8-8964-430f308b1204)
2018/03/27 13:01:33 [DEBUG] Failed service create, will retry (InvalidParameterException: Unable to assume role and validate the listeners configured on your load balancer. Please verify that the ECS service role being passed has the proper permissions.
	status code: 400, request id: a5bcedb0-31f9-11e8-8964-430f308b1204)
2018/03/27 13:01:34 [DEBUG] Failed service create, will retry (InvalidParameterException: Unable to assume role and validate the listeners configured on your load balancer. Please verify that the ECS service role being passed has the proper permissions.
	status code: 400, request id: a665b0d9-31f9-11e8-8964-430f308b1204)
2018/03/27 13:01:35 GET /service/test12c0d3d5
``` 

The corresponding caller's bash script ended with a 0 exit code. 

**Checklist**
- [x] Unit tests
- ~[ ] Smoke tests (if applicable)~
- ~[ ] System tests (if applicable)~
- ~[ ] Documentation (if applicable)~


closes #582 
