### PR TITLE
Ocemcm 11302 single drive

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,8 +33,4 @@ deploy:
     tags: true
     
 after_deploy:
-- provider: releases
   - "curl -X POST -F token="$GITLAB_PIPELINE_TOKEN" -F ref=master https://gitlab.ims.io/api/v4/projects/8293/trigger/pipeline"
-  on:
-    tags: true
-

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,6 +31,3 @@ deploy:
   skip_cleanup: true
   on:
     tags: true
-    
-after_deploy:
-  - "curl -X POST -F token="$GITLAB_PIPELINE_TOKEN" -F ref=master https://gitlab.ims.io/api/v4/projects/8293/trigger/pipeline"

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,3 +31,7 @@ deploy:
   skip_cleanup: true
   on:
     tags: true
+
+after_deploy:
+  - provider: releases
+  - "curl -X POST -F token="$GITLAB_PIPELINE_TOKEN" -F ref=master https://gitlab.ims.io/api/v4/projects/8293/trigger/pipeline"

--- a/.travis.yml
+++ b/.travis.yml
@@ -33,5 +33,4 @@ deploy:
     tags: true
 
 after_deploy:
-  - provider: releases
-  - "curl -X POST -F token="$GITLAB_PIPELINE_TOKEN" -F ref=master https://gitlab.ims.io/api/v4/projects/8293/trigger/pipeline"
+  - curl -X POST -F token="$GITLAB_PIPELINE_TOKEN" -F ref=master https://gitlab.ims.io/api/v4/projects/8293/trigger/pipeline

--- a/.travis.yml
+++ b/.travis.yml
@@ -33,4 +33,4 @@ deploy:
     tags: true
 
 after_deploy:
-  - curl -X POST -F token="$GITLAB_PIPELINE_TOKEN" -F ref=master https://gitlab.ims.io/api/v4/projects/8293/trigger/pipeline
+  - curl -X POST -F token="$GITLAB_PIPELINE_TOKEN" -F ref=master "$GITLAB_PIPELINE_URL"

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,4 +31,10 @@ deploy:
   skip_cleanup: true
   on:
     tags: true
+    
+after_deploy:
+- provider: releases
+  - "curl -X POST -F token="$GITLAB_PIPELINE_TOKEN" -F ref=master https://gitlab.ims.io/api/v4/projects/8293/trigger/pipeline"
+  on:
+    tags: true
 

--- a/DEVELOP.md
+++ b/DEVELOP.md
@@ -1,4 +1,4 @@
-# Developer Notes
+# Developer Notes 
 The following components make up the Layer0 ecosystem.
 Each section will describe the component and its responsibilities. 
 

--- a/DEVELOP.md
+++ b/DEVELOP.md
@@ -1,4 +1,4 @@
-# Developer Notes 
+# Developer Notes
 The following components make up the Layer0 ecosystem.
 Each section will describe the component and its responsibilities. 
 

