### PR TITLE
OCEMCM-11036

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,4 +32,4 @@ stresstest:
 systemtest:
 	$(MAKE) -C tests/system test
 
-.PHONY: release unittest smoketest stresstest systemtest build
+.PHONY: release unittest smoketest stresstest systemtest

--- a/Makefile
+++ b/Makefile
@@ -15,6 +15,13 @@ release:
 		cd build/ && zip -r $$os.zip $$os && cd .. ; \
 	done
 
+build:
+	$(MAKE) -C api build
+	$(MAKE) -C cli build
+	$(MAKE) -C runner build
+	$(MAKE) -C setup build
+	$(MAKE) -C plugins/terraform build
+
 unittest:
 	$(MAKE) -C api test
 	$(MAKE) -C cli test
@@ -32,4 +39,4 @@ stresstest:
 systemtest:
 	$(MAKE) -C tests/system test
 
-.PHONY: release unittest smoketest stresstest systemtest
+.PHONY: release unittest smoketest stresstest systemtest build

--- a/Makefile
+++ b/Makefile
@@ -15,13 +15,6 @@ release:
 		cd build/ && zip -r $$os.zip $$os && cd .. ; \
 	done
 
-build:
-	$(MAKE) -C api build
-	$(MAKE) -C cli build
-	$(MAKE) -C runner build
-	$(MAKE) -C setup build
-	$(MAKE) -C plugins/terraform build
-
 unittest:
 	$(MAKE) -C api test
 	$(MAKE) -C cli test

