### PR TITLE
Add docker repo override feature to layer0

### DIFF
--- a/api/backend/ecs/deploy_manager.go
+++ b/api/backend/ecs/deploy_manager.go
@@ -5,8 +5,10 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/aws/aws-sdk-go/aws"
 	"github.com/quintilesims/layer0/api/backend/ecs/id"
 	"github.com/quintilesims/layer0/common/aws/ecs"
+	"github.com/quintilesims/layer0/common/config"
 	"github.com/quintilesims/layer0/common/errors"
 	"github.com/quintilesims/layer0/common/models"
 )
@@ -78,6 +80,12 @@ func (this *ECSDeployManager) CreateDeploy(deployName string, body []byte) (*mod
 	dockerrun, err := CreateRenderedDockerrun(body)
 	if err != nil {
 		return nil, err
+	}
+
+	// override container images prefixes if override specified
+	for _, c := range dockerrun.ContainerDefinitions {
+		s := config.DockerRepoOverride(aws.StringValue(c.Image))
+		c.Image = &s
 	}
 
 	// deploys for jobs will have the deploy.Family field, but they will match familyName

--- a/api/backend/ecs/deploy_manager_test.go
+++ b/api/backend/ecs/deploy_manager_test.go
@@ -349,7 +349,8 @@ func TestCreateDeploy(t *testing.T) {
 				manager := target.(*ECSDeployManager)
 				manager.CreateDeploy("some_name", dockerrun)
 			},
-		}, {
+		},
+		{
 			Name: "Should marshal dockerrun with placement constraints correctly",
 			Setup: func(reporter *testutils.Reporter, ctrl *gomock.Controller) interface{} {
 				mockDeploy := NewMockECSDeployManager(ctrl)
@@ -371,6 +372,7 @@ func TestCreateDeploy(t *testing.T) {
 						reporter.AssertEqual(*containers[0].Name, "test")
 						reporter.AssertEqual(*volumes[0].Name, "test")
 						reporter.AssertEqual(len(placementConstraints), 1)
+						reporter.AssertEqual(*containers[0].Image, "12345.dkr.ecr.us-west-2.amazonaws.com/test")
 					}).
 					Return(task, nil)
 

--- a/common/config/config.go
+++ b/common/config/config.go
@@ -39,6 +39,7 @@ const (
 	TEST_AWS_TAG_DYNAMO_TABLE = "LAYER0_TEST_AWS_TAG_DYNAMO_TABLE"
 	TEST_AWS_JOB_DYNAMO_TABLE = "LAYER0_TEST_AWS_JOB_DYNAMO_TABLE"
 	AWS_TIME_BETWEEN_REQUESTS = "LAYER0_AWS_TIME_BETWEEN_REQUESTS"
+	DOCKER_REPO_OVERRIDE      = "LAYER0_DOCKER_REPO_OVERRIDE"
 )
 
 // defaults
@@ -253,4 +254,25 @@ func ShouldVerifyVersion() bool {
 	}
 
 	return true
+}
+
+func DockerRepoOverride(image string) string {
+	v := get(DOCKER_REPO_OVERRIDE)
+	overrideMap := map[string]string{}
+	for _, s := range strings.Split(v, ",") {
+		if mapping := strings.Split(s, ":"); len(mapping) == 2 {
+			overrideMap[mapping[0]] = mapping[1]
+		}
+	}
+
+	imageParts := strings.Split(image, "/")
+	if len(imageParts) < 2 {
+		return image
+	}
+
+	if override, ok := overrideMap[imageParts[0]]; ok {
+		return override + "/" + strings.Join(imageParts[1:], "/")
+	}
+
+	return image
 }

