### PR TITLE
Fix CPU leak caused by `time.Tick`

### DIFF
--- a/api/main.go
+++ b/api/main.go
@@ -135,7 +135,13 @@ func main() {
 		logrus.Fatal(err)
 	}
 
-	defer provider.Ticker.Stop()
+	rateLimit, err := time.ParseDuration(config.AWSTimeBetweenRequests())
+	if err != nil {
+		logrus.Fatal(err)
+	}
+
+	provider.ResetRateLimiter(rateLimit)
+	defer provider.StopRateLimiter()
 
 	lgc, err := startup.GetLogic(backend)
 	if err != nil {

--- a/api/main.go
+++ b/api/main.go
@@ -11,6 +11,7 @@ import (
 	"github.com/emicklei/go-restful/swagger"
 	"github.com/quintilesims/layer0/api/handlers"
 	"github.com/quintilesims/layer0/api/logic"
+	"github.com/quintilesims/layer0/common/aws/provider"
 	"github.com/quintilesims/layer0/common/config"
 	"github.com/quintilesims/layer0/common/logutils"
 	"github.com/quintilesims/layer0/common/startup"
@@ -133,6 +134,8 @@ func main() {
 	if err != nil {
 		logrus.Fatal(err)
 	}
+
+	defer provider.Ticker.Stop()
 
 	lgc, err := startup.GetLogic(backend)
 	if err != nil {

--- a/common/aws/provider/connection.go
+++ b/common/aws/provider/connection.go
@@ -2,10 +2,8 @@ package provider
 
 import (
 	"fmt"
-	"time"
 
 	"github.com/aws/aws-sdk-go/aws/credentials"
-	"github.com/aws/aws-sdk-go/aws/request"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/autoscaling"
 	"github.com/aws/aws-sdk-go/service/cloudformation"
@@ -73,15 +71,6 @@ var getConfig = func(credProvider CredProvider, region string) (sess *session.Se
 
 	creds := credentials.NewStaticCredentials(access_key, secret_key, "")
 	sess = session.New(config.GetAWSConfig(creds, config.AWSRegion()))
-	delay, err := time.ParseDuration(config.AWSTimeBetweenRequests())
-	if err != nil {
-		return
-	}
-
-	ticker := time.Tick(delay)
-	sess.Handlers.Send.PushBack(func(r *request.Request) {
-		<-ticker
-	})
 
 	return
 }

--- a/common/aws/provider/connection.go
+++ b/common/aws/provider/connection.go
@@ -67,8 +67,6 @@ func init() {
 }
 
 var getConfig = func(credProvider CredProvider, region string) (sess *session.Session, err error) {
-	fmt.Printf("getConfig called with %v and %v\n", credProvider, region)
-	fmt.Printf("ticker: %v\n", Ticker)
 	if !regionIsValid(region) {
 		err = fmt.Errorf("Region '%s' is not a valid region!", region)
 		return

--- a/common/aws/provider/connection.go
+++ b/common/aws/provider/connection.go
@@ -55,7 +55,7 @@ var regionIsValid = func(region string) (isValid bool) {
 	return
 }
 
-var ticker *time.Ticker
+var Ticker *time.Ticker
 
 func init() {
 	delay, err := time.ParseDuration(config.AWSTimeBetweenRequests())
@@ -63,12 +63,12 @@ func init() {
 		return
 	}
 
-	ticker = time.NewTicker(delay)
+	Ticker = time.NewTicker(delay)
 }
 
 var getConfig = func(credProvider CredProvider, region string) (sess *session.Session, err error) {
 	fmt.Printf("getConfig called with %v and %v\n", credProvider, region)
-	fmt.Printf("ticker: %v\n", ticker)
+	fmt.Printf("ticker: %v\n", Ticker)
 	if !regionIsValid(region) {
 		err = fmt.Errorf("Region '%s' is not a valid region!", region)
 		return
@@ -87,7 +87,7 @@ var getConfig = func(credProvider CredProvider, region string) (sess *session.Se
 	creds := credentials.NewStaticCredentials(access_key, secret_key, "")
 	sess = session.New(config.GetAWSConfig(creds, config.AWSRegion()))
 	sess.Handlers.Send.PushBack(func(r *request.Request) {
-		<-ticker.C
+		<-Ticker.C
 	})
 
 	return

--- a/common/aws/provider/connection.go
+++ b/common/aws/provider/connection.go
@@ -55,15 +55,17 @@ var regionIsValid = func(region string) (isValid bool) {
 	return
 }
 
-var Ticker *time.Ticker
+const DefaultRateLimit = time.Millisecond * 200
 
-func init() {
-	delay, err := time.ParseDuration(config.AWSTimeBetweenRequests())
-	if err != nil {
-		return
-	}
+var rateLimiter = time.NewTicker(DefaultRateLimit)
 
-	Ticker = time.NewTicker(delay)
+func ResetRateLimiter(rate time.Duration) {
+	rateLimiter.Stop()
+	rateLimiter = time.NewTicker(rate)
+}
+
+func StopRateLimiter() {
+	rateLimiter.Stop()
 }
 
 var getConfig = func(credProvider CredProvider, region string) (sess *session.Session, err error) {
@@ -85,7 +87,7 @@ var getConfig = func(credProvider CredProvider, region string) (sess *session.Se
 	creds := credentials.NewStaticCredentials(access_key, secret_key, "")
 	sess = session.New(config.GetAWSConfig(creds, config.AWSRegion()))
 	sess.Handlers.Send.PushBack(func(r *request.Request) {
-		<-Ticker.C
+		<-rateLimiter.C
 	})
 
 	return

--- a/common/aws/provider/connection.go
+++ b/common/aws/provider/connection.go
@@ -54,6 +54,7 @@ var regionIsValid = func(region string) (isValid bool) {
 }
 
 var getConfig = func(credProvider CredProvider, region string) (sess *session.Session, err error) {
+	fmt.Printf("getConfig called with %v and %v\n", credProvider, region)
 	if !regionIsValid(region) {
 		err = fmt.Errorf("Region '%s' is not a valid region!", region)
 		return

--- a/runner/main.go
+++ b/runner/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"os"
 	"strings"
+	"time"
 
 	"github.com/Sirupsen/logrus"
 	"github.com/quintilesims/layer0/common/aws/provider"
@@ -96,7 +97,13 @@ func Run(c *cli.Context) {
 		log.Fatal(err)
 	}
 
-	defer provider.Ticker.Stop()
+	rateLimit, err := time.ParseDuration(config.AWSTimeBetweenRequests())
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	provider.ResetRateLimiter(rateLimit)
+	defer provider.StopRateLimiter()
 
 	logic, err := startup.GetLogic(backend)
 	if err != nil {

--- a/runner/main.go
+++ b/runner/main.go
@@ -96,6 +96,8 @@ func Run(c *cli.Context) {
 		log.Fatal(err)
 	}
 
+	defer provider.Ticker.Stop()
+
 	logic, err := startup.GetLogic(backend)
 	if err != nil {
 		log.Fatal(err)


### PR DESCRIPTION
# What does this pull request do?

`layer0/common/aws/provider/connection.go` contained code for a ticker intended to provide a rate limit for the `l0-api`. However, this resulted in infinitely-growing CPU usage on the AWS instance because:
- A new ticker would be created every time `connection.go::getConfig()` was called
- Using `time.Tick()` instead of `time.NewTicker()` yielded only the ticker - it did not yield a mechanism by which to terminate the ticker.

This PR replaces `time.Tick()` with `time.NewTicker()` in order to obtain the mechanism by which a ticker can be stopped. The ticker - henceforth referred to as the rate limiter - is initialized with a default `time.Duration` value, and control of the rate limiter is passed to outside packages by way of public functions. `api/main.go` and `runner/main.go` now handle the call to `time.ParseDuration()` so that they can return usefully (instead of causing a panic down the line if `time.NewTicker()` is called with `nil`), and they also contain `defer provider.StopRateLimiter()` to make sure that they don't leave dangling resources.


# How should this be tested?

## 1. Deploy
Deploy a new new Layer0 instance with `l0-setup`.
- Source: `github.com/quintilesims/layer0//setup/module?ref=620-api-cpu-utilization`
- Version: `tlake620`
- Key Pair: `xfra-dev`, or whatever key pair you use (necessary if you want to monitor the instance with SSH and htop)

## 2. Monitor
Use one or both methods below to monitor CPU usage of the instance. You can try hammering it with a lot of tasks (`for n in {1..999} ; do echo iter ${n}: $(l0 task create ENVIRONMENT task${n} DEPLOY) ; done`) or services or something. In any event, the CPU should respond accordingly, but - and here's the key - it should always return to consuming barely anything when idle.

If you were to deploy an API of v0.10.4-v0.10.8 and monitored it the same way, you would see the CPU usage floor of an idle API gradually increasing with time; it would grow faster the more AWS calls it had to make.

### AWS Console
- Find the Layer0 API cluster in ECS
- Metrics tab
- CPUUtilization

### SSH and htop
- Modify the Load Balancer for the Layer0 API Service
    - Add a 22:22/TCP listener
    - Add a rule to the Load Balancer's Security Group which allows SSH (port 22) traffic from anywhere
- Run `ssh -i path/to/key-pair.pem ec2-user@${LAYER0_API_ENDPOINT} -o serveraliveinterval=30`
- Run `sudo yum install -y htop`
- Run `htop`
    - Press `F4` and enter `l0` to filter out processes which aren't things like `l0-api` and `l0-runner`

## Some charts
Three-day CPU usage of Layer0 API in v0.10.8:

<img width="920" alt="Three-day CPU usage of Layer0 API in v0.10.8" src="https://user-images.githubusercontent.com/5035800/41677008-01c15b66-747c-11e8-85c5-7635e86d0158.png">

Three-day CPU usage of Layer0 API with these changes:

<img width="920" alt="Three-day CPU usage of Layer0 API with these changes" src="https://user-images.githubusercontent.com/5035800/41677016-03009c1c-747c-11e8-8e97-3415bf7c13e2.png">



# Checklist

- ~[ ] Unit tests~
- ~[ ] Smoke tests (if applicable)~
- ~[ ] System tests (if applicable)~
- ~[ ] Documentation (if applicable)~

_I'm actually not sure how best to test this particular behavior, if there's a good way to test it at all._


# Issues

Closes #620.