### PR TITLE
594: Fix filter pattern for l0 admin logs to capture more events

### DIFF
--- a/api/provider/aws/admin_logs.go
+++ b/api/provider/aws/admin_logs.go
@@ -9,7 +9,7 @@ import (
 
 func (a *AdminProvider) Logs(tail int, start, end time.Time) ([]models.LogFile, error) {
 	logGroupName := a.Config.LogGroupName()
-	filterPattern := fmt.Sprintf("{ $.userIdentity.sessionContext.sessionIssuer.userName = \"l0-%s-ecs-role\" }", a.Config.Instance())
+	filterPattern := fmt.Sprintf("{ $.userIdentity.sessionContext.sessionIssuer.userName = \"l0-%s-ecs-role\" || $.userIdentity.userName = \"l0-%s-user\" }", a.Config.Instance(), a.Config.Instance())
 
 	return GetLogsFromCloudWatch(a.AWS.CloudWatchLogs, logGroupName, nil, tail, start, end, filterPattern)
 }

--- a/docs-src/docs/reference/cli.md
+++ b/docs-src/docs/reference/cli.md
@@ -28,24 +28,19 @@ Use the `debug` subcommand to view the running version of your Layer0 API server
 l0 admin debug
 ```
 
-### admin sql
-Use the `sql` subcommand to initialize the Layer0 API database.
+### admin logs
+Use the `logs` subcommand to retrieve all CloudTrail logs for your Layer0 instance.
 
 #### Usage
 ```
-l0 admin sql
+l0 admin logs [--start "YYYY-MM-DD HH:MM" | --end "YYYY-MM-DD HH:MM" | 
+    --tail n]
 ```
 
-#### Additional information
-The `sql` subcommand is automatically executed during the Layer0 installation process; we recommend that you do not use this subcommand unless specifically directed to do so.
-
-### admin version
-Use the `version` subcommand to display the current version of the Layer0 API.
-
-#### Usage
-```
-l0 admin version 
-```
+#### Optional arguments
+* `--start "YYYY-MM-DD HH:MM"` - The start of the time range to fetch logs.
+* `--end "YYYY-MM-DD HH:MM"` - The end of the time range to fetch logs.
+* `--tail n` - The number of lines from the end to return.
 
 ---
 
@@ -275,6 +270,25 @@ Use the `list` subcommand to display a list of environments in your instance of 
 ```
 l0 environment list
 ```
+
+### environment logs
+Use the `logs` subcommand to retrieve CloudTrail logs for an existing Layer0 environment.
+
+#### Usage
+```
+l0 environment logs [--start "YYYY-MM-DD HH:MM" | --end "YYYY-MM-DD HH:MM" | 
+    --tail n] environmentName
+```
+
+#### Required parameters
+* `environmentName` - The name of the Layer0 environment for which you want to retrieve CloudTrail logs from.
+
+
+#### Optional arguments
+* `--start "YYYY-MM-DD HH:MM"` - The start of the time range to fetch logs.
+* `--end "YYYY-MM-DD HH:MM"` - The end of the time range to fetch logs.
+* `--tail n` - The number of lines from the end to return.
+
 
 ### environment setmincount
 Use the `setmincount` subcommand to set the minimum number of EC2 instances allowed the environment's autoscaling group.


### PR DESCRIPTION
Closes issue #594 

- Implements a change to the pattern filter that is used for the command `l0 admin logs` to capture more events from the CloudWatch log stream that CloudTrail uses when a Layer0 instance is created.
- Docmentation cleanup: added usage patterns for the commands `l0 admin logs` and `l0 environment logs`

How to test:

Create a new Layer0 instance through `l0-setup`. Execute commands that will create CloudTrail events that were not being captured before (any creates such as CreateService, CreateLoadBalancer, etc will suffice). These CloudTrail events will be keyed on userIdentity.userName = l0-fqdn-user where fqdn is the name of your Layer0 instance.