--- a/common/config/testing.go
+++ b/common/config/testing.go
@@ -14,6 +14,7 @@ const (
 	TEST_AWS_SERVICE_AMI          = "ami-abc123"
 	TEST_AWS_ECS_ROLE             = "role-abc123"
 	TEST_AWS_KEY_PAIR             = "test-key-pair"
+	TEST_DOCKER_REPO_OVERRIDE     = "quintilesims:12345.dkr.ecr.us-west-2.amazonaws.com"
 )
 
 func SetTestConfig() {
@@ -27,4 +28,5 @@ func SetTestConfig() {
 	os.Setenv(AWS_WINDOWS_SERVICE_AMI, TEST_AWS_SERVICE_AMI)
 	os.Setenv(AWS_ECS_ROLE, TEST_AWS_ECS_ROLE)
 	os.Setenv(AWS_SSH_KEY_PAIR, TEST_AWS_KEY_PAIR)
+	os.Setenv(DOCKER_REPO_OVERRIDE, TEST_DOCKER_REPO_OVERRIDE)
 }

--- a/common/db/job_store/memory.go
+++ b/common/db/job_store/memory.go
@@ -48,7 +48,7 @@ func (m *MemoryJobStore) SelectByID(jobID string) (*models.Job, error) {
 		}
 	}
 