--- a/api/logic/job_logic.go
+++ b/api/logic/job_logic.go
@@ -168,9 +168,11 @@ func (this *L0JobLogic) createJobDeploy(jobID string) (*models.Deploy, error) {
 
 	context := struct {
 		RunnerVersionTag string
+		DockerRegistry string
 		Variables        []struct{ Key, Val string }
 	}{
 		RunnerVersionTag: config.RunnerVersionTag(),
+		DockerRegistry: config.DockerRegistry(),
 		Variables: []struct{ Key, Val string }{
 			{
 				Key: config.JOB_ID,
@@ -243,7 +245,7 @@ var jobDockerrun string = `
     "containerDefinitions": [
         {
             "name": "l0-job",
-            "image": "quintilesims/l0-runner:{{ .RunnerVersionTag }}",
+            "image": "{{ .DockerRegistry }}/l0-runner:{{ .RunnerVersionTag }}",
             "essential": true,
             "memory": 64,
             "environment": [

--- a/common/config/config.go
+++ b/common/config/config.go
@@ -92,7 +92,6 @@ var RequiredAPIVariables = []string{
 	AWS_LINUX_SERVICE_AMI,
 	AWS_WINDOWS_SERVICE_AMI,
 	AWS_REGION,
-	DOCKER_REGISTRY,
 }
 
 var RequiredCLIVariables = []string{}
@@ -103,7 +102,6 @@ var RequiredRunnerVariables = []string{
 	AWS_VPC_ID,
 	AWS_PRIVATE_SUBNETS,
 	AWS_PUBLIC_SUBNETS,
-	DOCKER_REGISTRY,
 }
 
 func Validate(required []string) error {

--- a/common/config/config.go
+++ b/common/config/config.go
@@ -39,6 +39,7 @@ const (
 	TEST_AWS_TAG_DYNAMO_TABLE = "LAYER0_TEST_AWS_TAG_DYNAMO_TABLE"
 	TEST_AWS_JOB_DYNAMO_TABLE = "LAYER0_TEST_AWS_JOB_DYNAMO_TABLE"
 	AWS_TIME_BETWEEN_REQUESTS = "LAYER0_AWS_TIME_BETWEEN_REQUESTS"
+	DOCKER_REGISTRY           = "LAYER0_DOCKER_REGISTRY"
 )
 
 // defaults
@@ -91,6 +92,7 @@ var RequiredAPIVariables = []string{
 	AWS_LINUX_SERVICE_AMI,
 	AWS_WINDOWS_SERVICE_AMI,
 	AWS_REGION,
+	DOCKER_REGISTRY,
 }
 
 var RequiredCLIVariables = []string{}
@@ -101,6 +103,7 @@ var RequiredRunnerVariables = []string{
 	AWS_VPC_ID,
 	AWS_PRIVATE_SUBNETS,
 	AWS_PUBLIC_SUBNETS,
+	DOCKER_REGISTRY,
 }
 
 func Validate(required []string) error {
@@ -172,6 +175,11 @@ func AWSSecretKey() string {
 func AWSRegion() string {
 	return get(AWS_REGION)
 }
+
+func DockerRegistry() string {
+	return get(DOCKER_REGISTRY)
+}
+
 
 func AWSVPCID() string {
 	return get(AWS_VPC_ID)

--- a/setup/command/init.go
+++ b/setup/command/init.go
@@ -42,6 +42,10 @@ func (f *CommandFactory) Init() cli.Command {
 				Name:  "aws-ssh-key-pair",
 				Usage: instance.INPUT_AWS_SSH_KEY_PAIR_DESCRIPTION,
 			},
+			cli.StringFlag{
+				Name:  "docker-registry",
+				Usage: instance.INPUT_DOCKER_REGISTRY_DESCRIPTION,
+			},
 		},
 		Action: func(c *cli.Context) error {
 			args, err := extractArgs(c.Args(), "NAME")
@@ -70,6 +74,10 @@ func (f *CommandFactory) Init() cli.Command {
 
 			if v := c.String("aws-ssh-key-pair"); v != "" {
 				overrides[instance.INPUT_AWS_SSH_KEY_PAIR] = v
+			}
+
+			if v := c.String("docker-registry"); v != "" {
+				overrides[instance.INPUT_DOCKER_REGISTRY] = v
 			}
 
 			dockerPath := strings.Replace(c.String("docker-path"), "~", homedir.Get(), -1)

--- a/setup/instance/inputs.go
+++ b/setup/instance/inputs.go
@@ -20,6 +20,7 @@ const (
 	INPUT_PASSWORD         = "password"
 	INPUT_DOCKERCFG        = "dockercfg"
 	INPUT_VPC_ID           = "vpc_id"
+	INPUT_DOCKER_REGISTRY  = "docker_registry"
 )
 
 const INPUT_SOURCE_DESCRIPTION = `
@@ -98,6 +99,11 @@ created for you. Existing VPCs must satisfy the following constraints:
 
 Note that changing this value will destroy and recreate any existing resources.
 `
+const INPUT_DOCKER_REGISTRY_DESCRIPTION = `
+Docker registory (optional): The registory (domain, eg: d.ims.io/layer0) from where the layer0 
+pulls the image
+
+`
 
 type ModuleInput struct {
 	Name        string
@@ -175,6 +181,12 @@ var Layer0ModuleInputs = []*ModuleInput{
 	{
 		Name:        INPUT_VPC_ID,
 		Description: INPUT_VPC_ID_DESCRIPTION,
+		prompter:    OptionalStringPrompter,
+	},
+	{
+		Name:        INPUT_DOCKER_REGISTRY,
+		Default:     "quintilesims",
+		Description: INPUT_DOCKER_REGISTRY_DESCRIPTION,
 		prompter:    OptionalStringPrompter,
 	},
 }

--- a/setup/instance/inputs.go
+++ b/setup/instance/inputs.go
@@ -100,7 +100,7 @@ created for you. Existing VPCs must satisfy the following constraints:
 Note that changing this value will destroy and recreate any existing resources.
 `
 const INPUT_DOCKER_REGISTRY_DESCRIPTION = `
-Docker registory (optional): The registory (domain, eg: d.ims.io/layer0) from where the layer0 
+Docker registry (optional): The container registry (domain/layer0, eg: d.ims.io/layer0) from where the layer0 
 pulls the image
 
 `

--- a/setup/module/api/Dockerrun.aws.json
+++ b/setup/module/api/Dockerrun.aws.json
@@ -1,7 +1,7 @@
 [
     {
         "name": "api",
-        "image": "quintilesims/l0-api:${layer0_version}",
+        "image": "${docker_registry}/l0-api:${layer0_version}",
         "essential": true,
         "memory": 500,
         "portMappings": [
@@ -37,6 +37,7 @@
             { "name": "LAYER0_AWS_ECS_ROLE", "value": "${ecs_role}" },
             { "name": "LAYER0_AWS_SSH_KEY_PAIR", "value": "${ssh_key_pair}" },
             { "name": "LAYER0_AWS_ACCOUNT_ID", "value": "${account_id}" },
+            { "name": "LAYER0_DOCKER_REGISTRY", "value": "${docker_registry}" },
             { "name": "LAYER0_API_LOG_LEVEL", "value": "debug" },
             { "name": "LAYER0_RUNNER_LOG_LEVEL", "value": "debug" }
         ]

--- a/setup/module/api/deploy.tf
+++ b/setup/module/api/deploy.tf
@@ -26,5 +26,6 @@ data "template_file" "container_definitions" {
     log_group_name       = "${aws_cloudwatch_log_group.mod.id}"
     dynamo_tag_table     = "${aws_dynamodb_table.tags.id}"
     dynamo_job_table     = "${aws_dynamodb_table.jobs.id}"
+    docker_registry      = "${var.docker_registry}"
   }
 }

--- a/setup/module/api/variables.tf
+++ b/setup/module/api/variables.tf
@@ -8,6 +8,8 @@ variable "layer0_version" {}
 
 variable "vpc_id" {}
 
+variable "docker_registry" {}
+
 variable "username" {}
 
 variable "password" {}

--- a/setup/module/main.tf
+++ b/setup/module/main.tf
@@ -27,6 +27,7 @@ module "api" {
   layer0_version = "${var.layer0_version}"
   username       = "${var.username}"
   password       = "${var.password}"
+  docker_registry = "${var.docker_registry}"
 
   # todo: format hack is a workaround for https://github.com/hashicorp/terraform/issues/14399
   vpc_id = "${ var.vpc_id == "" ? format("%s", module.vpc.vpc_id) : var.vpc_id }"

--- a/setup/module/variables.tf
+++ b/setup/module/variables.tf
@@ -20,3 +20,9 @@ variable "vpc_id" {
   description = "optional - use an empty string to provision a new vpc"
   type        = "string"
 }
+
+variable "docker_registry" {
+  description = "optional - use an empty string to use dockerhub"
+  type        = "string"
+  default     = "quintilesims"
+}


### PR DESCRIPTION
**What does this pull request do?**
Introduce an optional docker-registry configuration for layer0-api, where a custom registry could be configured during the deploy, which will be used to pull the layer0 images. (dockerhub is used as the default docker registry location)

**How should this be tested?**
Layer0-api is running OK (using both default and custom docker-registry)
Layer0-jobs are pulling the container images from the intended docker-registry
