### PR TITLE
652 - Bump L0 API instance to t3.small

### DIFF
--- a/setup/module/api/environment.tf
+++ b/setup/module/api/environment.tf
@@ -35,7 +35,7 @@ data "template_file" "user_data" {
 resource "aws_launch_configuration" "api" {
   name_prefix          = "l0-${var.name}-api-"
   image_id             = "${data.aws_ami.linux.id}"
-  instance_type        = "t2.small"
+  instance_type        = "t3.small"
   security_groups      = ["${aws_security_group.api_env.id}"]
   iam_instance_profile = "${aws_iam_instance_profile.ecs.id}"
   user_data            = "${data.template_file.user_data.rendered}"


### PR DESCRIPTION
**What does this pull request do?**
Fixes #652 

**How should this be tested?**
Build `l0-setup` and run the following against the preprod AWS account:
```
./l0-setup init --docker-path=/path/to/my/docker_config uswest2dev
./l0-setup plan uswest2dev > ~/plan.log
./l0-setup apply uswest2dev
./l0-setup destroy uswest2dev
```

NOTE: For `init`, you need to point to the following module on your machine, e.g. `/Users/<myusername>/go/src/github.com/quintilesims/layer0/setup/module`

This has been tested as specified above and successfully created the L0 API.

**Checklist**
- [ x] Unit tests
- [ ] Smoke tests (if applicable)
- [ ] System tests (if applicable)
- [ ] Documentation (if applicable)


closes #652 