-	return nil, fmt.Errorf("Job with id '%d' does not exist", jobID)
+	return nil, fmt.Errorf("Job with id '%s' does not exist", jobID)
 }
 
 func (m *MemoryJobStore) UpdateJobStatus(jobID string, status types.JobStatus) error {

--- a/docs-src/docs/setup/install.md
+++ b/docs-src/docs/setup/install.md
@@ -117,10 +117,20 @@ These files can be downloaded at any time using the `pull` command (`l0-setup pu
 !!! info "Using a Private Docker Registry"
     **The procedures in this section are optional, but are highly recommended for production use.**
 
-If you require authentication to a private Docker registry, you will need a Docker configuration file present on your machine with access to private repositories (typically located at `~/.docker/config.json`). 
+There are two methods of enabling access to a private docker registry: `docker-repo-override` flag or a docker configuration file.
+
+First method: if you require authentication to a private Docker registry, that uses AWS ECR [d.ims.io](https://github.com/quintilesims/d.ims.io), which internally maps image repository URIs, for example from `d.ims.io/sample/guestbook` to `<aws_account_Id>.dkr.ecr.us-west-2.amazonaws.com/sample/guestbook`, you can specify the `docker-repo-override` during `l0-setup init <instance_name>`.
+
+```
+l0-setup init --docker-repo-override d.ims.io:12345.dkr.ecr.us-west-2.amazonaws.com
+```
+
+This will update any images with `d.ims.io` prefix to the mapped prefix of `12345.dkr.ecr.us-west-2.amazonaws.com`; allowing the ecs-agent (reponsible for pulling images on a container instance), to use its internal authentication mechanism to pull an image from ECR, without needing to provide additional private docker registry authentication.
+
+Second method: if you require authentication to a private Docker registry, you can authenticate via a Docker configuration file present on your machine with access to private repositories (typically located at `~/.docker/config.json`). 
 
 If you don't have a config file yet, you can generate one by running `docker login [registry-address]`. 
-A configuration file will be generated at `~/.docker/config.json`.
+A configuration file will be generated at `~/.docker/config.json`. If you are using a credential helper to store docker logins securely, you will need to disable this temporarily so that the `docker login ...` command will save the credentials in plain-text, in the configuration file.
 
 To add this authentication to your Layer0 instance, run:
 ```

--- a/setup/command/init.go
+++ b/setup/command/init.go
@@ -19,6 +19,10 @@ func (f *CommandFactory) Init() cli.Command {
 				Usage: "path to docker config.json file",
 			},
 			cli.StringFlag{
+				Name:  "docker-repo-override",
+				Usage: "map to an ecr backed docker repository. (e.g. d.ims.io:<account_id>.dkr.ecr.us-west-2.amazonaws.com)",
+			},
+			cli.StringFlag{
 				Name:  "module-source",
 				Usage: instance.INPUT_SOURCE_DESCRIPTION,
 			},
@@ -70,6 +74,10 @@ func (f *CommandFactory) Init() cli.Command {
 
 			if v := c.String("aws-ssh-key-pair"); v != "" {
 				overrides[instance.INPUT_AWS_SSH_KEY_PAIR] = v
+			}
+
+			if v := c.String("docker-repo-override"); v != "" {
+				overrides[instance.INPUT_DOCKER_REPO_OVERRIDE] = v
 			}
 
 			dockerPath := strings.Replace(c.String("docker-path"), "~", homedir.Get(), -1)

--- a/setup/instance/inputs.go
+++ b/setup/instance/inputs.go
@@ -10,16 +10,17 @@ import (
 const LAYER0_MODULE_SOURCE = "github.com/quintilesims/layer0//setup/module"
 
 const (
-	INPUT_SOURCE           = "source"
-	INPUT_LAYER0_VERSION   = "layer0_version"
-	INPUT_AWS_ACCESS_KEY   = "access_key"
-	INPUT_AWS_SECRET_KEY   = "secret_key"
-	INPUT_AWS_REGION       = "region"
-	INPUT_AWS_SSH_KEY_PAIR = "ssh_key_pair"
-	INPUT_USERNAME         = "username"
-	INPUT_PASSWORD         = "password"
-	INPUT_DOCKERCFG        = "dockercfg"
-	INPUT_VPC_ID           = "vpc_id"
+	INPUT_SOURCE               = "source"
+	INPUT_LAYER0_VERSION       = "layer0_version"
+	INPUT_AWS_ACCESS_KEY       = "access_key"
+	INPUT_AWS_SECRET_KEY       = "secret_key"
+	INPUT_AWS_REGION           = "region"
+	INPUT_AWS_SSH_KEY_PAIR     = "ssh_key_pair"
+	INPUT_USERNAME             = "username"
+	INPUT_PASSWORD             = "password"
+	INPUT_DOCKERCFG            = "dockercfg"
+	INPUT_VPC_ID               = "vpc_id"
+	INPUT_DOCKER_REPO_OVERRIDE = "docker_repo_override"
 )
 
 const INPUT_SOURCE_DESCRIPTION = `
@@ -99,6 +100,13 @@ created for you. Existing VPCs must satisfy the following constraints:
 Note that changing this value will destroy and recreate any existing resources.
 `
 
+const INPUT_DOCKER_REPO_OVERRIDE_DESCRIPTION = `
+Docker Repository Override (optional): Allows you to map one repository prefix to another when a
+new layer0 deploy is created. For example, specifiying "d.ims.io:aws.ecr.repo" will update
+all image names for new container definitions, within a task definition. An image like "d.ims.io/guestbook"
+will be updated to "aws.ecr.repo/guestbook"
+`
+
 type ModuleInput struct {
 	Name        string
 	Description string
@@ -175,6 +183,11 @@ var Layer0ModuleInputs = []*ModuleInput{
 	{
 		Name:        INPUT_VPC_ID,
 		Description: INPUT_VPC_ID_DESCRIPTION,
+		prompter:    OptionalStringPrompter,
+	},
+	{
+		Name:        INPUT_DOCKER_REPO_OVERRIDE,
+		Description: INPUT_DOCKER_REPO_OVERRIDE_DESCRIPTION,
 		prompter:    OptionalStringPrompter,
 	},
 }

--- a/setup/module/api/Dockerrun.aws.json
+++ b/setup/module/api/Dockerrun.aws.json
@@ -38,7 +38,8 @@
             { "name": "LAYER0_AWS_SSH_KEY_PAIR", "value": "${ssh_key_pair}" },
             { "name": "LAYER0_AWS_ACCOUNT_ID", "value": "${account_id}" },
             { "name": "LAYER0_API_LOG_LEVEL", "value": "debug" },
-            { "name": "LAYER0_RUNNER_LOG_LEVEL", "value": "debug" }
+            { "name": "LAYER0_RUNNER_LOG_LEVEL", "value": "debug" },
+            { "name": "LAYER0_DOCKER_REPO_OVERRIDE", "value": "${docker_repo_override}" }
         ]
     }
 ]

--- a/setup/module/api/deploy.tf
+++ b/setup/module/api/deploy.tf
@@ -26,5 +26,6 @@ data "template_file" "container_definitions" {
     log_group_name       = "${aws_cloudwatch_log_group.mod.id}"
     dynamo_tag_table     = "${aws_dynamodb_table.tags.id}"
     dynamo_job_table     = "${aws_dynamodb_table.jobs.id}"
+    docker_repo_override = "${var.docker_repo_override}"
   }
 }

--- a/setup/module/api/variables.tf
+++ b/setup/module/api/variables.tf
@@ -33,3 +33,5 @@ variable "group_policies" {
     "s3",
   ]
 }
