### PR TITLE
update to latest AMI

### DIFF
--- a/setup/module/api/core.tf
+++ b/setup/module/api/core.tf
@@ -178,6 +178,6 @@ data "aws_ami" "windows" {
 
   filter {
     name   = "name"
-    values = ["Windows_Server-2016-English-Full-ECS_Optimized-2018.03.26"]
+    values = ["Windows_Server-2016-English-Full-ECS_Optimized-2018.04.18"]
   }
 }

--- a/setup/module/api/core.tf
+++ b/setup/module/api/core.tf
@@ -164,7 +164,7 @@ data "aws_ami" "linux" {
 
   filter {
     name   = "name"
-    values = ["amzn-ami-2017.09.d-amazon-ecs-optimized"]
+    values = ["amzn-ami-2017.09.l-amazon-ecs-optimized"]
   }
 }
 
@@ -178,6 +178,6 @@ data "aws_ami" "windows" {
 
   filter {
     name   = "name"
-    values = ["Windows_Server-2016-English-Full-ECS_Optimized-2017.11.24"]
+    values = ["Windows_Server-2016-English-Full-ECS_Optimized-2018.03.26"]
   }
 }


### PR DESCRIPTION
**What does this pull request do?**
Updates latest terraform resource lookup to use most recent `name` values for linux, Windows AMIs. 

**Checklist**
- [x] Manual tests


closes #
https://github.com/quintilesims/layer0/issues/607
