### PR TITLE
Added architecture filter

### DIFF
--- a/setup/module/api/core.tf
+++ b/setup/module/api/core.tf
@@ -111,6 +111,11 @@ data "aws_ami" "linux" {
   most_recent = true
 
   filter {
+    name   = "architecture"
+    values = ["x86_64"]
+  }
+
+  filter {
     name   = "name"
     values = ["amzn2-ami-ecs-hvm-*"]
   }


### PR DESCRIPTION
**What does this pull request do?**
In layer0 v0.12.5 , we use the terraform script (v0.11.7) with AWS module 2.0>= && <3.0 to deploy api image. However there is a bug that the layer0 tf definition does not pick the architecture settings of x86_64 by default as described if the filter on ami name is also specified. So we have to explicitly specify architecture type on top of the name filter.

Ref in Tf doc: 

https://registry.terraform.io/providers/hashicorp/aws/2.70.0/docs/resources/ami#architecture

https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ami#virtualization_type


**How should this be tested?**
We need to check the iam image type after deploy layer0 for several rounds


**Checklist**
- [x] Unit tests
- [x] Smoke tests (if applicable)
- [x] System tests (if applicable)
- [x] Documentation (if applicable)


closes #
(reference the issue(s) this pull request closes)
