### PR TITLE
- added helper method to smoke tests to wait for env scale

### DIFF
--- a/api/provider/aws/common.go
+++ b/api/provider/aws/common.go
@@ -302,8 +302,8 @@ func deleteSGWithRetry(ec2api ec2iface.EC2API, securityGroupID string) error {
 	}
 
 	if err := retry.Retry(retrySGDeleteFN,
-		retry.WithTimeout(time.Second*30),
-		retry.WithDelay(time.Second),
+		retry.WithTimeout(time.Second*60),
+		retry.WithDelay(time.Second*5),
 	); err != nil {
 		return errors.New(errors.EventualConsistencyError, err)
 	}

--- a/tests/smoke/common/test_helpers.bash
+++ b/tests/smoke/common/test_helpers.bash
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+waitForEnvironmentToScale() {
+    echo "waiting for environment to reach desired scale"
+
+    # 300 seconds / sleep duration of 5 = 60
+    for value in {1..60}
+    do
+        output=$(l0 -o json environment get env_name | jq '.[0]' | jq '.desired_size == .current_size')
+        if [ "$output" = "true" ]; then
+            echo "current has reached desired scale"
+            break
+        fi
+
+        echo "waiting..."
+        sleep 5
+    done
+}

--- a/tests/smoke/service.bats
+++ b/tests/smoke/service.bats
@@ -27,7 +27,7 @@
 }
 
 @test "update" {
-  l0 service update svc_name_stateful dpl_name_stateful2
+  l0 service update svc_name_stateful dpl_name_stateful2:latest
 }
 
 @test "logs" {

--- a/tests/smoke/task.bats
+++ b/tests/smoke/task.bats
@@ -1,12 +1,15 @@
 #!/usr/bin/env bat
 
+load common/test_helpers
+
 @test "create" {
   l0 environment create --scale 1 env_name
+  waitForEnvironmentToScale env_name
   l0 deploy create ./common/Task_stateful.Dockerrun.aws.json dpl_name_stateful
   l0 deploy create ./common/Task_stateless.Dockerrun.aws.json dpl_name_stateless
   l0 task create env_name tsk_name_stateless dpl_name_stateless:latest
   l0 task create --stateful env_name tsk_name_stateful1 dpl_name_stateful:latest
-  l0 task create --env c1:COMMAND="sleep 1" --env c2:COMMAND="sleep 2" env_name tsk_name_stateful2 dpl_name_stateful:latest
+  l0 task create --env c1:COMMAND="sleep 1" --env c2:COMMAND="sleep 2" --stateful env_name tsk_name_stateful2 dpl_name_stateful:latest
 }
 
 @test "get" {
@@ -31,13 +34,4 @@
   l0 deploy delete dpl_name_stateful:latest
   l0 deploy delete dpl_name_stateless:latest
   l0 environment delete env_name
-}
-
-@test "deploy delete alpine:latest" {
-    l0 deploy delete alpine:latest
-}
-
-# this deletes the remaining service(s), load balancer(s), and task(s)
-@test "environment delete test" {
-    l0 environment delete test
 }


### PR DESCRIPTION
**What does this pull request do?**
Updates Test smoke tests to use helper method so that tasks are created after the cluster has the capacity to create tasks


**How should this be tested?**
Run the following commands:
`bats tasks.bats`
`bats service.bats`


**Checklist**
- ~[ ] Unit tests~
- [x] Smoke tests (if applicable)
- ~[ ] System tests (if applicable)~
- ~[ ] Documentation (if applicable)~


fixes #602