+
+variable "docker_repo_override" {}

--- a/setup/module/main.tf
+++ b/setup/module/main.tf
@@ -30,8 +30,9 @@ module "api" {
   # todo: format hack is a workaround for https://github.com/hashicorp/terraform/issues/14399
   vpc_id = "${ var.vpc_id == "" ? format("%s", module.vpc.vpc_id) : var.vpc_id }"
 
-  ssh_key_pair = "${var.ssh_key_pair}"
-  dockercfg    = "${var.dockercfg}"
+  ssh_key_pair         = "${var.ssh_key_pair}"
+  dockercfg            = "${var.dockercfg}"
+  docker_repo_override = "${var.docker_repo_override}"
 
   tags {
     "layer0" = "${var.name}"

--- a/setup/module/variables.tf
+++ b/setup/module/variables.tf
@@ -20,3 +20,5 @@ variable "vpc_id" {
   description = "optional - use an empty string to provision a new vpc"
   type        = "string"
 }
+
+variable "docker_repo_override" {}

--- a/tests/clients/layer0_test_client.go
+++ b/tests/clients/layer0_test_client.go
@@ -62,7 +62,7 @@ func (l *Layer0TestClient) CreateLoadBalancer(name, environmentID string) *model
 
 	ports := []models.Port{{HostPort: 80, ContainerPort: 80, Protocol: "http"}}
 
-	loadBalancer, err := l.Client.CreateLoadBalancer(name, environmentID, hc, ports, true)
+	loadBalancer, err := l.Client.CreateLoadBalancer(name, environmentID, hc, ports, true, 60)
 	if err != nil {
 		l.T.Fatal(err)
 	}


### PR DESCRIPTION
**What does this pull request do?**
Adds a new configuration called `docker-repo-override` to l0-setup. This allows the user to specify a mapping of docker image prefixes. For example, the value can be set to: `d.ims.io:12345.dkr.ecr.us-west-2.amazonaws.com`. 

One use case this allows is to allow images to be pulled from an ECR repository without specifying docker credentials.

**How should this be tested?**

1. Create a new l0 instance in a repository other than the carbon account (like the chunnel) with the mapping `d.ims.io:<carbon_aws_account_Id>.dkr.ecr.us-west-2.amazonaws.com`
  (Or you can re-use my instance `seshichunnels`)
2. Create a guestbook deploy
  `l0 deploy create <task definition> guestbook-dpl`
  a. Confirm the deploy correctly replaces the image prefix correctly
  `go run main.go -o json deploy get guestbook-dpl | jq '.[0].dockerrun' -r | base64 -d | jq .`
3. Create a new environment and load balancer 
  `l0 create environment demo-env && l0 loadbalancer create --port 80:80/http demo-env guestbook-lb`
4. Create a service that uses the deploy and load balancer created in the previous steps
  `l0 environment create demo-env`
5. Confirm the service is up and running
  `l0 service create --loadbalancer demo-env:guestbook-lb demo-env guestbook-svc guestbook-dpl:latest`

If the above steps worked, it would've meant that instead of pulling the image via a proxy docker repo frontend (like d.ims.io), the image was pulled directly from ECR by the ecs-agent authenticating using the IAM Role permissions. The image `d.ims.io/quintilesims/guestbook` is also hosted on the carbon account's ECR. So the test confirms that cross-account access will also work.

Notes: An image called `d.ims.io/quintilesims/guestbook:latest` already exists.

You can use the below task definition for step 2:
```
    "AWSEBDockerrunVersion": 2,
    "requiresCompatibilities": [ "EC2" ],
    "containerDefinitions": [
        {
            "name": "guestbook",
            "image": "d.ims.io/quintiles/guestbook",
            "essential": true,
            "memory": 128,
            "portMappings": [
                {
                    "hostPort": 80,
                    "containerPort": 80
                }
            ]
        }
    ]
}
```

**Checklist**
- [x] Unit tests
- ~[ ] Smoke tests (if applicable)~
- ~[ ] System tests (if applicable)~
- [x] Documentation (if applicable)


closes #540 
links https://github.com/quintilesims/d.ims.io/pull/58