### PR TITLE
ecs service ARN update ,fixed OCEMCM-9665.

### DIFF
--- a/common/aws/ecs/ecs.go
+++ b/common/aws/ecs/ecs.go
@@ -769,8 +769,8 @@ func (this *ECS) ListClusterServiceNames(clusterName, prefix string) ([]string, 
 	fn := func(output *ecs.ListServicesOutput, lastPage bool) bool {
 		for _, serviceARN := range output.ServiceArns {
 			// sample service ARN:
-			// arn:aws:ecs:us-west-2:856306994068:service/l0-tlakedev-guestbo80d9d
-			serviceName := strings.Split(aws.StringValue(serviceARN), "/")[1]
+			// arn:aws:ecs:us-west-2:064627975291:service/l0-v12102-Develop81116/l0-v12102-Develope8871
+			serviceName := strings.Split(aws.StringValue(serviceARN), "/")[2]
 			if strings.HasPrefix(serviceName, prefix) {
 				serviceNames = append(serviceNames, serviceName)
 			}

--- a/setup/module/api/core.tf
+++ b/setup/module/api/core.tf
@@ -112,7 +112,7 @@ data "aws_ami" "linux" {
 
   filter {
     name   = "name"
-    values = ["amzn-ami-2018.03.20200813-amazon-ecs-optimized"]
+    values = ["amzn-ami-2018.03.20201130-amazon-ecs-optimized"]
   }
 }
 


### PR DESCRIPTION

Include a fix to OCEMCM-9665, update the new ARN format of ECS services
