### PR TITLE
Add retry logic for lb delete

### DIFF
--- a/api/provider/aws/common.go
+++ b/api/provider/aws/common.go
@@ -280,7 +280,7 @@ func readService(ecsapi ecsiface.ECSAPI, clusterName, serviceID string) (*ecs.Se
 	return output.Services[0], nil
 }
 
-func waitTillSGDeletedFN(ec2api ec2iface.EC2API, securityGroupName string) func() (shouldRetry bool, err error) {
+func waitUntilSGDeletedFN(ec2api ec2iface.EC2API, securityGroupName string) func() (shouldRetry bool, err error) {
 	return func() (shouldRetry bool, err error) {
 		filter := &ec2.Filter{}
 		filter.SetName("group-name")

--- a/api/provider/aws/load_balancer_delete.go
+++ b/api/provider/aws/load_balancer_delete.go
@@ -1,6 +1,7 @@
 package aws
 
 import (
+	"log"
 	"strings"
 	"time"
 
@@ -45,6 +46,7 @@ func (l *LoadBalancerProvider) Delete(loadBalancerID string) error {
 			return false, nil
 		}
 
+		log.Printf("[DEBUG] Load Balancer not deleted, will retry lookup")
 		return true, nil
 	}
 

--- a/api/provider/aws/load_balancer_delete.go
+++ b/api/provider/aws/load_balancer_delete.go
@@ -2,9 +2,14 @@ package aws
 
 import (
 	"strings"
+	"time"
+
+	"github.com/quintilesims/layer0/common/errors"
+	"github.com/quintilesims/layer0/common/retry"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/awserr"
+	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/aws/aws-sdk-go/service/elb"
 	"github.com/aws/aws-sdk-go/service/iam"
 )
@@ -19,6 +24,32 @@ func (l *LoadBalancerProvider) Delete(loadBalancerID string) error {
 
 	if err := l.deleteLoadBalancer(fqLoadBalancerID); err != nil {
 		return err
+	}
+
+	// Check for eventually consistency
+	fnDescribeLB := func() (shouldRetry bool, err error) {
+		input := &elb.DescribeLoadBalancersInput{}
+		input.SetLoadBalancerNames([]*string{aws.String(fqLoadBalancerID)})
+		input.SetPageSize(1)
+
+		output, err := l.AWS.ELB.DescribeLoadBalancers(input)
+		if err != nil {
+			if err, ok := err.(awserr.Error); ok && err.Code() == "LoadBalancerNotFound" {
+				return false, nil
+			}
+
+			return false, err
+		}
+
+		if len(output.LoadBalancerDescriptions) != 1 {
+			return false, nil
+		}
+
+		return true, nil
+	}
+
+	if err := retry.Retry(fnDescribeLB, retry.WithTimeout(time.Second*30), retry.WithDelay(time.Second)); err != nil {
+		return errors.New(errors.EventualConsistencyError, err)
 	}
 
 	roleName := getLoadBalancerRoleName(fqLoadBalancerID)
@@ -42,6 +73,33 @@ func (l *LoadBalancerProvider) Delete(loadBalancerID string) error {
 		if err := deleteSG(l.AWS.EC2, groupID); err != nil {
 			return err
 		}
+	}
+
+	// Check for eventually consistency
+	fnReadSG := func() (shouldRetry bool, err error) {
+		filter := &ec2.Filter{}
+		filter.SetName("group-name")
+		filter.SetValues([]*string{aws.String(securityGroupName)})
+
+		input := &ec2.DescribeSecurityGroupsInput{}
+		input.SetFilters([]*ec2.Filter{filter})
+
+		output, err := l.AWS.EC2.DescribeSecurityGroups(input)
+		if err != nil && !strings.Contains(err.Error(), "does not exist") {
+			return false, err
+		}
+
+		for _, group := range output.SecurityGroups {
+			if aws.StringValue(group.GroupName) == securityGroupName {
+				return true, nil
+			}
+		}
+
+		return false, nil
+	}
+
+	if err := retry.Retry(fnReadSG, retry.WithTimeout(time.Second*30), retry.WithDelay(time.Second)); err != nil {
+		return errors.New(errors.EventualConsistencyError, err)
 	}
 
 	if err := l.deleteTags(loadBalancerID); err != nil {

--- a/api/provider/aws/load_balancer_delete.go
+++ b/api/provider/aws/load_balancer_delete.go
@@ -93,6 +93,7 @@ func (l *LoadBalancerProvider) Delete(loadBalancerID string) error {
 
 		for _, group := range output.SecurityGroups {
 			if aws.StringValue(group.GroupName) == securityGroupName {
+				log.Printf("[DEBUG] Security Group not deleted, will retry lookup")
 				return true, nil
 			}
 		}

--- a/api/provider/aws/load_balancer_delete.go
+++ b/api/provider/aws/load_balancer_delete.go
@@ -27,7 +27,7 @@ func (l *LoadBalancerProvider) Delete(loadBalancerID string) error {
 	}
 
 	// Check for eventually consistency
-	waitTillLBDeletedFN := func() (shouldRetry bool, err error) {
+	waitUntilLBDeletedFN := func() (shouldRetry bool, err error) {
 		input := &elb.DescribeLoadBalancersInput{}
 		input.SetLoadBalancerNames([]*string{aws.String(fqLoadBalancerID)})
 		input.SetPageSize(1)
@@ -44,7 +44,7 @@ func (l *LoadBalancerProvider) Delete(loadBalancerID string) error {
 		return true, nil
 	}
 
-	if err := retry.Retry(waitTillLBDeletedFN, retry.WithTimeout(time.Second*30), retry.WithDelay(time.Second)); err != nil {
+	if err := retry.Retry(waitUntilLBDeletedFN, retry.WithTimeout(time.Second*30), retry.WithDelay(time.Second)); err != nil {
 		return errors.New(errors.EventualConsistencyError, err)
 	}
 
@@ -72,7 +72,7 @@ func (l *LoadBalancerProvider) Delete(loadBalancerID string) error {
 	}
 
 	// Check for eventually consistency
-	fn := waitTillSGDeletedFN(l.AWS.EC2, securityGroupName)
+	fn := waitUntilSGDeletedFN(l.AWS.EC2, securityGroupName)
 	if err := retry.Retry(fn, retry.WithTimeout(time.Second*30), retry.WithDelay(time.Second)); err != nil {
 		return errors.New(errors.EventualConsistencyError, err)
 	}

--- a/api/provider/aws/load_balancer_delete.go
+++ b/api/provider/aws/load_balancer_delete.go
@@ -32,8 +32,7 @@ func (l *LoadBalancerProvider) Delete(loadBalancerID string) error {
 		input.SetLoadBalancerNames([]*string{aws.String(fqLoadBalancerID)})
 		input.SetPageSize(1)
 
-		_, err = l.AWS.ELB.DescribeLoadBalancers(input)
-		if err != nil {
+		if _, err = l.AWS.ELB.DescribeLoadBalancers(input); err != nil {
 			if err, ok := err.(awserr.Error); ok && err.Code() == "LoadBalancerNotFound" {
 				return false, nil
 			}

--- a/api/provider/aws/test_aws/load_balancer_delete_test.go
+++ b/api/provider/aws/test_aws/load_balancer_delete_test.go
@@ -159,11 +159,8 @@ func TestLoadBalancerDeleteRetry(t *testing.T) {
 		}
 	}
 
-	deleteLBInput := &elb.DeleteLoadBalancerInput{}
-	deleteLBInput.SetLoadBalancerName("l0-test-lb_id")
-
 	mockAWS.ELB.EXPECT().
-		DeleteLoadBalancer(deleteLBInput).
+		DeleteLoadBalancer(gomock.Any()).
 		Return(&elb.DeleteLoadBalancerOutput{}, nil)
 
 	lb := &elb.LoadBalancerDescription{}

--- a/api/provider/aws/test_aws/load_balancer_delete_test.go
+++ b/api/provider/aws/test_aws/load_balancer_delete_test.go
@@ -56,7 +56,7 @@ func TestLoadBalancerDelete(t *testing.T) {
 
 	mockAWS.ELB.EXPECT().
 		DescribeLoadBalancers(gomock.Any()).
-		Return(&elb.DescribeLoadBalancersOutput{}, nil)
+		Return(&elb.DescribeLoadBalancersOutput{}, awserr.New("LoadBalancerNotFound", "", nil))
 
 	deleteRolePolicyInput := &iam.DeleteRolePolicyInput{}
 	deleteRolePolicyInput.SetRoleName("l0-test-lb_id-lb")
@@ -104,7 +104,7 @@ func TestLoadBalancerDeleteIdempotence(t *testing.T) {
 
 	mockAWS.ELB.EXPECT().
 		DescribeLoadBalancers(gomock.Any()).
-		Return(&elb.DescribeLoadBalancersOutput{}, nil)
+		Return(&elb.DescribeLoadBalancersOutput{}, awserr.New("LoadBalancerNotFound", "", nil))
 
 	mockAWS.IAM.EXPECT().
 		DeleteRolePolicy(gomock.Any()).
@@ -175,7 +175,8 @@ func TestLoadBalancerDeleteRetry(t *testing.T) {
 			Return(describeLoadBalancersOutput, nil),
 		mockAWS.ELB.EXPECT().
 			DescribeLoadBalancers(gomock.Any()).
-			Return(&elb.DescribeLoadBalancersOutput{}, nil))
+			Return(&elb.DescribeLoadBalancersOutput{}, awserr.New("LoadBalancerNotFound", "", nil)),
+	)
 
 	mockAWS.IAM.EXPECT().
 		DeleteRolePolicy(gomock.Any()).


### PR DESCRIPTION
**What does this pull request do?**
Adds retry logic to lb-delete to handle eventual consistency errors.

### Features
- Retry on loadbalancer describe to verify delete
- Retry on security groups list to verify delete

**Checklist**
- [x] Unit tests

closes #584 