### PR TITLE
use home dir for terraform plugin

### DIFF
--- a/docs-src/docs/reference/terraform-plugin.md
+++ b/docs-src/docs/reference/terraform-plugin.md
@@ -12,7 +12,7 @@ This provider allows users to create, manage, and update Layer0 entities using T
 ## Install
 Download a Layer0 v0.8.4+ [release](/releases).
 The Terraform plugin binary is located in the release zip file as `terraform-provider-layer0`.
-Copy this `terraform-provider-layer0` binary into the same directory as your Terraform binary - and you're done!
+Copy this `terraform-provider-layer0` binary into `~/.terraform.d/plugins/` - and you're done!
 
 For further information, see Terraform's documentation on installing a Terraform plugin [here](https://www.terraform.io/docs/plugins/basics.html#installing-a-plugin).
 


### PR DESCRIPTION
`~/.terraform.d/plugins` rather than arbitrary install directory

**What does this pull request do?**
Update the docs page to help better with the terraform plugin installation.

**How should this be tested?**
Try the instructions now :)


**Checklist**
- [ ] ~Unit tests~
- [ ] ~Smoke tests (if applicable)~
- [ ] ~System tests (if applicable)~
- [X] Documentation (if applicable)


closes #
No related issue.