### PR TITLE
Capping AWS provider to pre-2.0 versions

### DIFF
--- a/setup/module/main.tf
+++ b/setup/module/main.tf
@@ -1,4 +1,5 @@
 provider "aws" {
+  version    = ">= 1.0.0, < 2.0.0"
   access_key = "${var.access_key}"
   secret_key = "${var.secret_key}"
   region     = "${var.region}"


### PR DESCRIPTION
**What does this pull request do?**
The AWS 2.0+ providers are not compatible with Layer0's `l0-setup`. This change caps the provider at pre-2.0 versions.


**How should this be tested?**
Run `l0-setup` to completion. There should be no terraform validation errors.


**Checklist**
N/A on all
- [ ] Unit tests
- [ ] Smoke tests (if applicable)
- [ ] System tests (if applicable)
- [ ] Documentation (if applicable)


closes #
https://github.com/quintilesims/layer0/issues/632