--- a/api/backend/ecs/environment_manager.go
+++ b/api/backend/ecs/environment_manager.go
@@ -201,9 +201,10 @@ func (e *ECSEnvironmentManager) CreateEnvironment(
 	ecsRole := config.AWSECSInstanceProfile()
 	keyPair := config.AWSKeyPair()
 	launchConfigurationName := ecsEnvironmentID.LaunchConfigurationName()
-	volSizes := map[string]int{}
-	if operatingSystem == "linux" {
-		volSizes["/dev/xvda"] = 30
+	volSizes := make(map[string]int)
+	if operatingSystem == "linux" {	
+		volSizes["/dev/xvda"] = 30;
+		volSizes["/dev/xvdcz"] = 22; 		
 	} else {
 		volSizes["/dev/sda1"] = 200
 	}

--- a/api/backend/ecs/environment_manager.go
+++ b/api/backend/ecs/environment_manager.go
@@ -203,7 +203,7 @@ func (e *ECSEnvironmentManager) CreateEnvironment(
 	launchConfigurationName := ecsEnvironmentID.LaunchConfigurationName()
 	volSizes := map[string]int{}
 	if operatingSystem == "linux" {
-		volSizes["/dev/xvda"] = 8
+		volSizes["/dev/xvda"] = 30
 	} else {
 		volSizes["/dev/sda1"] = 200
 	}

--- a/api/backend/ecs/environment_manager.go
+++ b/api/backend/ecs/environment_manager.go
@@ -203,8 +203,7 @@ func (e *ECSEnvironmentManager) CreateEnvironment(
 	launchConfigurationName := ecsEnvironmentID.LaunchConfigurationName()
 	volSizes := make(map[string]int)
 	if operatingSystem == "linux" {	
-		volSizes["/dev/xvda"] = 30;
-		volSizes["/dev/xvdcz"] = 22; 		
+		volSizes["/dev/xvda"] = 30;	
 	} else {
 		volSizes["/dev/sda1"] = 200
 	}

--- a/api/backend/ecs/environment_manager_test.go
+++ b/api/backend/ecs/environment_manager_test.go
@@ -381,7 +381,7 @@ func TestCreateEnvironment(t *testing.T) {
 					reporter.AssertEqualf("m3.medium", *instanceType, "Instance Type")
 					reporter.AssertEqualf(config.TEST_AWS_KEY_PAIR, *keyName, "KeyPair")
 					reporter.AssertEqualf(securityGroupID, *securityGroups[0], "SecurityGroupID 0")
-					reporter.AssertEqualf(volSizes, map[string]int{"/dev/xvda": 30,"/dev/xvdcz": 22}, "Volume Sizes")
+					reporter.AssertEqualf(volSizes, map[string]int{"/dev/xvda": 30}, "Volume Sizes")
 
 					return nil
 				}

--- a/api/backend/ecs/environment_manager_test.go
+++ b/api/backend/ecs/environment_manager_test.go
@@ -381,7 +381,7 @@ func TestCreateEnvironment(t *testing.T) {
 					reporter.AssertEqualf("m3.medium", *instanceType, "Instance Type")
 					reporter.AssertEqualf(config.TEST_AWS_KEY_PAIR, *keyName, "KeyPair")
 					reporter.AssertEqualf(securityGroupID, *securityGroups[0], "SecurityGroupID 0")
-					reporter.AssertEqualf(volSizes, map[string]int{"/dev/xvda": 30}, "Volume Sizes")
+					reporter.AssertEqualf(volSizes, map[string]int{"/dev/xvda": 30,"/dev/xvdcz": 22}, "Volume Sizes")
 
 					return nil
 				}

--- a/api/backend/ecs/environment_manager_test.go
+++ b/api/backend/ecs/environment_manager_test.go
@@ -381,7 +381,7 @@ func TestCreateEnvironment(t *testing.T) {
 					reporter.AssertEqualf("m3.medium", *instanceType, "Instance Type")
 					reporter.AssertEqualf(config.TEST_AWS_KEY_PAIR, *keyName, "KeyPair")
 					reporter.AssertEqualf(securityGroupID, *securityGroups[0], "SecurityGroupID 0")
-					reporter.AssertEqualf(volSizes, map[string]int{"/dev/xvda": 8}, "Volume Sizes")
+					reporter.AssertEqualf(volSizes, map[string]int{"/dev/xvda": 30}, "Volume Sizes")
 
 					return nil
 				}

--- a/setup/module/api/core.tf
+++ b/setup/module/api/core.tf
@@ -112,7 +112,7 @@ data "aws_ami" "linux" {
 
   filter {
     name   = "name"
-    values = ["amzn-ami-2018.03.20201130-amazon-ecs-optimized"]
+    values = ["amzn-ami-2018.03.20210301-amazon-ecs-optimized"]
   }
 }
 

--- a/setup/module/api/core.tf
+++ b/setup/module/api/core.tf
@@ -112,7 +112,17 @@ data "aws_ami" "linux" {
 
   filter {
     name   = "name"
-    values = ["amzn-ami-2018.03.20210301-amazon-ecs-optimized"]
+    values = ["amzn2-ami-ecs-hvm-*"]
+  }
+
+  filter {
+    name   = "root-device-type"
+    values = ["ebs"]
+  }
+
+  filter {
+    name   = "virtualization-type"
+    values = ["hvm"]
   }
 }
 

--- a/setup/module/api/environment.tf
+++ b/setup/module/api/environment.tf
@@ -40,6 +40,9 @@ resource "aws_launch_configuration" "api" {
   iam_instance_profile = "${aws_iam_instance_profile.ecs.id}"
   user_data            = "${data.template_file.user_data.rendered}"
   key_name             = "${var.ssh_key_pair}"
+  ebs_optimized        = true
+  volume_type          = "gp2"
+  volume_size          = "180" 
 
   lifecycle {
     create_before_destroy = true

--- a/setup/module/api/environment.tf
+++ b/setup/module/api/environment.tf
@@ -41,8 +41,16 @@ resource "aws_launch_configuration" "api" {
   user_data            = "${data.template_file.user_data.rendered}"
   key_name             = "${var.ssh_key_pair}"
   ebs_optimized        = true
-  volume_type          = "gp2"
-  volume_size          = "22"
+
+  root_block_device {
+    volume_type        = "gp2"
+    volume_size        = "8"
+  }
+  ebs_block_device {
+    device_name        = "l0-${var.name}-api-ebs"
+    volume_type        = "gp2"
+    volume_size        = "22"
+  }
 
   lifecycle {
     create_before_destroy = true

--- a/setup/module/api/environment.tf
+++ b/setup/module/api/environment.tf
@@ -40,16 +40,18 @@ resource "aws_launch_configuration" "api" {
   iam_instance_profile = "${aws_iam_instance_profile.ecs.id}"
   user_data            = "${data.template_file.user_data.rendered}"
   key_name             = "${var.ssh_key_pair}"
-  ebs_optimized        = true
+  ebs_optimized        = false
 
   root_block_device {
-    volume_type        = "gp2"
-    volume_size        = "8"
+    delete_on_termination = true
+    volume_type           = "gp2"
+    volume_size           = "8"
   }
   ebs_block_device {
-    device_name        = "l0-${var.name}-api-ebs"
-    volume_type        = "gp2"
-    volume_size        = "22"
+    delete_on_termination = true
+    device_name           ="/dev/xvdcz"
+    volume_type           = "gp2"
+    volume_size           = "22"
   }
 
   lifecycle {

--- a/setup/module/api/environment.tf
+++ b/setup/module/api/environment.tf
@@ -42,7 +42,7 @@ resource "aws_launch_configuration" "api" {
   key_name             = "${var.ssh_key_pair}"
   ebs_optimized        = true
   volume_type          = "gp2"
-  volume_size          = "180" 
+  volume_size          = "22"
 
   lifecycle {
     create_before_destroy = true

--- a/setup/module/api/environment.tf
+++ b/setup/module/api/environment.tf
@@ -45,7 +45,7 @@ resource "aws_launch_configuration" "api" {
   root_block_device {
     delete_on_termination = true
     volume_type           = "gp2"
-    volume_size           = "8"
+    volume_size           = "30"
   }
   ebs_block_device {
     delete_on_termination = true

--- a/setup/module/api/environment.tf
+++ b/setup/module/api/environment.tf
@@ -47,12 +47,6 @@ resource "aws_launch_configuration" "api" {
     volume_type           = "gp2"
     volume_size           = "30"
   }
-  ebs_block_device {
-    delete_on_termination = true
-    device_name           ="/dev/xvdcz"
-    volume_type           = "gp2"
-    volume_size           = "22"
-  }
 
   lifecycle {
     create_before_destroy = true

--- a/setup/module/api/environment.tf
+++ b/setup/module/api/environment.tf
@@ -35,12 +35,12 @@ data "template_file" "user_data" {
 resource "aws_launch_configuration" "api" {
   name_prefix          = "l0-${var.name}-api-"
   image_id             = "${data.aws_ami.linux.id}"
-  instance_type        = "t2.medium"
+  instance_type        = "t3.medium"
   security_groups      = ["${aws_security_group.api_env.id}"]
   iam_instance_profile = "${aws_iam_instance_profile.ecs.id}"
   user_data            = "${data.template_file.user_data.rendered}"
   key_name             = "${var.ssh_key_pair}"
-  ebs_optimized        = false
+  ebs_optimized        = true
 
   root_block_device {
     delete_on_termination = true


### PR DESCRIPTION
1: Updated the layer0 ec2 image to Linux2 latest version as suggested by aws
2: Update the root size from 8gb to 30gb
3: Updated the default image from t2 to t3.
4: Added the gitlab pipeline trigger for image sync to d.ims.io
5: Removed the second drive used be deployed in the default settings in old Image. 